### PR TITLE
Bump MEOS.NET to MEOS 1.4

### DIFF
--- a/MEOS.NET/Internal/MEOSExposedFunctions.cs
+++ b/MEOS.NET/Internal/MEOSExposedFunctions.cs
@@ -5978,8 +5978,15 @@ namespace MEOS.NET.Internal
         public static bool cbufferset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.cbufferset_value_n(s, n, result));
 
-        public static IntPtr cbufferset_values(IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_values(s));
+        public static IntPtr[] cbufferset_values(IntPtr s)
+        {
+            int _n = (int)MEOSExposedFunctions.set_num_values(s);
+            IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_values(s));
+            IntPtr[] _out = new IntPtr[_n];
+            for (int _i = 0; _i < _n; _i++)
+            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
+            return _out;
+        }
 
         public static IntPtr cbuffer_union_transfn(IntPtr state, IntPtr cb)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_union_transfn(state, cb));
@@ -8401,8 +8408,15 @@ namespace MEOS.NET.Internal
         public static bool poseset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.poseset_value_n(s, n, result));
 
-        public static IntPtr poseset_values(IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_values(s));
+        public static IntPtr[] poseset_values(IntPtr s)
+        {
+            int _n = (int)MEOSExposedFunctions.set_num_values(s);
+            IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_values(s));
+            IntPtr[] _out = new IntPtr[_n];
+            for (int _i = 0; _i < _n; _i++)
+            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
+            return _out;
+        }
 
         public static bool contained_pose_set(IntPtr pose, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_pose_set(pose, s));

--- a/MEOS.NET/Internal/MEOSExposedFunctions.cs
+++ b/MEOS.NET/Internal/MEOSExposedFunctions.cs
@@ -8,6 +8,273 @@ namespace MEOS.NET.Internal
     [GeneratedCode("MEOS.NET.Builder.MEOSIDL", "0.1.0")]
     internal partial class MEOSExposedFunctions
     {
+        public static string describeH3Error(uint err)
+            => SafeExecution<string>(() => MEOSExternalFunctions.describeH3Error(err));
+
+        public static uint latLngToCell(IntPtr g, int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.latLngToCell(g, res, @out));
+
+        public static uint cellToLatLng(ulong h3, IntPtr g)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToLatLng(h3, g));
+
+        public static uint cellToBoundary(ulong h3, IntPtr gp)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToBoundary(h3, gp));
+
+        public static uint maxGridDiskSize(int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.maxGridDiskSize(k, @out));
+
+        public static uint gridDiskUnsafe(ulong origin, int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDiskUnsafe(origin, k, @out));
+
+        public static uint gridDiskDistancesUnsafe(ulong origin, int k, IntPtr @out, IntPtr distances)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDiskDistancesUnsafe(origin, k, @out, distances));
+
+        public static uint gridDiskDistancesSafe(ulong origin, int k, IntPtr @out, IntPtr distances)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDiskDistancesSafe(origin, k, @out, distances));
+
+        public static uint gridDisksUnsafe(IntPtr h3Set, int length, int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDisksUnsafe(h3Set, length, k, @out));
+
+        public static uint gridDisk(ulong origin, int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDisk(origin, k, @out));
+
+        public static uint gridDiskDistances(ulong origin, int k, IntPtr @out, IntPtr distances)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDiskDistances(origin, k, @out, distances));
+
+        public static uint maxGridRingSize(int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.maxGridRingSize(k, @out));
+
+        public static uint gridRingUnsafe(ulong origin, int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridRingUnsafe(origin, k, @out));
+
+        public static uint gridRing(ulong origin, int k, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridRing(origin, k, @out));
+
+        public static uint maxPolygonToCellsSize(IntPtr geoPolygon, int res, uint flags, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.maxPolygonToCellsSize(geoPolygon, res, flags, @out));
+
+        public static uint polygonToCells(IntPtr geoPolygon, int res, uint flags, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.polygonToCells(geoPolygon, res, flags, @out));
+
+        public static uint maxPolygonToCellsSizeExperimental(IntPtr polygon, int res, uint flags, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.maxPolygonToCellsSizeExperimental(polygon, res, flags, @out));
+
+        public static uint polygonToCellsExperimental(IntPtr polygon, int res, uint flags, long size, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.polygonToCellsExperimental(polygon, res, flags, size, @out));
+
+        public static uint cellsToLinkedMultiPolygon(IntPtr h3Set, int numHexes, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellsToLinkedMultiPolygon(h3Set, numHexes, @out));
+
+        public static void destroyLinkedMultiPolygon(IntPtr polygon)
+            => SafeExecution(() => MEOSExternalFunctions.destroyLinkedMultiPolygon(polygon));
+
+        public static double degsToRads(double degrees)
+            => SafeExecution<double>(() => MEOSExternalFunctions.degsToRads(degrees));
+
+        public static double radsToDegs(double radians)
+            => SafeExecution<double>(() => MEOSExternalFunctions.radsToDegs(radians));
+
+        public static double greatCircleDistanceRads(IntPtr a, IntPtr b)
+            => SafeExecution<double>(() => MEOSExternalFunctions.greatCircleDistanceRads(a, b));
+
+        public static double greatCircleDistanceKm(IntPtr a, IntPtr b)
+            => SafeExecution<double>(() => MEOSExternalFunctions.greatCircleDistanceKm(a, b));
+
+        public static double greatCircleDistanceM(IntPtr a, IntPtr b)
+            => SafeExecution<double>(() => MEOSExternalFunctions.greatCircleDistanceM(a, b));
+
+        public static uint getHexagonAreaAvgKm2(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getHexagonAreaAvgKm2(res, @out));
+
+        public static uint getHexagonAreaAvgM2(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getHexagonAreaAvgM2(res, @out));
+
+        public static uint cellAreaRads2(ulong h, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellAreaRads2(h, @out));
+
+        public static uint cellAreaKm2(ulong h, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellAreaKm2(h, @out));
+
+        public static uint cellAreaM2(ulong h, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellAreaM2(h, @out));
+
+        public static uint getHexagonEdgeLengthAvgKm(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getHexagonEdgeLengthAvgKm(res, @out));
+
+        public static uint getHexagonEdgeLengthAvgM(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getHexagonEdgeLengthAvgM(res, @out));
+
+        public static uint edgeLengthRads(ulong edge, IntPtr length)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.edgeLengthRads(edge, length));
+
+        public static uint edgeLengthKm(ulong edge, IntPtr length)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.edgeLengthKm(edge, length));
+
+        public static uint edgeLengthM(ulong edge, IntPtr length)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.edgeLengthM(edge, length));
+
+        public static uint getNumCells(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getNumCells(res, @out));
+
+        public static int res0CellCount()
+            => SafeExecution<int>(() => MEOSExternalFunctions.res0CellCount());
+
+        public static uint getRes0Cells(IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getRes0Cells(@out));
+
+        public static int pentagonCount()
+            => SafeExecution<int>(() => MEOSExternalFunctions.pentagonCount());
+
+        public static uint getPentagons(int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getPentagons(res, @out));
+
+        public static int getResolution(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.getResolution(h));
+
+        public static int getBaseCellNumber(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.getBaseCellNumber(h));
+
+        public static uint getIndexDigit(ulong h, int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getIndexDigit(h, res, @out));
+
+        public static uint constructCell(int res, int baseCellNumber, IntPtr digits, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.constructCell(res, baseCellNumber, digits, @out));
+
+        public static uint stringToH3(string str, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.stringToH3(str, @out));
+
+        public static uint h3ToString(ulong h, string str, ulong sz)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.h3ToString(h, str, sz));
+
+        public static int isValidCell(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isValidCell(h));
+
+        public static int isValidIndex(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isValidIndex(h));
+
+        public static uint cellToParent(ulong h, int parentRes, IntPtr parent)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToParent(h, parentRes, parent));
+
+        public static uint cellToChildrenSize(ulong h, int childRes, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToChildrenSize(h, childRes, @out));
+
+        public static uint cellToChildren(ulong h, int childRes, IntPtr children)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToChildren(h, childRes, children));
+
+        public static uint cellToCenterChild(ulong h, int childRes, IntPtr child)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToCenterChild(h, childRes, child));
+
+        public static uint cellToChildPos(ulong child, int parentRes, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToChildPos(child, parentRes, @out));
+
+        public static uint childPosToCell(long childPos, ulong parent, int childRes, IntPtr child)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.childPosToCell(childPos, parent, childRes, child));
+
+        public static uint compactCells(IntPtr h3Set, IntPtr compactedSet, long numHexes)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.compactCells(h3Set, compactedSet, numHexes));
+
+        public static uint uncompactCellsSize(IntPtr compactedSet, long numCompacted, int res, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.uncompactCellsSize(compactedSet, numCompacted, res, @out));
+
+        public static uint uncompactCells(IntPtr compactedSet, long numCompacted, IntPtr outSet, long numOut, int res)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.uncompactCells(compactedSet, numCompacted, outSet, numOut, res));
+
+        public static int isResClassIII(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isResClassIII(h));
+
+        public static int isPentagon(ulong h)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isPentagon(h));
+
+        public static uint maxFaceCount(ulong h3, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.maxFaceCount(h3, @out));
+
+        public static uint getIcosahedronFaces(ulong h3, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getIcosahedronFaces(h3, @out));
+
+        public static uint areNeighborCells(ulong origin, ulong destination, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.areNeighborCells(origin, destination, @out));
+
+        public static uint cellsToDirectedEdge(ulong origin, ulong destination, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellsToDirectedEdge(origin, destination, @out));
+
+        public static int isValidDirectedEdge(ulong edge)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isValidDirectedEdge(edge));
+
+        public static uint getDirectedEdgeOrigin(ulong edge, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getDirectedEdgeOrigin(edge, @out));
+
+        public static uint getDirectedEdgeDestination(ulong edge, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.getDirectedEdgeDestination(edge, @out));
+
+        public static uint directedEdgeToCells(ulong edge, IntPtr originDestination)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.directedEdgeToCells(edge, originDestination));
+
+        public static uint originToDirectedEdges(ulong origin, IntPtr edges)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.originToDirectedEdges(origin, edges));
+
+        public static uint directedEdgeToBoundary(ulong edge, IntPtr gb)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.directedEdgeToBoundary(edge, gb));
+
+        public static uint cellToVertex(ulong origin, int vertexNum, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToVertex(origin, vertexNum, @out));
+
+        public static uint cellToVertexes(ulong origin, IntPtr vertexes)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToVertexes(origin, vertexes));
+
+        public static uint vertexToLatLng(ulong vertex, IntPtr point)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.vertexToLatLng(vertex, point));
+
+        public static int isValidVertex(ulong vertex)
+            => SafeExecution<int>(() => MEOSExternalFunctions.isValidVertex(vertex));
+
+        public static uint gridDistance(ulong origin, ulong h3, IntPtr distance)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridDistance(origin, h3, distance));
+
+        public static uint gridPathCellsSize(ulong start, ulong end, IntPtr size)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridPathCellsSize(start, end, size));
+
+        public static uint gridPathCells(ulong start, ulong end, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.gridPathCells(start, end, @out));
+
+        public static uint cellToLocalIj(ulong origin, ulong h3, uint mode, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cellToLocalIj(origin, h3, mode, @out));
+
+        public static uint localIjToCell(ulong origin, IntPtr ij, uint mode, IntPtr @out)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.localIjToCell(origin, ij, mode, @out));
+
+        public static int date_in(string str)
+            => SafeExecution<int>(() => MEOSExternalFunctions.date_in(str));
+
+        public static string date_out(int d)
+            => SafeExecution<string>(() => MEOSExternalFunctions.date_out(d));
+
+        public static int interval_cmp(IntPtr interv1, IntPtr interv2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.interval_cmp(interv1, interv2));
+
+        public static IntPtr interval_in(string str, int typmod)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_in(str, typmod));
+
+        public static string interval_out(IntPtr interv)
+            => SafeExecution<string>(() => MEOSExternalFunctions.interval_out(interv));
+
+        public static long time_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.time_in(str, typmod));
+
+        public static string time_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.time_out(t));
+
+        public static long timestamp_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_in(str, typmod));
+
+        public static string timestamp_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.timestamp_out(t));
+
+        public static long timestamptz_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_in(str, typmod));
+
+        public static string timestamptz_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.timestamptz_out(t));
+
         public static IntPtr meos_array_create(int elem_size)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meos_array_create(elem_size));
 
@@ -125,8 +392,8 @@ namespace MEOS.NET.Internal
         public static IntPtr add_interval_interval(IntPtr interv1, IntPtr interv2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.add_interval_interval(interv1, interv2));
 
-        public static int add_timestamptz_interval(int t, IntPtr interv)
-            => SafeExecution<int>(() => MEOSExternalFunctions.add_timestamptz_interval(t, interv));
+        public static long add_timestamptz_interval(long t, IntPtr interv)
+            => SafeExecution<long>(() => MEOSExternalFunctions.add_timestamptz_interval(t, interv));
 
         public static bool bool_in(string str)
             => SafeExecution<bool>(() => MEOSExternalFunctions.bool_in(str));
@@ -137,11 +404,11 @@ namespace MEOS.NET.Internal
         public static IntPtr cstring2text(string str)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cstring2text(str));
 
-        public static int date_to_timestamp(int dateVal)
-            => SafeExecution<int>(() => MEOSExternalFunctions.date_to_timestamp(dateVal));
+        public static long date_to_timestamp(int dateVal)
+            => SafeExecution<long>(() => MEOSExternalFunctions.date_to_timestamp(dateVal));
 
-        public static int date_to_timestamptz(int d)
-            => SafeExecution<int>(() => MEOSExternalFunctions.date_to_timestamptz(d));
+        public static long date_to_timestamptz(int d)
+            => SafeExecution<long>(() => MEOSExternalFunctions.date_to_timestamptz(d));
 
         public static double float_exp(double d)
             => SafeExecution<double>(() => MEOSExternalFunctions.float_exp(d));
@@ -161,7 +428,7 @@ namespace MEOS.NET.Internal
         public static int int32_cmp(int l, int r)
             => SafeExecution<int>(() => MEOSExternalFunctions.int32_cmp(l, r));
 
-        public static int int64_cmp(int l, int r)
+        public static int int64_cmp(long l, long r)
             => SafeExecution<int>(() => MEOSExternalFunctions.int64_cmp(l, r));
 
         public static IntPtr interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs)
@@ -173,10 +440,10 @@ namespace MEOS.NET.Internal
         public static int minus_date_int(int d, int days)
             => SafeExecution<int>(() => MEOSExternalFunctions.minus_date_int(d, days));
 
-        public static int minus_timestamptz_interval(int t, IntPtr interv)
-            => SafeExecution<int>(() => MEOSExternalFunctions.minus_timestamptz_interval(t, interv));
+        public static long minus_timestamptz_interval(long t, IntPtr interv)
+            => SafeExecution<long>(() => MEOSExternalFunctions.minus_timestamptz_interval(t, interv));
 
-        public static IntPtr minus_timestamptz_timestamptz(int t1, int t2)
+        public static IntPtr minus_timestamptz_timestamptz(long t1, long t2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_timestamptz(t1, t2));
 
         public static IntPtr mul_interval_double(IntPtr interv, double factor)
@@ -197,16 +464,16 @@ namespace MEOS.NET.Internal
         public static string pg_interval_out(IntPtr interv)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_interval_out(interv));
 
-        public static int pg_timestamp_in(string str, int typmod)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_timestamp_in(str, typmod));
+        public static long pg_timestamp_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.pg_timestamp_in(str, typmod));
 
-        public static string pg_timestamp_out(int t)
+        public static string pg_timestamp_out(long t)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_timestamp_out(t));
 
-        public static int pg_timestamptz_in(string str, int typmod)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_timestamptz_in(str, typmod));
+        public static long pg_timestamptz_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.pg_timestamptz_in(str, typmod));
 
-        public static string pg_timestamptz_out(int t)
+        public static string pg_timestamptz_out(long t)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_timestamptz_out(t));
 
         public static string text2cstring(IntPtr txt)
@@ -236,13 +503,13 @@ namespace MEOS.NET.Internal
         public static IntPtr textcat_text_text(IntPtr txt1, IntPtr txt2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textcat_text_text(txt1, txt2));
 
-        public static int timestamptz_shift(int t, IntPtr interv)
-            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_shift(t, interv));
+        public static long timestamptz_shift(long t, IntPtr interv)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_shift(t, interv));
 
-        public static int timestamp_to_date(int t)
+        public static int timestamp_to_date(long t)
             => SafeExecution<int>(() => MEOSExternalFunctions.timestamp_to_date(t));
 
-        public static int timestamptz_to_date(int t)
+        public static int timestamptz_to_date(long t)
             => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_to_date(t));
 
         public static IntPtr bigintset_in(string str)
@@ -251,7 +518,7 @@ namespace MEOS.NET.Internal
         public static string bigintset_out(IntPtr set)
             => SafeExecution<string>(() => MEOSExternalFunctions.bigintset_out(set));
 
-        public static IntPtr bigintspan_expand(IntPtr s, int value)
+        public static IntPtr bigintspan_expand(IntPtr s, long value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_expand(s, value));
 
         public static IntPtr bigintspan_in(string str)
@@ -389,7 +656,7 @@ namespace MEOS.NET.Internal
         public static IntPtr bigintset_make(IntPtr values, int count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_make(values, count));
 
-        public static IntPtr bigintspan_make(int lower, int upper, bool lower_inc, bool upper_inc)
+        public static IntPtr bigintspan_make(long lower, long upper, bool lower_inc, bool upper_inc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_make(lower, upper, lower_inc, upper_inc));
 
         public static IntPtr dateset_make(IntPtr values, int count)
@@ -428,10 +695,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzset_make(IntPtr values, int count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_make(values, count));
 
-        public static IntPtr tstzspan_make(int lower, int upper, bool lower_inc, bool upper_inc)
+        public static IntPtr tstzspan_make(long lower, long upper, bool lower_inc, bool upper_inc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_make(lower, upper, lower_inc, upper_inc));
 
-        public static IntPtr bigint_to_set(int i)
+        public static IntPtr bigint_to_set(long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_to_set(i));
 
         public static IntPtr bigint_to_span(int i)
@@ -506,13 +773,13 @@ namespace MEOS.NET.Internal
         public static IntPtr text_to_set(IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.text_to_set(txt));
 
-        public static IntPtr timestamptz_to_set(int t)
+        public static IntPtr timestamptz_to_set(long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_set(t));
 
-        public static IntPtr timestamptz_to_span(int t)
+        public static IntPtr timestamptz_to_span(long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_span(t));
 
-        public static IntPtr timestamptz_to_spanset(int t)
+        public static IntPtr timestamptz_to_spanset(long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_spanset(t));
 
         public static IntPtr tstzset_to_dateset(IntPtr s)
@@ -524,41 +791,41 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzspanset_to_datespanset(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_to_datespanset(ss));
 
-        public static int bigintset_end_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintset_end_value(s));
+        public static long bigintset_end_value(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintset_end_value(s));
 
-        public static int bigintset_start_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintset_start_value(s));
+        public static long bigintset_start_value(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintset_start_value(s));
 
         public static bool bigintset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.bigintset_value_n(s, n, result));
 
-        public static int[] bigintset_values(IntPtr s)
+        public static long[] bigintset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_values(s));
-            int[] _out = new int[_n];
+            long[] _out = new long[_n];
             Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
 
-        public static int bigintspan_lower(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_lower(s));
+        public static long bigintspan_lower(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_lower(s));
 
-        public static int bigintspan_upper(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_upper(s));
+        public static long bigintspan_upper(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_upper(s));
 
-        public static int bigintspan_width(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_width(s));
+        public static long bigintspan_width(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_width(s));
 
-        public static int bigintspanset_lower(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_lower(ss));
+        public static long bigintspanset_lower(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_lower(ss));
 
-        public static int bigintspanset_upper(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_upper(ss));
+        public static long bigintspanset_upper(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_upper(ss));
 
-        public static int bigintspanset_width(IntPtr ss, bool boundspan)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_width(ss, boundspan));
+        public static long bigintspanset_width(IntPtr ss, bool boundspan)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_width(ss, boundspan));
 
         public static int dateset_end_value(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.dateset_end_value(s));
@@ -677,20 +944,20 @@ namespace MEOS.NET.Internal
         public static int intspanset_width(IntPtr ss, bool boundspan)
             => SafeExecution<int>(() => MEOSExternalFunctions.intspanset_width(ss, boundspan));
 
-        public static int set_hash(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.set_hash(s));
+        public static uint set_hash(IntPtr s)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.set_hash(s));
 
-        public static int set_hash_extended(IntPtr s, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.set_hash_extended(s, seed));
+        public static ulong set_hash_extended(IntPtr s, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_hash_extended(s, seed));
 
         public static int set_num_values(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.set_num_values(s));
 
-        public static int span_hash(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_hash(s));
+        public static uint span_hash(IntPtr s)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.span_hash(s));
 
-        public static int span_hash_extended(IntPtr s, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_hash_extended(s, seed));
+        public static ulong span_hash_extended(IntPtr s, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.span_hash_extended(s, seed));
 
         public static bool span_lower_inc(IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.span_lower_inc(s));
@@ -701,11 +968,11 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_end_span(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_end_span(ss));
 
-        public static int spanset_hash(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_hash(ss));
+        public static uint spanset_hash(IntPtr ss)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.spanset_hash(ss));
 
-        public static int spanset_hash_extended(IntPtr ss, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_hash_extended(ss, seed));
+        public static ulong spanset_hash_extended(IntPtr ss, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_hash_extended(ss, seed));
 
         public static bool spanset_lower_inc(IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_lower_inc(ss));
@@ -744,29 +1011,30 @@ namespace MEOS.NET.Internal
         public static bool textset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.textset_value_n(s, n, result));
 
-        public static int[] textset_values(IntPtr s)
+        public static IntPtr[] textset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.textset_values(s));
-            int[] _out = new int[_n];
-            Marshal.Copy(_p, _out, 0, _n);
+            IntPtr[] _out = new IntPtr[_n];
+            for (int _i = 0; _i < _n; _i++)
+            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
             return _out;
         }
 
-        public static int tstzset_end_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzset_end_value(s));
+        public static long tstzset_end_value(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzset_end_value(s));
 
-        public static int tstzset_start_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzset_start_value(s));
+        public static long tstzset_start_value(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzset_start_value(s));
 
         public static bool tstzset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tstzset_value_n(s, n, result));
 
-        public static int[] tstzset_values(IntPtr s)
+        public static long[] tstzset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_values(s));
-            int[] _out = new int[_n];
+            long[] _out = new long[_n];
             Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
@@ -774,26 +1042,26 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzspan_duration(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_duration(s));
 
-        public static int tstzspan_lower(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspan_lower(s));
+        public static long tstzspan_lower(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspan_lower(s));
 
-        public static int tstzspan_upper(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspan_upper(s));
+        public static long tstzspan_upper(IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspan_upper(s));
 
         public static IntPtr tstzspanset_duration(IntPtr ss, bool boundspan)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_duration(ss, boundspan));
 
-        public static int tstzspanset_end_timestamptz(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_end_timestamptz(ss));
+        public static long tstzspanset_end_timestamptz(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_end_timestamptz(ss));
 
-        public static int tstzspanset_lower(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_lower(ss));
+        public static long tstzspanset_lower(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_lower(ss));
 
         public static int tstzspanset_num_timestamps(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_num_timestamps(ss));
 
-        public static int tstzspanset_start_timestamptz(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_start_timestamptz(ss));
+        public static long tstzspanset_start_timestamptz(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_start_timestamptz(ss));
 
         public static IntPtr tstzspanset_timestamps(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_timestamps(ss));
@@ -801,16 +1069,16 @@ namespace MEOS.NET.Internal
         public static bool tstzspanset_timestamptz_n(IntPtr ss, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tstzspanset_timestamptz_n(ss, n, result));
 
-        public static int tstzspanset_upper(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_upper(ss));
+        public static long tstzspanset_upper(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_upper(ss));
 
-        public static IntPtr bigintset_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
+        public static IntPtr bigintset_shift_scale(IntPtr s, long shift, long width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr bigintspan_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
+        public static IntPtr bigintspan_shift_scale(IntPtr s, long shift, long width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr bigintspanset_shift_scale(IntPtr ss, int shift, int width, bool hasshift, bool haswidth)
+        public static IntPtr bigintspanset_shift_scale(IntPtr ss, long shift, long width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspanset_shift_scale(ss, shift, width, hasshift, haswidth));
 
         public static IntPtr dateset_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
@@ -903,25 +1171,25 @@ namespace MEOS.NET.Internal
         public static IntPtr textset_upper(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textset_upper(s));
 
-        public static int timestamptz_tprecision(int t, IntPtr duration, int torigin)
-            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_tprecision(t, duration, torigin));
+        public static long timestamptz_tprecision(long t, IntPtr duration, long torigin)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_tprecision(t, duration, torigin));
 
         public static IntPtr tstzset_shift_scale(IntPtr s, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_shift_scale(s, shift, duration));
 
-        public static IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, int torigin)
+        public static IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, long torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_tprecision(s, duration, torigin));
 
         public static IntPtr tstzspan_shift_scale(IntPtr s, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_shift_scale(s, shift, duration));
 
-        public static IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, int torigin)
+        public static IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, long torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_tprecision(s, duration, torigin));
 
         public static IntPtr tstzspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_shift_scale(ss, shift, duration));
 
-        public static IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, int torigin)
+        public static IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, long torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_tprecision(ss, duration, torigin));
 
         public static int set_cmp(IntPtr s1, IntPtr s2)
@@ -1005,7 +1273,7 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_split_n_spans(IntPtr ss, int span_count, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_split_n_spans(ss, span_count, count));
 
-        public static bool adjacent_span_bigint(IntPtr s, int i)
+        public static bool adjacent_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_bigint(s, i));
 
         public static bool adjacent_span_date(IntPtr s, int d)
@@ -1023,10 +1291,10 @@ namespace MEOS.NET.Internal
         public static bool adjacent_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_spanset(s, ss));
 
-        public static bool adjacent_span_timestamptz(IntPtr s, int t)
+        public static bool adjacent_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_timestamptz(s, t));
 
-        public static bool adjacent_spanset_bigint(IntPtr ss, int i)
+        public static bool adjacent_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_bigint(ss, i));
 
         public static bool adjacent_spanset_date(IntPtr ss, int d)
@@ -1038,7 +1306,7 @@ namespace MEOS.NET.Internal
         public static bool adjacent_spanset_int(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_int(ss, i));
 
-        public static bool adjacent_spanset_timestamptz(IntPtr ss, int t)
+        public static bool adjacent_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_timestamptz(ss, t));
 
         public static bool adjacent_spanset_span(IntPtr ss, IntPtr s)
@@ -1047,13 +1315,13 @@ namespace MEOS.NET.Internal
         public static bool adjacent_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_spanset(ss1, ss2));
 
-        public static bool contained_bigint_set(int i, IntPtr s)
+        public static bool contained_bigint_set(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_set(i, s));
 
-        public static bool contained_bigint_span(int i, IntPtr s)
+        public static bool contained_bigint_span(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_span(i, s));
 
-        public static bool contained_bigint_spanset(int i, IntPtr ss)
+        public static bool contained_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_spanset(i, ss));
 
         public static bool contained_date_set(int d, IntPtr s)
@@ -1101,16 +1369,16 @@ namespace MEOS.NET.Internal
         public static bool contained_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_text_set(txt, s));
 
-        public static bool contained_timestamptz_set(int t, IntPtr s)
+        public static bool contained_timestamptz_set(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_set(t, s));
 
-        public static bool contained_timestamptz_span(int t, IntPtr s)
+        public static bool contained_timestamptz_span(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_span(t, s));
 
-        public static bool contained_timestamptz_spanset(int t, IntPtr ss)
+        public static bool contained_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_spanset(t, ss));
 
-        public static bool contains_set_bigint(IntPtr s, int i)
+        public static bool contains_set_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_bigint(s, i));
 
         public static bool contains_set_date(IntPtr s, int d)
@@ -1128,10 +1396,10 @@ namespace MEOS.NET.Internal
         public static bool contains_set_text(IntPtr s, IntPtr t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_text(s, t));
 
-        public static bool contains_set_timestamptz(IntPtr s, int t)
+        public static bool contains_set_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_timestamptz(s, t));
 
-        public static bool contains_span_bigint(IntPtr s, int i)
+        public static bool contains_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_bigint(s, i));
 
         public static bool contains_span_date(IntPtr s, int d)
@@ -1149,10 +1417,10 @@ namespace MEOS.NET.Internal
         public static bool contains_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_spanset(s, ss));
 
-        public static bool contains_span_timestamptz(IntPtr s, int t)
+        public static bool contains_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_timestamptz(s, t));
 
-        public static bool contains_spanset_bigint(IntPtr ss, int i)
+        public static bool contains_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_bigint(ss, i));
 
         public static bool contains_spanset_date(IntPtr ss, int d)
@@ -1170,7 +1438,7 @@ namespace MEOS.NET.Internal
         public static bool contains_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_spanset(ss1, ss2));
 
-        public static bool contains_spanset_timestamptz(IntPtr ss, int t)
+        public static bool contains_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_timestamptz(ss, t));
 
         public static bool overlaps_set_set(IntPtr s1, IntPtr s2)
@@ -1200,28 +1468,28 @@ namespace MEOS.NET.Internal
         public static bool after_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_set_date(s, d));
 
-        public static bool after_set_timestamptz(IntPtr s, int t)
+        public static bool after_set_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_set_timestamptz(s, t));
 
         public static bool after_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_span_date(s, d));
 
-        public static bool after_span_timestamptz(IntPtr s, int t)
+        public static bool after_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_span_timestamptz(s, t));
 
         public static bool after_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_spanset_date(ss, d));
 
-        public static bool after_spanset_timestamptz(IntPtr ss, int t)
+        public static bool after_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_spanset_timestamptz(ss, t));
 
-        public static bool after_timestamptz_set(int t, IntPtr s)
+        public static bool after_timestamptz_set(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_set(t, s));
 
-        public static bool after_timestamptz_span(int t, IntPtr s)
+        public static bool after_timestamptz_span(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_span(t, s));
 
-        public static bool after_timestamptz_spanset(int t, IntPtr ss)
+        public static bool after_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_spanset(t, ss));
 
         public static bool before_date_set(int d, IntPtr s)
@@ -1236,37 +1504,37 @@ namespace MEOS.NET.Internal
         public static bool before_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_set_date(s, d));
 
-        public static bool before_set_timestamptz(IntPtr s, int t)
+        public static bool before_set_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_set_timestamptz(s, t));
 
         public static bool before_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_span_date(s, d));
 
-        public static bool before_span_timestamptz(IntPtr s, int t)
+        public static bool before_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_span_timestamptz(s, t));
 
         public static bool before_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_spanset_date(ss, d));
 
-        public static bool before_spanset_timestamptz(IntPtr ss, int t)
+        public static bool before_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_spanset_timestamptz(ss, t));
 
-        public static bool before_timestamptz_set(int t, IntPtr s)
+        public static bool before_timestamptz_set(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_set(t, s));
 
-        public static bool before_timestamptz_span(int t, IntPtr s)
+        public static bool before_timestamptz_span(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_span(t, s));
 
-        public static bool before_timestamptz_spanset(int t, IntPtr ss)
+        public static bool before_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_spanset(t, ss));
 
-        public static bool left_bigint_set(int i, IntPtr s)
+        public static bool left_bigint_set(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_set(i, s));
 
-        public static bool left_bigint_span(int i, IntPtr s)
+        public static bool left_bigint_span(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_span(i, s));
 
-        public static bool left_bigint_spanset(int i, IntPtr ss)
+        public static bool left_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_spanset(i, ss));
 
         public static bool left_float_set(double d, IntPtr s)
@@ -1287,7 +1555,7 @@ namespace MEOS.NET.Internal
         public static bool left_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_int_spanset(i, ss));
 
-        public static bool left_set_bigint(IntPtr s, int i)
+        public static bool left_set_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_bigint(s, i));
 
         public static bool left_set_float(IntPtr s, double d)
@@ -1302,7 +1570,7 @@ namespace MEOS.NET.Internal
         public static bool left_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_text(s, txt));
 
-        public static bool left_span_bigint(IntPtr s, int i)
+        public static bool left_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_bigint(s, i));
 
         public static bool left_span_float(IntPtr s, double d)
@@ -1317,7 +1585,7 @@ namespace MEOS.NET.Internal
         public static bool left_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_spanset(s, ss));
 
-        public static bool left_spanset_bigint(IntPtr ss, int i)
+        public static bool left_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_spanset_bigint(ss, i));
 
         public static bool left_spanset_float(IntPtr ss, double d)
@@ -1347,28 +1615,28 @@ namespace MEOS.NET.Internal
         public static bool overafter_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_set_date(s, d));
 
-        public static bool overafter_set_timestamptz(IntPtr s, int t)
+        public static bool overafter_set_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_set_timestamptz(s, t));
 
         public static bool overafter_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_span_date(s, d));
 
-        public static bool overafter_span_timestamptz(IntPtr s, int t)
+        public static bool overafter_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_span_timestamptz(s, t));
 
         public static bool overafter_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_spanset_date(ss, d));
 
-        public static bool overafter_spanset_timestamptz(IntPtr ss, int t)
+        public static bool overafter_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_spanset_timestamptz(ss, t));
 
-        public static bool overafter_timestamptz_set(int t, IntPtr s)
+        public static bool overafter_timestamptz_set(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_set(t, s));
 
-        public static bool overafter_timestamptz_span(int t, IntPtr s)
+        public static bool overafter_timestamptz_span(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_span(t, s));
 
-        public static bool overafter_timestamptz_spanset(int t, IntPtr ss)
+        public static bool overafter_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_spanset(t, ss));
 
         public static bool overbefore_date_set(int d, IntPtr s)
@@ -1383,37 +1651,37 @@ namespace MEOS.NET.Internal
         public static bool overbefore_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_set_date(s, d));
 
-        public static bool overbefore_set_timestamptz(IntPtr s, int t)
+        public static bool overbefore_set_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_set_timestamptz(s, t));
 
         public static bool overbefore_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_span_date(s, d));
 
-        public static bool overbefore_span_timestamptz(IntPtr s, int t)
+        public static bool overbefore_span_timestamptz(IntPtr s, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_span_timestamptz(s, t));
 
         public static bool overbefore_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_spanset_date(ss, d));
 
-        public static bool overbefore_spanset_timestamptz(IntPtr ss, int t)
+        public static bool overbefore_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_spanset_timestamptz(ss, t));
 
-        public static bool overbefore_timestamptz_set(int t, IntPtr s)
+        public static bool overbefore_timestamptz_set(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_set(t, s));
 
-        public static bool overbefore_timestamptz_span(int t, IntPtr s)
+        public static bool overbefore_timestamptz_span(long t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_span(t, s));
 
-        public static bool overbefore_timestamptz_spanset(int t, IntPtr ss)
+        public static bool overbefore_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_spanset(t, ss));
 
-        public static bool overleft_bigint_set(int i, IntPtr s)
+        public static bool overleft_bigint_set(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_set(i, s));
 
-        public static bool overleft_bigint_span(int i, IntPtr s)
+        public static bool overleft_bigint_span(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_span(i, s));
 
-        public static bool overleft_bigint_spanset(int i, IntPtr ss)
+        public static bool overleft_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_spanset(i, ss));
 
         public static bool overleft_float_set(double d, IntPtr s)
@@ -1434,7 +1702,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_int_spanset(i, ss));
 
-        public static bool overleft_set_bigint(IntPtr s, int i)
+        public static bool overleft_set_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_bigint(s, i));
 
         public static bool overleft_set_float(IntPtr s, double d)
@@ -1449,7 +1717,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_text(s, txt));
 
-        public static bool overleft_span_bigint(IntPtr s, int i)
+        public static bool overleft_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_bigint(s, i));
 
         public static bool overleft_span_float(IntPtr s, double d)
@@ -1464,7 +1732,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_spanset(s, ss));
 
-        public static bool overleft_spanset_bigint(IntPtr ss, int i)
+        public static bool overleft_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_spanset_bigint(ss, i));
 
         public static bool overleft_spanset_float(IntPtr ss, double d)
@@ -1482,13 +1750,13 @@ namespace MEOS.NET.Internal
         public static bool overleft_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_text_set(txt, s));
 
-        public static bool overright_bigint_set(int i, IntPtr s)
+        public static bool overright_bigint_set(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_set(i, s));
 
-        public static bool overright_bigint_span(int i, IntPtr s)
+        public static bool overright_bigint_span(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_span(i, s));
 
-        public static bool overright_bigint_spanset(int i, IntPtr ss)
+        public static bool overright_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_spanset(i, ss));
 
         public static bool overright_float_set(double d, IntPtr s)
@@ -1509,7 +1777,7 @@ namespace MEOS.NET.Internal
         public static bool overright_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_int_spanset(i, ss));
 
-        public static bool overright_set_bigint(IntPtr s, int i)
+        public static bool overright_set_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_bigint(s, i));
 
         public static bool overright_set_float(IntPtr s, double d)
@@ -1524,7 +1792,7 @@ namespace MEOS.NET.Internal
         public static bool overright_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_text(s, txt));
 
-        public static bool overright_span_bigint(IntPtr s, int i)
+        public static bool overright_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_bigint(s, i));
 
         public static bool overright_span_float(IntPtr s, double d)
@@ -1539,7 +1807,7 @@ namespace MEOS.NET.Internal
         public static bool overright_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_spanset(s, ss));
 
-        public static bool overright_spanset_bigint(IntPtr ss, int i)
+        public static bool overright_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_spanset_bigint(ss, i));
 
         public static bool overright_spanset_float(IntPtr ss, double d)
@@ -1557,13 +1825,13 @@ namespace MEOS.NET.Internal
         public static bool overright_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_text_set(txt, s));
 
-        public static bool right_bigint_set(int i, IntPtr s)
+        public static bool right_bigint_set(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_set(i, s));
 
-        public static bool right_bigint_span(int i, IntPtr s)
+        public static bool right_bigint_span(long i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_span(i, s));
 
-        public static bool right_bigint_spanset(int i, IntPtr ss)
+        public static bool right_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_spanset(i, ss));
 
         public static bool right_float_set(double d, IntPtr s)
@@ -1584,7 +1852,7 @@ namespace MEOS.NET.Internal
         public static bool right_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_int_spanset(i, ss));
 
-        public static bool right_set_bigint(IntPtr s, int i)
+        public static bool right_set_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_bigint(s, i));
 
         public static bool right_set_float(IntPtr s, double d)
@@ -1599,7 +1867,7 @@ namespace MEOS.NET.Internal
         public static bool right_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_text(s, txt));
 
-        public static bool right_span_bigint(IntPtr s, int i)
+        public static bool right_span_bigint(IntPtr s, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_bigint(s, i));
 
         public static bool right_span_float(IntPtr s, double d)
@@ -1614,7 +1882,7 @@ namespace MEOS.NET.Internal
         public static bool right_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_spanset(s, ss));
 
-        public static bool right_spanset_bigint(IntPtr ss, int i)
+        public static bool right_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_spanset_bigint(ss, i));
 
         public static bool right_spanset_float(IntPtr ss, double d)
@@ -1632,7 +1900,7 @@ namespace MEOS.NET.Internal
         public static bool right_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_text_set(txt, s));
 
-        public static IntPtr intersection_bigint_set(int i, IntPtr s)
+        public static IntPtr intersection_bigint_set(long i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_bigint_set(i, s));
 
         public static IntPtr intersection_date_set(int d, IntPtr s)
@@ -1644,7 +1912,7 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_int_set(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_int_set(i, s));
 
-        public static IntPtr intersection_set_bigint(IntPtr s, int i)
+        public static IntPtr intersection_set_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_bigint(s, i));
 
         public static IntPtr intersection_set_date(IntPtr s, int d)
@@ -1662,10 +1930,10 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_text(s, txt));
 
-        public static IntPtr intersection_set_timestamptz(IntPtr s, int t)
+        public static IntPtr intersection_set_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_timestamptz(s, t));
 
-        public static IntPtr intersection_span_bigint(IntPtr s, int i)
+        public static IntPtr intersection_span_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_bigint(s, i));
 
         public static IntPtr intersection_span_date(IntPtr s, int d)
@@ -1683,10 +1951,10 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_spanset(s, ss));
 
-        public static IntPtr intersection_span_timestamptz(IntPtr s, int t)
+        public static IntPtr intersection_span_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_timestamptz(s, t));
 
-        public static IntPtr intersection_spanset_bigint(IntPtr ss, int i)
+        public static IntPtr intersection_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_bigint(ss, i));
 
         public static IntPtr intersection_spanset_date(IntPtr ss, int d)
@@ -1704,22 +1972,22 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_spanset(ss1, ss2));
 
-        public static IntPtr intersection_spanset_timestamptz(IntPtr ss, int t)
+        public static IntPtr intersection_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_timestamptz(ss, t));
 
         public static IntPtr intersection_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_text_set(txt, s));
 
-        public static IntPtr intersection_timestamptz_set(int t, IntPtr s)
+        public static IntPtr intersection_timestamptz_set(long t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_timestamptz_set(t, s));
 
-        public static IntPtr minus_bigint_set(int i, IntPtr s)
+        public static IntPtr minus_bigint_set(long i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_set(i, s));
 
-        public static IntPtr minus_bigint_span(int i, IntPtr s)
+        public static IntPtr minus_bigint_span(long i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_span(i, s));
 
-        public static IntPtr minus_bigint_spanset(int i, IntPtr ss)
+        public static IntPtr minus_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_spanset(i, ss));
 
         public static IntPtr minus_date_set(int d, IntPtr s)
@@ -1749,7 +2017,7 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_int_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_int_spanset(i, ss));
 
-        public static IntPtr minus_set_bigint(IntPtr s, int i)
+        public static IntPtr minus_set_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_bigint(s, i));
 
         public static IntPtr minus_set_date(IntPtr s, int d)
@@ -1767,10 +2035,10 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_text(s, txt));
 
-        public static IntPtr minus_set_timestamptz(IntPtr s, int t)
+        public static IntPtr minus_set_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_timestamptz(s, t));
 
-        public static IntPtr minus_span_bigint(IntPtr s, int i)
+        public static IntPtr minus_span_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_bigint(s, i));
 
         public static IntPtr minus_span_date(IntPtr s, int d)
@@ -1788,10 +2056,10 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_spanset(s, ss));
 
-        public static IntPtr minus_span_timestamptz(IntPtr s, int t)
+        public static IntPtr minus_span_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_timestamptz(s, t));
 
-        public static IntPtr minus_spanset_bigint(IntPtr ss, int i)
+        public static IntPtr minus_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_bigint(ss, i));
 
         public static IntPtr minus_spanset_date(IntPtr ss, int d)
@@ -1809,28 +2077,28 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_spanset(ss1, ss2));
 
-        public static IntPtr minus_spanset_timestamptz(IntPtr ss, int t)
+        public static IntPtr minus_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_timestamptz(ss, t));
 
         public static IntPtr minus_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_text_set(txt, s));
 
-        public static IntPtr minus_timestamptz_set(int t, IntPtr s)
+        public static IntPtr minus_timestamptz_set(long t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_set(t, s));
 
-        public static IntPtr minus_timestamptz_span(int t, IntPtr s)
+        public static IntPtr minus_timestamptz_span(long t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_span(t, s));
 
-        public static IntPtr minus_timestamptz_spanset(int t, IntPtr ss)
+        public static IntPtr minus_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_spanset(t, ss));
 
-        public static IntPtr union_bigint_set(int i, IntPtr s)
+        public static IntPtr union_bigint_set(long i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_set(i, s));
 
-        public static IntPtr union_bigint_span(IntPtr s, int i)
+        public static IntPtr union_bigint_span(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_span(s, i));
 
-        public static IntPtr union_bigint_spanset(int i, IntPtr ss)
+        public static IntPtr union_bigint_spanset(long i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_spanset(i, ss));
 
         public static IntPtr union_date_set(int d, IntPtr s)
@@ -1860,7 +2128,7 @@ namespace MEOS.NET.Internal
         public static IntPtr union_int_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_int_spanset(i, ss));
 
-        public static IntPtr union_set_bigint(IntPtr s, int i)
+        public static IntPtr union_set_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_bigint(s, i));
 
         public static IntPtr union_set_date(IntPtr s, int d)
@@ -1878,10 +2146,10 @@ namespace MEOS.NET.Internal
         public static IntPtr union_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_text(s, txt));
 
-        public static IntPtr union_set_timestamptz(IntPtr s, int t)
+        public static IntPtr union_set_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_timestamptz(s, t));
 
-        public static IntPtr union_span_bigint(IntPtr s, int i)
+        public static IntPtr union_span_bigint(IntPtr s, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_bigint(s, i));
 
         public static IntPtr union_span_date(IntPtr s, int d)
@@ -1899,10 +2167,10 @@ namespace MEOS.NET.Internal
         public static IntPtr union_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_spanset(s, ss));
 
-        public static IntPtr union_span_timestamptz(IntPtr s, int t)
+        public static IntPtr union_span_timestamptz(IntPtr s, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_timestamptz(s, t));
 
-        public static IntPtr union_spanset_bigint(IntPtr ss, int i)
+        public static IntPtr union_spanset_bigint(IntPtr ss, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_bigint(ss, i));
 
         public static IntPtr union_spanset_date(IntPtr ss, int d)
@@ -1920,32 +2188,32 @@ namespace MEOS.NET.Internal
         public static IntPtr union_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_spanset(ss1, ss2));
 
-        public static IntPtr union_spanset_timestamptz(IntPtr ss, int t)
+        public static IntPtr union_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_timestamptz(ss, t));
 
         public static IntPtr union_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_text_set(txt, s));
 
-        public static IntPtr union_timestamptz_set(int t, IntPtr s)
+        public static IntPtr union_timestamptz_set(long t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_set(t, s));
 
-        public static IntPtr union_timestamptz_span(int t, IntPtr s)
+        public static IntPtr union_timestamptz_span(long t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_span(t, s));
 
-        public static IntPtr union_timestamptz_spanset(int t, IntPtr ss)
+        public static IntPtr union_timestamptz_spanset(long t, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_spanset(t, ss));
 
-        public static int distance_bigintset_bigintset(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintset_bigintset(s1, s2));
+        public static long distance_bigintset_bigintset(IntPtr s1, IntPtr s2)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintset_bigintset(s1, s2));
 
-        public static int distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspan_bigintspan(s1, s2));
+        public static long distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspan_bigintspan(s1, s2));
 
-        public static int distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspan(ss, s));
+        public static long distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspan(ss, s));
 
-        public static int distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspanset(ss1, ss2));
+        public static long distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspanset(ss1, ss2));
 
         public static int distance_dateset_dateset(IntPtr s1, IntPtr s2)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_dateset_dateset(s1, s2));
@@ -1983,8 +2251,8 @@ namespace MEOS.NET.Internal
         public static int distance_intspanset_intspanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_intspanset_intspanset(ss1, ss2));
 
-        public static int distance_set_bigint(IntPtr s, int i)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_bigint(s, i));
+        public static long distance_set_bigint(IntPtr s, long i)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_set_bigint(s, i));
 
         public static int distance_set_date(IntPtr s, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_date(s, d));
@@ -1995,11 +2263,11 @@ namespace MEOS.NET.Internal
         public static int distance_set_int(IntPtr s, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_int(s, i));
 
-        public static double distance_set_timestamptz(IntPtr s, int t)
+        public static double distance_set_timestamptz(IntPtr s, long t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_set_timestamptz(s, t));
 
-        public static int distance_span_bigint(IntPtr s, int i)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_bigint(s, i));
+        public static long distance_span_bigint(IntPtr s, long i)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_span_bigint(s, i));
 
         public static int distance_span_date(IntPtr s, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_date(s, d));
@@ -2010,11 +2278,11 @@ namespace MEOS.NET.Internal
         public static int distance_span_int(IntPtr s, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_int(s, i));
 
-        public static double distance_span_timestamptz(IntPtr s, int t)
+        public static double distance_span_timestamptz(IntPtr s, long t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_span_timestamptz(s, t));
 
-        public static int distance_spanset_bigint(IntPtr ss, int i)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_bigint(ss, i));
+        public static long distance_spanset_bigint(IntPtr ss, long i)
+            => SafeExecution<long>(() => MEOSExternalFunctions.distance_spanset_bigint(ss, i));
 
         public static int distance_spanset_date(IntPtr ss, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_date(ss, d));
@@ -2025,7 +2293,7 @@ namespace MEOS.NET.Internal
         public static int distance_spanset_int(IntPtr ss, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_int(ss, i));
 
-        public static double distance_spanset_timestamptz(IntPtr ss, int t)
+        public static double distance_spanset_timestamptz(IntPtr ss, long t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_spanset_timestamptz(ss, t));
 
         public static double distance_tstzset_tstzset(IntPtr s1, IntPtr s2)
@@ -2040,10 +2308,10 @@ namespace MEOS.NET.Internal
         public static double distance_tstzspanset_tstzspanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_tstzspanset_tstzspanset(ss1, ss2));
 
-        public static IntPtr bigint_extent_transfn(IntPtr state, int i)
+        public static IntPtr bigint_extent_transfn(IntPtr state, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_extent_transfn(state, i));
 
-        public static IntPtr bigint_union_transfn(IntPtr state, int i)
+        public static IntPtr bigint_union_transfn(IntPtr state, long i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_union_transfn(state, i));
 
         public static IntPtr date_extent_transfn(IntPtr state, int d)
@@ -2091,19 +2359,19 @@ namespace MEOS.NET.Internal
         public static IntPtr text_union_transfn(IntPtr state, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.text_union_transfn(state, txt));
 
-        public static IntPtr timestamptz_extent_transfn(IntPtr state, int t)
+        public static IntPtr timestamptz_extent_transfn(IntPtr state, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_extent_transfn(state, t));
 
-        public static IntPtr timestamptz_union_transfn(IntPtr state, int t)
+        public static IntPtr timestamptz_union_transfn(IntPtr state, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_union_transfn(state, t));
 
-        public static int bigint_get_bin(int value, int vsize, int vorigin)
-            => SafeExecution<int>(() => MEOSExternalFunctions.bigint_get_bin(value, vsize, vorigin));
+        public static long bigint_get_bin(long value, long vsize, long vorigin)
+            => SafeExecution<long>(() => MEOSExternalFunctions.bigint_get_bin(value, vsize, vorigin));
 
-        public static IntPtr bigintspan_bins(IntPtr s, int vsize, int vorigin, IntPtr count)
+        public static IntPtr bigintspan_bins(IntPtr s, long vsize, long vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_bins(s, vsize, vorigin, count));
 
-        public static IntPtr bigintspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count)
+        public static IntPtr bigintspanset_bins(IntPtr ss, long vsize, long vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspanset_bins(ss, vsize, vorigin, count));
 
         public static int date_get_bin(int d, IntPtr duration, int torigin)
@@ -2133,13 +2401,13 @@ namespace MEOS.NET.Internal
         public static IntPtr intspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intspanset_bins(ss, vsize, vorigin, count));
 
-        public static int timestamptz_get_bin(int t, IntPtr duration, int torigin)
-            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_get_bin(t, duration, torigin));
+        public static long timestamptz_get_bin(long t, IntPtr duration, long torigin)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_get_bin(t, duration, torigin));
 
-        public static IntPtr tstzspan_bins(IntPtr s, IntPtr duration, int origin, IntPtr count)
+        public static IntPtr tstzspan_bins(IntPtr s, IntPtr duration, long origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_bins(s, duration, origin, count));
 
-        public static IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, int torigin, IntPtr count)
+        public static IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_bins(ss, duration, torigin, count));
 
         public static string tbox_as_hexwkb(IntPtr box, IntPtr variant, IntPtr size)
@@ -2160,13 +2428,13 @@ namespace MEOS.NET.Internal
         public static string tbox_out(IntPtr box, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.tbox_out(box, maxdd));
 
-        public static IntPtr float_timestamptz_to_tbox(double d, int t)
+        public static IntPtr float_timestamptz_to_tbox(double d, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.float_timestamptz_to_tbox(d, t));
 
         public static IntPtr float_tstzspan_to_tbox(double d, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.float_tstzspan_to_tbox(d, s));
 
-        public static IntPtr int_timestamptz_to_tbox(int i, int t)
+        public static IntPtr int_timestamptz_to_tbox(int i, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.int_timestamptz_to_tbox(i, t));
 
         public static IntPtr int_tstzspan_to_tbox(int i, IntPtr s)
@@ -2175,7 +2443,7 @@ namespace MEOS.NET.Internal
         public static IntPtr numspan_tstzspan_to_tbox(IntPtr span, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_tstzspan_to_tbox(span, s));
 
-        public static IntPtr numspan_timestamptz_to_tbox(IntPtr span, int t)
+        public static IntPtr numspan_timestamptz_to_tbox(IntPtr span, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_timestamptz_to_tbox(span, t));
 
         public static IntPtr tbox_copy(IntPtr box)
@@ -2208,14 +2476,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tbox_to_tstzspan(IntPtr box)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_to_tstzspan(box));
 
-        public static IntPtr timestamptz_to_tbox(int t)
+        public static IntPtr timestamptz_to_tbox(long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_tbox(t));
 
-        public static int tbox_hash(IntPtr box)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tbox_hash(box));
+        public static uint tbox_hash(IntPtr box)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.tbox_hash(box));
 
-        public static int tbox_hash_extended(IntPtr box, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tbox_hash_extended(box, seed));
+        public static ulong tbox_hash_extended(IntPtr box, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tbox_hash_extended(box, seed));
 
         public static bool tbox_hast(IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_hast(box));
@@ -2400,7 +2668,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tbool_from_base_temp(bool b, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbool_from_base_temp(b, temp));
 
-        public static IntPtr tboolinst_make(bool b, int t)
+        public static IntPtr tboolinst_make(bool b, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tboolinst_make(b, t));
 
         public static IntPtr tboolseq_from_base_tstzset(bool b, IntPtr s)
@@ -2418,7 +2686,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tfloat_from_base_temp(double d, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_from_base_temp(d, temp));
 
-        public static IntPtr tfloatinst_make(double d, int t)
+        public static IntPtr tfloatinst_make(double d, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatinst_make(d, t));
 
         public static IntPtr tfloatseq_from_base_tstzset(double d, IntPtr s)
@@ -2433,7 +2701,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tint_from_base_temp(int i, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_from_base_temp(i, temp));
 
-        public static IntPtr tintinst_make(int i, int t)
+        public static IntPtr tintinst_make(int i, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintinst_make(i, t));
 
         public static IntPtr tintseq_from_base_tstzset(int i, IntPtr s)
@@ -2457,7 +2725,7 @@ namespace MEOS.NET.Internal
         public static IntPtr ttext_from_base_temp(IntPtr txt, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttext_from_base_temp(txt, temp));
 
-        public static IntPtr ttextinst_make(IntPtr txt, int t)
+        public static IntPtr ttextinst_make(IntPtr txt, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttextinst_make(txt, t));
 
         public static IntPtr ttextseq_from_base_tstzset(IntPtr txt, IntPtr s)
@@ -2493,7 +2761,7 @@ namespace MEOS.NET.Internal
         public static bool tbool_start_value(IntPtr temp)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbool_start_value(temp));
 
-        public static bool tbool_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool tbool_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbool_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tbool_value_n(IntPtr temp, int n, IntPtr result)
@@ -2511,11 +2779,11 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_end_sequence(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_end_sequence(temp));
 
-        public static int temporal_end_timestamptz(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_end_timestamptz(temp));
+        public static long temporal_end_timestamptz(IntPtr temp)
+            => SafeExecution<long>(() => MEOSExternalFunctions.temporal_end_timestamptz(temp));
 
-        public static int temporal_hash(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_hash(temp));
+        public static uint temporal_hash(IntPtr temp)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.temporal_hash(temp));
 
         public static IntPtr temporal_instant_n(IntPtr temp, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_instant_n(temp, n));
@@ -2562,8 +2830,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_start_sequence(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_start_sequence(temp));
 
-        public static int temporal_start_timestamptz(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_start_timestamptz(temp));
+        public static long temporal_start_timestamptz(IntPtr temp)
+            => SafeExecution<long>(() => MEOSExternalFunctions.temporal_start_timestamptz(temp));
 
         public static IntPtr temporal_stops(IntPtr temp, double maxdist, IntPtr minduration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_stops(temp, maxdist, minduration));
@@ -2598,7 +2866,7 @@ namespace MEOS.NET.Internal
         public static double tfloat_start_value(IntPtr temp)
             => SafeExecution<double>(() => MEOSExternalFunctions.tfloat_start_value(temp));
 
-        public static bool tfloat_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool tfloat_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tfloat_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tfloat_value_n(IntPtr temp, int n, IntPtr result)
@@ -2619,7 +2887,7 @@ namespace MEOS.NET.Internal
         public static int tint_start_value(IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.tint_start_value(temp));
 
-        public static bool tint_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool tint_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tint_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tint_value_n(IntPtr temp, int n, IntPtr result)
@@ -2652,7 +2920,7 @@ namespace MEOS.NET.Internal
         public static IntPtr ttext_start_value(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttext_start_value(temp));
 
-        public static bool ttext_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool ttext_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.ttext_value_at_timestamptz(temp, t, strict, value));
 
         public static bool ttext_value_n(IntPtr temp, int n, IntPtr result)
@@ -2727,7 +2995,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_append_tsequence(IntPtr temp, IntPtr seq, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_append_tsequence(temp, seq, expand));
 
-        public static IntPtr temporal_delete_timestamptz(IntPtr temp, int t, bool connect)
+        public static IntPtr temporal_delete_timestamptz(IntPtr temp, long t, bool connect)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_delete_timestamptz(temp, t, connect));
 
         public static IntPtr temporal_delete_tstzset(IntPtr temp, IntPtr s, bool connect)
@@ -2757,7 +3025,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tbool_minus_value(IntPtr temp, bool b)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbool_minus_value(temp, b));
 
-        public static IntPtr temporal_after_timestamptz(IntPtr temp, int t, bool strict)
+        public static IntPtr temporal_after_timestamptz(IntPtr temp, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_after_timestamptz(temp, t, strict));
 
         public static IntPtr temporal_at_max(IntPtr temp)
@@ -2766,7 +3034,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_at_min(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_min(temp));
 
-        public static IntPtr temporal_at_timestamptz(IntPtr temp, int t)
+        public static IntPtr temporal_at_timestamptz(IntPtr temp, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_timestamptz(temp, t));
 
         public static IntPtr temporal_at_tstzset(IntPtr temp, IntPtr s)
@@ -2781,7 +3049,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_at_values(IntPtr temp, IntPtr set)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_values(temp, set));
 
-        public static IntPtr temporal_before_timestamptz(IntPtr temp, int t, bool strict)
+        public static IntPtr temporal_before_timestamptz(IntPtr temp, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_before_timestamptz(temp, t, strict));
 
         public static IntPtr temporal_minus_max(IntPtr temp)
@@ -2790,7 +3058,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_minus_min(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_minus_min(temp));
 
-        public static IntPtr temporal_minus_timestamptz(IntPtr temp, int t)
+        public static IntPtr temporal_minus_timestamptz(IntPtr temp, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_minus_timestamptz(temp, t));
 
         public static IntPtr temporal_minus_tstzset(IntPtr temp, IntPtr s)
@@ -3747,7 +4015,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tfloat_wsum_transfn(IntPtr state, IntPtr temp, IntPtr interv)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_wsum_transfn(state, temp, interv));
 
-        public static IntPtr timestamptz_tcount_transfn(IntPtr state, int t)
+        public static IntPtr timestamptz_tcount_transfn(IntPtr state, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_tcount_transfn(state, t));
 
         public static IntPtr tint_tmax_transfn(IntPtr state, IntPtr temp)
@@ -3807,10 +4075,10 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_simplify_min_tdelta(IntPtr temp, IntPtr mint)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_simplify_min_tdelta(temp, mint));
 
-        public static IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, int origin)
+        public static IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, long origin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tprecision(temp, duration, origin));
 
-        public static IntPtr temporal_tsample(IntPtr temp, IntPtr duration, int origin, int interp)
+        public static IntPtr temporal_tsample(IntPtr temp, IntPtr duration, long origin, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tsample(temp, duration, origin, interp));
 
         public static double temporal_dyntimewarp_distance(IntPtr temp1, IntPtr temp2)
@@ -3828,10 +4096,10 @@ namespace MEOS.NET.Internal
         public static double temporal_hausdorff_distance(IntPtr temp1, IntPtr temp2)
             => SafeExecution<double>(() => MEOSExternalFunctions.temporal_hausdorff_distance(temp1, temp2));
 
-        public static IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, int origin, IntPtr count)
+        public static IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, long origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_time_bins(temp, duration, origin, count));
 
-        public static (IntPtr[], int[]) temporal_time_split(IntPtr temp, IntPtr duration, int torigin)
+        public static (IntPtr[], long[]) temporal_time_split(IntPtr temp, IntPtr duration, long torigin)
         {
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _count_count = Marshal.AllocHGlobal(sizeof(int));
@@ -3843,7 +4111,7 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                int[] __out_time_bins_out = new int[_n];
+                long[] __out_time_bins_out = new long[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_time_bins_out);
             }
@@ -3854,7 +4122,7 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count)
+        public static IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_time_boxes(temp, duration, torigin, count));
 
         public static IntPtr tfloat_value_bins(IntPtr temp, double vsize, double vorigin, IntPtr count)
@@ -3886,10 +4154,10 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count)
+        public static IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static (IntPtr[], double[], int[]) tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin)
+        public static (IntPtr[], double[], long[]) tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin)
         {
             IntPtr _out_value_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -3905,7 +4173,7 @@ namespace MEOS.NET.Internal
                 double[] __out_value_bins_out = new double[_n];
                 Marshal.Copy(__out_value_bins_arr, __out_value_bins_out, 0, _n);
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                int[] __out_time_bins_out = new int[_n];
+                long[] __out_time_bins_out = new long[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_value_bins_out, __out_time_bins_out);
             }
@@ -3917,16 +4185,16 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count)
+        public static IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_time_tiles(box, duration, torigin, count));
 
         public static IntPtr tfloatbox_value_tiles(IntPtr box, double vsize, double vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_value_tiles(box, vsize, vorigin, count));
 
-        public static IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count)
+        public static IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_value_time_tiles(box, vsize, duration, vorigin, torigin, count));
 
-        public static IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count)
+        public static IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_time_boxes(temp, duration, torigin, count));
 
         public static IntPtr tint_value_bins(IntPtr temp, int vsize, int vorigin, IntPtr count)
@@ -3958,10 +4226,10 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, int torigin, IntPtr count)
+        public static IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static (IntPtr[], int[], int[]) tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, int torigin)
+        public static (IntPtr[], int[], long[]) tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, long torigin)
         {
             IntPtr _out_value_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -3977,7 +4245,7 @@ namespace MEOS.NET.Internal
                 int[] __out_value_bins_out = new int[_n];
                 Marshal.Copy(__out_value_bins_arr, __out_value_bins_out, 0, _n);
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                int[] __out_time_bins_out = new int[_n];
+                long[] __out_time_bins_out = new long[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_value_bins_out, __out_time_bins_out);
             }
@@ -3989,14 +4257,239 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count)
+        public static IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_time_tiles(box, duration, torigin, count));
 
         public static IntPtr tintbox_value_tiles(IntPtr box, int xsize, int xorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_value_tiles(box, xsize, xorigin, count));
 
-        public static IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, int torigin, IntPtr count)
+        public static IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_value_time_tiles(box, xsize, duration, xorigin, torigin, count));
+
+        public static bool temptype_subtype(int subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype(subtype));
+
+        public static bool temptype_subtype_all(int subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype_all(subtype));
+
+        public static string tempsubtype_name(int subtype)
+            => SafeExecution<string>(() => MEOSExternalFunctions.tempsubtype_name(subtype));
+
+        public static bool tempsubtype_from_string(string str, IntPtr subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tempsubtype_from_string(str, subtype));
+
+        public static string meosoper_name(IntPtr oper)
+            => SafeExecution<string>(() => MEOSExternalFunctions.meosoper_name(oper));
+
+        public static IntPtr meosoper_from_string(string name)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meosoper_from_string(name));
+
+        public static string interptype_name(int interp)
+            => SafeExecution<string>(() => MEOSExternalFunctions.interptype_name(interp));
+
+        public static int interptype_from_string(string interp_str)
+            => SafeExecution<int>(() => MEOSExternalFunctions.interptype_from_string(interp_str));
+
+        public static string meostype_name(int type)
+            => SafeExecution<string>(() => MEOSExternalFunctions.meostype_name(type));
+
+        public static int temptype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temptype_basetype(type));
+
+        public static int settype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.settype_basetype(type));
+
+        public static int spantype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_basetype(type));
+
+        public static int spantype_spansettype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_spansettype(type));
+
+        public static int spansettype_spantype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spansettype_spantype(type));
+
+        public static int basetype_spantype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_spantype(type));
+
+        public static int basetype_settype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_settype(type));
+
+        public static bool tnumber_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_basetype(type));
+
+        public static bool geo_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_basetype(type));
+
+        public static bool meos_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.meos_basetype(type));
+
+        public static bool alphanum_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_basetype(type));
+
+        public static bool alphanum_temptype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_temptype(type));
+
+        public static bool time_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.time_type(type));
+
+        public static bool set_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_basetype(type));
+
+        public static bool set_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_type(type));
+
+        public static bool numset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numset_type(type));
+
+        public static bool ensure_numset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numset_type(type));
+
+        public static bool timeset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timeset_type(type));
+
+        public static bool set_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_spantype(type));
+
+        public static bool ensure_set_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_spantype(type));
+
+        public static bool alphanumset_type(int settype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanumset_type(settype));
+
+        public static bool geoset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_type(type));
+
+        public static bool ensure_geoset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoset_type(type));
+
+        public static bool spatialset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spatialset_type(type));
+
+        public static bool ensure_spatialset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatialset_type(type));
+
+        public static bool span_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_basetype(type));
+
+        public static bool span_canon_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_canon_basetype(type));
+
+        public static bool span_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_type(type));
+
+        public static bool type_span_bbox(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.type_span_bbox(type));
+
+        public static bool span_tbox_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_tbox_type(type));
+
+        public static bool ensure_span_tbox_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_tbox_type(type));
+
+        public static bool numspan_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_basetype(type));
+
+        public static bool numspan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_type(type));
+
+        public static bool ensure_numspan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numspan_type(type));
+
+        public static bool timespan_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_basetype(type));
+
+        public static bool timespan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_type(type));
+
+        public static bool spanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_type(type));
+
+        public static bool timespanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespanset_type(type));
+
+        public static bool ensure_timespanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_timespanset_type(type));
+
+        public static bool temporal_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_type(type));
+
+        public static bool temporal_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_basetype(type));
+
+        public static bool temptype_supports_linear(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_supports_linear(type));
+
+        public static bool basetype_byvalue(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_byvalue(type));
+
+        public static bool basetype_varlength(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_varlength(type));
+
+        public static short meostype_length(int type)
+            => SafeExecution<short>(() => MEOSExternalFunctions.meostype_length(type));
+
+        public static bool talphanum_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.talphanum_type(type));
+
+        public static bool talpha_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.talpha_type(type));
+
+        public static bool tnumber_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_type(type));
+
+        public static bool ensure_tnumber_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_type(type));
+
+        public static bool ensure_tnumber_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_basetype(type));
+
+        public static bool tnumber_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_spantype(type));
+
+        public static bool spatial_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_basetype(type));
+
+        public static bool tspatial_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tspatial_type(type));
+
+        public static bool ensure_tspatial_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tspatial_type(type));
+
+        public static bool tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_type(type));
+
+        public static bool ensure_tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tpoint_type(type));
+
+        public static bool tgeo_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type(type));
+
+        public static bool ensure_tgeo_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type(type));
+
+        public static bool tgeo_type_all(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type_all(type));
+
+        public static bool ensure_tgeo_type_all(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type_all(type));
+
+        public static bool tgeometry_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeometry_type(type));
+
+        public static bool ensure_tgeometry_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeometry_type(type));
+
+        public static bool tgeodetic_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeodetic_type(type));
+
+        public static bool ensure_tgeodetic_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeodetic_type(type));
+
+        public static bool ensure_tnumber_tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_tpoint_type(type));
+
+        public static int geo_get_srid(IntPtr g)
+            => SafeExecution<int>(() => MEOSExternalFunctions.geo_get_srid(g));
 
         public static IntPtr geo_as_ewkb(IntPtr gs, string endian, IntPtr size)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_as_ewkb(gs, endian, size));
@@ -4277,12 +4770,13 @@ namespace MEOS.NET.Internal
         public static bool geoset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_value_n(s, n, result));
 
-        public static int[] geoset_values(IntPtr s)
+        public static IntPtr[] geoset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.geoset_values(s));
-            int[] _out = new int[_n];
-            Marshal.Copy(_p, _out, 0, _n);
+            IntPtr[] _out = new IntPtr[_n];
+            for (int _i = 0; _i < _n; _i++)
+            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
             return _out;
         }
 
@@ -4343,7 +4837,7 @@ namespace MEOS.NET.Internal
         public static string stbox_out(IntPtr box, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.stbox_out(box, maxdd));
 
-        public static IntPtr geo_timestamptz_to_stbox(IntPtr gs, int t)
+        public static IntPtr geo_timestamptz_to_stbox(IntPtr gs, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_timestamptz_to_stbox(gs, t));
 
         public static IntPtr geo_tstzspan_to_stbox(IntPtr gs, IntPtr s)
@@ -4373,7 +4867,7 @@ namespace MEOS.NET.Internal
         public static IntPtr stbox_to_tstzspan(IntPtr box)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_to_tstzspan(box));
 
-        public static IntPtr timestamptz_to_stbox(int t)
+        public static IntPtr timestamptz_to_stbox(long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_stbox(t));
 
         public static IntPtr tstzset_to_stbox(IntPtr s)
@@ -4388,11 +4882,11 @@ namespace MEOS.NET.Internal
         public static double stbox_area(IntPtr box, bool spheroid)
             => SafeExecution<double>(() => MEOSExternalFunctions.stbox_area(box, spheroid));
 
-        public static int stbox_hash(IntPtr box)
-            => SafeExecution<int>(() => MEOSExternalFunctions.stbox_hash(box));
+        public static uint stbox_hash(IntPtr box)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.stbox_hash(box));
 
-        public static int stbox_hash_extended(IntPtr box, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.stbox_hash_extended(box, seed));
+        public static ulong stbox_hash_extended(IntPtr box, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.stbox_hash_extended(box, seed));
 
         public static bool stbox_hast(IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_hast(box));
@@ -4601,7 +5095,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_from_base_temp(IntPtr gs, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_from_base_temp(gs, temp));
 
-        public static IntPtr tgeoinst_make(IntPtr gs, int t)
+        public static IntPtr tgeoinst_make(IntPtr gs, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoinst_make(gs, t));
 
         public static IntPtr tgeoseq_from_base_tstzset(IntPtr gs, IntPtr s)
@@ -4616,7 +5110,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tpoint_from_base_temp(IntPtr gs, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_from_base_temp(gs, temp));
 
-        public static IntPtr tpointinst_make(IntPtr gs, int t)
+        public static IntPtr tpointinst_make(IntPtr gs, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointinst_make(gs, t));
 
         public static IntPtr tpointseq_from_base_tstzset(IntPtr gs, IntPtr s)
@@ -4658,7 +5152,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeompoint_to_tgeometry(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompoint_to_tgeometry(temp));
 
-        public static (int[], int[]) tpoint_as_mvtgeom(IntPtr temp, IntPtr bounds, int extent, int buffer, bool clip_geom)
+        public static (IntPtr[], long[]) tpoint_as_mvtgeom(IntPtr temp, IntPtr bounds, int extent, int buffer, bool clip_geom)
         {
             IntPtr _out_gsarr = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_timesarr = Marshal.AllocHGlobal(IntPtr.Size);
@@ -4668,10 +5162,11 @@ namespace MEOS.NET.Internal
                 SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_as_mvtgeom(temp, bounds, extent, buffer, clip_geom, _out_gsarr, _out_timesarr, _count_count));
                 int _n = Marshal.ReadInt32(_count_count);
                 IntPtr __out_gsarr_arr = Marshal.ReadIntPtr(_out_gsarr);
-                int[] __out_gsarr_out = new int[_n];
-                Marshal.Copy(__out_gsarr_arr, __out_gsarr_out, 0, _n);
+                IntPtr[] __out_gsarr_out = new IntPtr[_n];
+                for (int _i = 0; _i < _n; _i++)
+                { __out_gsarr_out[_i] = Marshal.ReadIntPtr(__out_gsarr_arr, _i * IntPtr.Size); }
                 IntPtr __out_timesarr_arr = Marshal.ReadIntPtr(_out_timesarr);
-                int[] __out_timesarr_out = new int[_n];
+                long[] __out_timesarr_out = new long[_n];
                 Marshal.Copy(__out_timesarr_arr, __out_timesarr_out, 0, _n);
                 return (__out_gsarr_out, __out_timesarr_out);
             }
@@ -4713,7 +5208,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_traversed_area(IntPtr temp, bool unary_union)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_traversed_area(temp, unary_union));
 
-        public static bool tgeo_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool tgeo_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tgeo_value_n(IntPtr temp, int n, IntPtr result)
@@ -4869,7 +5364,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_space_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_boxes(temp, xsize, ysize, zsize, sorigin, bitmatrix, border_inc, count));
 
-        public static IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc, IntPtr count)
+        public static IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool bitmatrix, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_time_boxes(temp, xsize, ysize, zsize, duration, sorigin, torigin, bitmatrix, border_inc, count));
 
         public static IntPtr tgeo_split_each_n_stboxes(IntPtr temp, int elem_count, IntPtr count)
@@ -5247,22 +5742,22 @@ namespace MEOS.NET.Internal
         public static IntPtr stbox_get_space_tile(IntPtr point, double xsize, double ysize, double zsize, IntPtr sorigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_space_tile(point, xsize, ysize, zsize, sorigin));
 
-        public static IntPtr stbox_get_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin)
+        public static IntPtr stbox_get_space_time_tile(IntPtr point, long t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_space_time_tile(point, t, xsize, ysize, zsize, duration, sorigin, torigin));
 
-        public static IntPtr stbox_get_time_tile(int t, IntPtr duration, int torigin)
+        public static IntPtr stbox_get_time_tile(long t, IntPtr duration, long torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_time_tile(t, duration, torigin));
 
         public static IntPtr stbox_space_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr sorigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_tiles(bounds, xsize, ysize, zsize, sorigin, border_inc, count));
 
-        public static IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool border_inc, IntPtr count)
+        public static IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_time_tiles(bounds, xsize, ysize, zsize, duration, sorigin, torigin, border_inc, count));
 
-        public static IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, int torigin, bool border_inc, IntPtr count)
+        public static IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, long torigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_time_tiles(bounds, duration, torigin, border_inc, count));
 
-        public static (IntPtr[], int[]) tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc)
+        public static (IntPtr[], IntPtr[]) tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc)
         {
             IntPtr _out_space_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _count_count = Marshal.AllocHGlobal(sizeof(int));
@@ -5274,8 +5769,9 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_space_bins_arr = Marshal.ReadIntPtr(_out_space_bins);
-                int[] __out_space_bins_out = new int[_n];
-                Marshal.Copy(__out_space_bins_arr, __out_space_bins_out, 0, _n);
+                IntPtr[] __out_space_bins_out = new IntPtr[_n];
+                for (int _i = 0; _i < _n; _i++)
+                { __out_space_bins_out[_i] = Marshal.ReadIntPtr(__out_space_bins_arr, _i * IntPtr.Size); }
                 return (_resultArr, __out_space_bins_out);
             }
             finally
@@ -5285,7 +5781,7 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static (IntPtr[], int[], int[]) tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc)
+        public static (IntPtr[], IntPtr[], long[]) tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool bitmatrix, bool border_inc)
         {
             IntPtr _out_space_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -5298,10 +5794,11 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_space_bins_arr = Marshal.ReadIntPtr(_out_space_bins);
-                int[] __out_space_bins_out = new int[_n];
-                Marshal.Copy(__out_space_bins_arr, __out_space_bins_out, 0, _n);
+                IntPtr[] __out_space_bins_out = new IntPtr[_n];
+                for (int _i = 0; _i < _n; _i++)
+                { __out_space_bins_out[_i] = Marshal.ReadIntPtr(__out_space_bins_arr, _i * IntPtr.Size); }
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                int[] __out_time_bins_out = new int[_n];
+                long[] __out_time_bins_out = new long[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_space_bins_out, __out_time_bins_out);
             }
@@ -5367,11 +5864,11 @@ namespace MEOS.NET.Internal
         public static IntPtr geom_to_cbuffer(IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geom_to_cbuffer(gs));
 
-        public static int cbuffer_hash(IntPtr cb)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_hash(cb));
+        public static uint cbuffer_hash(IntPtr cb)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.cbuffer_hash(cb));
 
-        public static int cbuffer_hash_extended(IntPtr cb, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_hash_extended(cb, seed));
+        public static ulong cbuffer_hash_extended(IntPtr cb, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.cbuffer_hash_extended(cb, seed));
 
         public static IntPtr cbuffer_point(IntPtr cb)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_point(cb));
@@ -5418,7 +5915,7 @@ namespace MEOS.NET.Internal
         public static IntPtr cbuffer_tstzspan_to_stbox(IntPtr cb, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_tstzspan_to_stbox(cb, s));
 
-        public static IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, int t)
+        public static IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_timestamptz_to_stbox(cb, t));
 
         public static double distance_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
@@ -5844,335 +6341,32 @@ namespace MEOS.NET.Internal
         public static IntPtr ttouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tcbuffer_tcbuffer(temp1, temp2));
 
-        public static bool ensure_valid_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_cbuffer(cb1, cb2));
-
-        public static bool ensure_valid_cbuffer_geo(IntPtr cb, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_geo(cb, gs));
-
-        public static bool ensure_valid_cbuffer_stbox(IntPtr cb, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_stbox(cb, box));
-
-        public static bool ensure_valid_cbufferset_cbuffer(IntPtr s, IntPtr cb)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbufferset_cbuffer(s, cb));
-
-        public static bool cbuffer_collinear(IntPtr cb1, IntPtr cb2, IntPtr cbuf3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_collinear(cb1, cb2, cbuf3, ratio));
-
-        public static IntPtr cbuffersegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffersegm_interpolate(start, end, ratio));
-
-        public static IntPtr cbuffersegm_locate(IntPtr start, IntPtr end, IntPtr value)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffersegm_locate(start, end, value));
-
-        public static IntPtr cbuffer_parse(IntPtr str, bool end)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_parse(str, end));
-
-        public static string cbuffer_wkt_out(int value, int maxdd, bool extended)
-            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_wkt_out(value, maxdd, extended));
-
-        public static IntPtr cbuffer_point_p(IntPtr cb)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_point_p(cb));
-
-        public static int datum_cbuffer_round(int buffer, int size)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_round(buffer, size));
-
-        public static IntPtr cbuffer_transf_pj(IntPtr cb, int srid_to, IntPtr pj)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_transf_pj(cb, srid_to, pj));
-
-        public static double cbuffer_distance(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<double>(() => MEOSExternalFunctions.cbuffer_distance(cb1, cb2));
-
-        public static int datum_cbuffer_distance(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_distance(cb1, cb2));
-
-        public static int cbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffersegm_distance_turnpt(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static int cbuffer_contains(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_contains(cb1, cb2));
-
-        public static int cbuffer_covers(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_covers(cb1, cb2));
-
-        public static int cbuffer_disjoint(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_disjoint(cb1, cb2));
-
-        public static int cbuffer_intersects(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_intersects(cb1, cb2));
-
-        public static int cbuffer_dwithin(IntPtr cb1, IntPtr cb2, double dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_dwithin(cb1, cb2, dist));
-
-        public static int cbuffer_touches(IntPtr cb1, IntPtr cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_touches(cb1, cb2));
-
-        public static int datum_cbuffer_contains(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_contains(cb1, cb2));
-
-        public static int datum_cbuffer_covers(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_covers(cb1, cb2));
-
-        public static int datum_cbuffer_disjoint(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_disjoint(cb1, cb2));
-
-        public static int datum_cbuffer_intersects(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_intersects(cb1, cb2));
-
-        public static int datum_cbuffer_dwithin(int cb1, int cb2, int dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_dwithin(cb1, cb2, dist));
-
-        public static int datum_cbuffer_touches(int cb1, int cb2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_touches(cb1, cb2));
-
-        public static bool temptype_subtype(int subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype(subtype));
-
-        public static bool temptype_subtype_all(int subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype_all(subtype));
-
-        public static string tempsubtype_name(int subtype)
-            => SafeExecution<string>(() => MEOSExternalFunctions.tempsubtype_name(subtype));
-
-        public static bool tempsubtype_from_string(string str, IntPtr subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tempsubtype_from_string(str, subtype));
-
-        public static string meosoper_name(IntPtr oper)
-            => SafeExecution<string>(() => MEOSExternalFunctions.meosoper_name(oper));
-
-        public static IntPtr meosoper_from_string(string name)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meosoper_from_string(name));
-
-        public static string interptype_name(int interp)
-            => SafeExecution<string>(() => MEOSExternalFunctions.interptype_name(interp));
-
-        public static int interptype_from_string(string interp_str)
-            => SafeExecution<int>(() => MEOSExternalFunctions.interptype_from_string(interp_str));
-
-        public static string meostype_name(int type)
-            => SafeExecution<string>(() => MEOSExternalFunctions.meostype_name(type));
-
-        public static int temptype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temptype_basetype(type));
-
-        public static int settype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.settype_basetype(type));
-
-        public static int spantype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_basetype(type));
-
-        public static int spantype_spansettype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_spansettype(type));
-
-        public static int spansettype_spantype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spansettype_spantype(type));
-
-        public static int basetype_spantype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_spantype(type));
-
-        public static int basetype_settype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_settype(type));
-
-        public static bool tnumber_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_basetype(type));
-
-        public static bool geo_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_basetype(type));
-
-        public static bool meos_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.meos_basetype(type));
-
-        public static bool alphanum_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_basetype(type));
-
-        public static bool alphanum_temptype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_temptype(type));
-
-        public static bool time_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.time_type(type));
-
-        public static bool set_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_basetype(type));
-
-        public static bool set_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_type(type));
-
-        public static bool numset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numset_type(type));
-
-        public static bool ensure_numset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numset_type(type));
-
-        public static bool timeset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timeset_type(type));
-
-        public static bool set_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_spantype(type));
-
-        public static bool ensure_set_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_spantype(type));
-
-        public static bool alphanumset_type(int settype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanumset_type(settype));
-
-        public static bool geoset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_type(type));
-
-        public static bool ensure_geoset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoset_type(type));
-
-        public static bool spatialset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spatialset_type(type));
-
-        public static bool ensure_spatialset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatialset_type(type));
-
-        public static bool span_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_basetype(type));
-
-        public static bool span_canon_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_canon_basetype(type));
-
-        public static bool span_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_type(type));
-
-        public static bool type_span_bbox(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.type_span_bbox(type));
-
-        public static bool span_tbox_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_tbox_type(type));
-
-        public static bool ensure_span_tbox_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_tbox_type(type));
-
-        public static bool numspan_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_basetype(type));
-
-        public static bool numspan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_type(type));
-
-        public static bool ensure_numspan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numspan_type(type));
-
-        public static bool timespan_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_basetype(type));
-
-        public static bool timespan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_type(type));
-
-        public static bool spanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_type(type));
-
-        public static bool timespanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespanset_type(type));
-
-        public static bool ensure_timespanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_timespanset_type(type));
-
-        public static bool temporal_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_type(type));
-
-        public static bool temporal_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_basetype(type));
-
-        public static bool temptype_supports_linear(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_supports_linear(type));
-
-        public static bool basetype_byvalue(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_byvalue(type));
-
-        public static bool basetype_varlength(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_varlength(type));
-
-        public static short meostype_length(int type)
-            => SafeExecution<short>(() => MEOSExternalFunctions.meostype_length(type));
-
-        public static bool talphanum_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.talphanum_type(type));
-
-        public static bool talpha_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.talpha_type(type));
-
-        public static bool tnumber_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_type(type));
-
-        public static bool ensure_tnumber_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_type(type));
-
-        public static bool ensure_tnumber_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_basetype(type));
-
-        public static bool tnumber_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_spantype(type));
-
-        public static bool spatial_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_basetype(type));
-
-        public static bool tspatial_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tspatial_type(type));
-
-        public static bool ensure_tspatial_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tspatial_type(type));
-
-        public static bool tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_type(type));
-
-        public static bool ensure_tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tpoint_type(type));
-
-        public static bool tgeo_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type(type));
-
-        public static bool ensure_tgeo_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type(type));
-
-        public static bool tgeo_type_all(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type_all(type));
-
-        public static bool ensure_tgeo_type_all(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type_all(type));
-
-        public static bool tgeometry_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeometry_type(type));
-
-        public static bool ensure_tgeometry_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeometry_type(type));
-
-        public static bool tgeodetic_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeodetic_type(type));
-
-        public static bool ensure_tgeodetic_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeodetic_type(type));
-
-        public static bool ensure_tnumber_tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_tpoint_type(type));
-
         public static IntPtr gsl_get_generation_rng()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.gsl_get_generation_rng());
 
         public static IntPtr gsl_get_aggregation_rng()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.gsl_get_aggregation_rng());
 
-        public static int datum_ceil(IntPtr d)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_ceil(d));
+        public static ulong datum_ceil(ulong d)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_ceil(d));
 
-        public static int datum_degrees(IntPtr d, IntPtr normalize)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_degrees(d, normalize));
+        public static ulong datum_degrees(ulong d, ulong normalize)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_degrees(d, normalize));
 
-        public static int datum_float_round(IntPtr value, IntPtr size)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_float_round(value, size));
+        public static ulong datum_float_round(ulong value, ulong size)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_float_round(value, size));
 
-        public static int datum_floor(IntPtr d)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_floor(d));
+        public static ulong datum_floor(ulong d)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_floor(d));
 
-        public static int datum_hash(IntPtr d, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_hash(d, basetype));
+        public static uint datum_hash(ulong d, int basetype)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.datum_hash(d, basetype));
 
-        public static int datum_hash_extended(IntPtr d, int basetype, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_hash_extended(d, basetype, seed));
+        public static ulong datum_hash_extended(ulong d, int basetype, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_hash_extended(d, basetype, seed));
 
-        public static int datum_radians(IntPtr d)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_radians(d));
+        public static ulong datum_radians(ulong d)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_radians(d));
 
         public static void floatspan_round_set(IntPtr s, int maxdd, IntPtr result)
             => SafeExecution(() => MEOSExternalFunctions.floatspan_round_set(s, maxdd, result));
@@ -6204,10 +6398,10 @@ namespace MEOS.NET.Internal
         public static IntPtr set_make_free(IntPtr values, int count, int basetype, bool order)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_make_free(values, count, basetype, order));
 
-        public static IntPtr span_make(IntPtr lower, IntPtr upper, bool lower_inc, bool upper_inc, int basetype)
+        public static IntPtr span_make(ulong lower, ulong upper, bool lower_inc, bool upper_inc, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_make(lower, upper, lower_inc, upper_inc, basetype));
 
-        public static void span_set(IntPtr lower, IntPtr upper, bool lower_inc, bool upper_inc, int basetype, int spantype, IntPtr s)
+        public static void span_set(ulong lower, ulong upper, bool lower_inc, bool upper_inc, int basetype, int spantype, IntPtr s)
             => SafeExecution(() => MEOSExternalFunctions.span_set(lower, upper, lower_inc, upper_inc, basetype, spantype, s));
 
         public static IntPtr spanset_make_exp(IntPtr spans, int count, int maxcount, bool normalize, bool order)
@@ -6222,26 +6416,26 @@ namespace MEOS.NET.Internal
         public static IntPtr set_spanset(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_spanset(s));
 
-        public static void value_set_span(IntPtr value, int basetype, IntPtr s)
+        public static void value_set_span(ulong value, int basetype, IntPtr s)
             => SafeExecution(() => MEOSExternalFunctions.value_set_span(value, basetype, s));
 
-        public static IntPtr value_set(IntPtr d, int basetype)
+        public static IntPtr value_set(ulong d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_set(d, basetype));
 
-        public static IntPtr value_span(IntPtr d, int basetype)
+        public static IntPtr value_span(ulong d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_span(d, basetype));
 
-        public static IntPtr value_spanset(IntPtr d, int basetype)
+        public static IntPtr value_spanset(ulong d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_spanset(d, basetype));
 
-        public static int numspan_width(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.numspan_width(s));
+        public static ulong numspan_width(IntPtr s)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.numspan_width(s));
 
-        public static int numspanset_width(IntPtr ss, bool boundspan)
-            => SafeExecution<int>(() => MEOSExternalFunctions.numspanset_width(ss, boundspan));
+        public static ulong numspanset_width(IntPtr ss, bool boundspan)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.numspanset_width(ss, boundspan));
 
-        public static int set_end_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.set_end_value(s));
+        public static ulong set_end_value(IntPtr s)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_end_value(s));
 
         public static int set_mem_size(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.set_mem_size(s));
@@ -6252,8 +6446,8 @@ namespace MEOS.NET.Internal
         public static void set_set_span(IntPtr s, IntPtr result)
             => SafeExecution(() => MEOSExternalFunctions.set_set_span(s, result));
 
-        public static int set_start_value(IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.set_start_value(s));
+        public static ulong set_start_value(IntPtr s)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_start_value(s));
 
         public static bool set_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.set_value_n(s, n, result));
@@ -6264,8 +6458,8 @@ namespace MEOS.NET.Internal
         public static IntPtr set_values(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_values(s));
 
-        public static int spanset_lower(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_lower(ss));
+        public static ulong spanset_lower(IntPtr ss)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_lower(ss));
 
         public static int spanset_mem_size(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.spanset_mem_size(ss));
@@ -6280,8 +6474,8 @@ namespace MEOS.NET.Internal
             return _out;
         }
 
-        public static int spanset_upper(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_upper(ss));
+        public static ulong spanset_upper(IntPtr ss)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_upper(ss));
 
         public static void datespan_set_tstzspan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.datespan_set_tstzspan(s1, s2));
@@ -6292,16 +6486,16 @@ namespace MEOS.NET.Internal
         public static void intspan_set_floatspan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.intspan_set_floatspan(s1, s2));
 
-        public static IntPtr numset_shift_scale(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr numset_shift_scale(IntPtr s, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numset_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr numspan_expand(IntPtr s, IntPtr value)
+        public static IntPtr numspan_expand(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_expand(s, value));
 
-        public static IntPtr numspan_shift_scale(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr numspan_shift_scale(IntPtr s, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr numspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr numspanset_shift_scale(IntPtr ss, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspanset_shift_scale(ss, shift, width, hasshift, haswidth));
 
         public static IntPtr set_compact(IntPtr s)
@@ -6313,7 +6507,7 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_compact(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_compact(ss));
 
-        public static IntPtr tbox_expand_value(IntPtr box, IntPtr value, int basetyp)
+        public static IntPtr tbox_expand_value(IntPtr box, ulong value, int basetyp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_expand_value(box, value, basetyp));
 
         public static IntPtr textcat_textset_text_common(IntPtr s, IntPtr txt, bool invert)
@@ -6322,109 +6516,109 @@ namespace MEOS.NET.Internal
         public static void tstzspan_set_datespan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.tstzspan_set_datespan(s1, s2));
 
-        public static bool adjacent_span_value(IntPtr s, IntPtr value)
+        public static bool adjacent_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_value(s, value));
 
-        public static bool adjacent_spanset_value(IntPtr ss, IntPtr value)
+        public static bool adjacent_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_value(ss, value));
 
-        public static bool adjacent_value_spanset(IntPtr value, IntPtr ss)
+        public static bool adjacent_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_value_spanset(value, ss));
 
-        public static bool contained_value_set(IntPtr value, IntPtr s)
+        public static bool contained_value_set(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_set(value, s));
 
-        public static bool contained_value_span(IntPtr value, IntPtr s)
+        public static bool contained_value_span(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_span(value, s));
 
-        public static bool contained_value_spanset(IntPtr value, IntPtr ss)
+        public static bool contained_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_spanset(value, ss));
 
-        public static bool contains_set_value(IntPtr s, IntPtr value)
+        public static bool contains_set_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_value(s, value));
 
-        public static bool contains_span_value(IntPtr s, IntPtr value)
+        public static bool contains_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_value(s, value));
 
-        public static bool contains_spanset_value(IntPtr ss, IntPtr value)
+        public static bool contains_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_value(ss, value));
 
         public static bool ovadj_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.ovadj_span_span(s1, s2));
 
-        public static bool left_set_value(IntPtr s, IntPtr value)
+        public static bool left_set_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_value(s, value));
 
-        public static bool left_span_value(IntPtr s, IntPtr value)
+        public static bool left_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_value(s, value));
 
-        public static bool left_spanset_value(IntPtr ss, IntPtr value)
+        public static bool left_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_spanset_value(ss, value));
 
-        public static bool left_value_set(IntPtr value, IntPtr s)
+        public static bool left_value_set(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_set(value, s));
 
-        public static bool left_value_span(IntPtr value, IntPtr s)
+        public static bool left_value_span(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_span(value, s));
 
-        public static bool left_value_spanset(IntPtr value, IntPtr ss)
+        public static bool left_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_spanset(value, ss));
 
         public static bool lfnadj_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.lfnadj_span_span(s1, s2));
 
-        public static bool overleft_set_value(IntPtr s, IntPtr value)
+        public static bool overleft_set_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_value(s, value));
 
-        public static bool overleft_span_value(IntPtr s, IntPtr value)
+        public static bool overleft_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_value(s, value));
 
-        public static bool overleft_spanset_value(IntPtr ss, IntPtr value)
+        public static bool overleft_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_spanset_value(ss, value));
 
-        public static bool overleft_value_set(IntPtr value, IntPtr s)
+        public static bool overleft_value_set(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_set(value, s));
 
-        public static bool overleft_value_span(IntPtr value, IntPtr s)
+        public static bool overleft_value_span(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_span(value, s));
 
-        public static bool overleft_value_spanset(IntPtr value, IntPtr ss)
+        public static bool overleft_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_spanset(value, ss));
 
-        public static bool overright_set_value(IntPtr s, IntPtr value)
+        public static bool overright_set_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_value(s, value));
 
-        public static bool overright_span_value(IntPtr s, IntPtr value)
+        public static bool overright_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_value(s, value));
 
-        public static bool overright_spanset_value(IntPtr ss, IntPtr value)
+        public static bool overright_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_spanset_value(ss, value));
 
-        public static bool overright_value_set(IntPtr value, IntPtr s)
+        public static bool overright_value_set(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_set(value, s));
 
-        public static bool overright_value_span(IntPtr value, IntPtr s)
+        public static bool overright_value_span(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_span(value, s));
 
-        public static bool overright_value_spanset(IntPtr value, IntPtr ss)
+        public static bool overright_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_spanset(value, ss));
 
-        public static bool right_value_set(IntPtr value, IntPtr s)
+        public static bool right_value_set(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_set(value, s));
 
-        public static bool right_set_value(IntPtr s, IntPtr value)
+        public static bool right_set_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_value(s, value));
 
-        public static bool right_value_span(IntPtr value, IntPtr s)
+        public static bool right_value_span(ulong value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_span(value, s));
 
-        public static bool right_value_spanset(IntPtr value, IntPtr ss)
+        public static bool right_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_spanset(value, ss));
 
-        public static bool right_span_value(IntPtr s, IntPtr value)
+        public static bool right_span_value(IntPtr s, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_value(s, value));
 
-        public static bool right_spanset_value(IntPtr ss, IntPtr value)
+        public static bool right_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_spanset_value(ss, value));
 
         public static bool bbox_type(int bboxtype)
@@ -6448,100 +6642,100 @@ namespace MEOS.NET.Internal
         public static bool inter_span_span(IntPtr s1, IntPtr s2, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.inter_span_span(s1, s2, result));
 
-        public static IntPtr intersection_set_value(IntPtr s, IntPtr value)
+        public static IntPtr intersection_set_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_value(s, value));
 
-        public static IntPtr intersection_span_value(IntPtr s, IntPtr value)
+        public static IntPtr intersection_span_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_value(s, value));
 
-        public static IntPtr intersection_spanset_value(IntPtr ss, IntPtr value)
+        public static IntPtr intersection_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_value(ss, value));
 
-        public static IntPtr intersection_value_set(IntPtr value, IntPtr s)
+        public static IntPtr intersection_value_set(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_set(value, s));
 
-        public static IntPtr intersection_value_span(IntPtr value, IntPtr s)
+        public static IntPtr intersection_value_span(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_span(value, s));
 
-        public static IntPtr intersection_value_spanset(IntPtr value, IntPtr ss)
+        public static IntPtr intersection_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_spanset(value, ss));
 
         public static int mi_span_span(IntPtr s1, IntPtr s2, IntPtr result)
             => SafeExecution<int>(() => MEOSExternalFunctions.mi_span_span(s1, s2, result));
 
-        public static IntPtr minus_set_value(IntPtr s, IntPtr value)
+        public static IntPtr minus_set_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_value(s, value));
 
-        public static IntPtr minus_span_value(IntPtr s, IntPtr value)
+        public static IntPtr minus_span_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_value(s, value));
 
-        public static IntPtr minus_spanset_value(IntPtr ss, IntPtr value)
+        public static IntPtr minus_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_value(ss, value));
 
-        public static IntPtr minus_value_set(IntPtr value, IntPtr s)
+        public static IntPtr minus_value_set(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_set(value, s));
 
-        public static IntPtr minus_value_span(IntPtr value, IntPtr s)
+        public static IntPtr minus_value_span(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_span(value, s));
 
-        public static IntPtr minus_value_spanset(IntPtr value, IntPtr ss)
+        public static IntPtr minus_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_spanset(value, ss));
 
         public static IntPtr super_union_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.super_union_span_span(s1, s2));
 
-        public static IntPtr union_set_value(IntPtr s, IntPtr value)
+        public static IntPtr union_set_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_value(s, value));
 
-        public static IntPtr union_span_value(IntPtr s, IntPtr value)
+        public static IntPtr union_span_value(IntPtr s, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_value(s, value));
 
-        public static IntPtr union_spanset_value(IntPtr ss, IntPtr value)
+        public static IntPtr union_spanset_value(IntPtr ss, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_value(ss, value));
 
-        public static IntPtr union_value_set(IntPtr value, IntPtr s)
+        public static IntPtr union_value_set(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_set(value, s));
 
-        public static IntPtr union_value_span(IntPtr value, IntPtr s)
+        public static IntPtr union_value_span(ulong value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_span(value, s));
 
-        public static IntPtr union_value_spanset(IntPtr value, IntPtr ss)
+        public static IntPtr union_value_spanset(ulong value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_spanset(value, ss));
 
-        public static int distance_set_set(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_set(s1, s2));
+        public static ulong distance_set_set(IntPtr s1, IntPtr s2)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_set_set(s1, s2));
 
-        public static int distance_set_value(IntPtr s, IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_value(s, value));
+        public static ulong distance_set_value(IntPtr s, ulong value)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_set_value(s, value));
 
-        public static int distance_span_span(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_span(s1, s2));
+        public static ulong distance_span_span(IntPtr s1, IntPtr s2)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_span_span(s1, s2));
 
-        public static int distance_span_value(IntPtr s, IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_value(s, value));
+        public static ulong distance_span_value(IntPtr s, ulong value)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_span_value(s, value));
 
-        public static int distance_spanset_span(IntPtr ss, IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_span(ss, s));
+        public static ulong distance_spanset_span(IntPtr ss, IntPtr s)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_span(ss, s));
 
-        public static int distance_spanset_spanset(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_spanset(ss1, ss2));
+        public static ulong distance_spanset_spanset(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_spanset(ss1, ss2));
 
-        public static int distance_spanset_value(IntPtr ss, IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_value(ss, value));
+        public static ulong distance_spanset_value(IntPtr ss, ulong value)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_value(ss, value));
 
-        public static int distance_value_value(IntPtr l, IntPtr r, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.distance_value_value(l, r, basetype));
+        public static ulong distance_value_value(ulong l, ulong r, int basetype)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_value_value(l, r, basetype));
 
-        public static IntPtr spanbase_extent_transfn(IntPtr state, IntPtr value, int basetype)
+        public static IntPtr spanbase_extent_transfn(IntPtr state, ulong value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanbase_extent_transfn(state, value, basetype));
 
-        public static IntPtr value_union_transfn(IntPtr state, IntPtr value, int basetype)
+        public static IntPtr value_union_transfn(IntPtr state, ulong value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_union_transfn(state, value, basetype));
 
-        public static IntPtr number_tstzspan_to_tbox(IntPtr d, int basetype, IntPtr s)
+        public static IntPtr number_tstzspan_to_tbox(ulong d, int basetype, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_tstzspan_to_tbox(d, basetype, s));
 
-        public static IntPtr number_timestamptz_to_tbox(IntPtr d, int basetype, int t)
+        public static IntPtr number_timestamptz_to_tbox(ulong d, int basetype, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_timestamptz_to_tbox(d, basetype, t));
 
         public static void tbox_set(IntPtr s, IntPtr p, IntPtr box)
@@ -6553,10 +6747,10 @@ namespace MEOS.NET.Internal
         public static void int_set_tbox(int i, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.int_set_tbox(i, box));
 
-        public static void number_set_tbox(IntPtr d, int basetype, IntPtr box)
+        public static void number_set_tbox(ulong d, int basetype, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.number_set_tbox(d, basetype, box));
 
-        public static IntPtr number_tbox(IntPtr value, int basetype)
+        public static IntPtr number_tbox(ulong value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_tbox(value, basetype));
 
         public static void numset_set_tbox(IntPtr s, IntPtr box)
@@ -6565,7 +6759,7 @@ namespace MEOS.NET.Internal
         public static void numspan_set_tbox(IntPtr span, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.numspan_set_tbox(span, box));
 
-        public static void timestamptz_set_tbox(int t, IntPtr box)
+        public static void timestamptz_set_tbox(long t, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.timestamptz_set_tbox(t, box));
 
         public static void tstzset_set_tbox(IntPtr s, IntPtr box)
@@ -6574,7 +6768,7 @@ namespace MEOS.NET.Internal
         public static void tstzspan_set_tbox(IntPtr s, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tstzspan_set_tbox(s, box));
 
-        public static IntPtr tbox_shift_scale_value(IntPtr box, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr tbox_shift_scale_value(IntPtr box, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_shift_scale_value(box, shift, width, hasshift, haswidth));
 
         public static void tbox_expand(IntPtr box1, IntPtr box2)
@@ -6694,28 +6888,28 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_from_mfjson(string mfjson, int temptype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_from_mfjson(mfjson, temptype));
 
-        public static IntPtr temporal_from_base_temp(IntPtr value, int temptype, IntPtr temp)
+        public static IntPtr temporal_from_base_temp(ulong value, int temptype, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_from_base_temp(value, temptype, temp));
 
         public static IntPtr tinstant_copy(IntPtr inst)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_copy(inst));
 
-        public static IntPtr tinstant_make(IntPtr value, int temptype, int t)
+        public static IntPtr tinstant_make(ulong value, int temptype, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_make(value, temptype, t));
 
-        public static IntPtr tinstant_make_free(IntPtr value, int temptype, int t)
+        public static IntPtr tinstant_make_free(ulong value, int temptype, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_make_free(value, temptype, t));
 
         public static IntPtr tsequence_copy(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_copy(seq));
 
-        public static IntPtr tsequence_from_base_temp(IntPtr value, int temptype, IntPtr seq)
+        public static IntPtr tsequence_from_base_temp(ulong value, int temptype, IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_temp(value, temptype, seq));
 
-        public static IntPtr tsequence_from_base_tstzset(IntPtr value, int temptype, IntPtr s)
+        public static IntPtr tsequence_from_base_tstzset(ulong value, int temptype, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_tstzset(value, temptype, s));
 
-        public static IntPtr tsequence_from_base_tstzspan(IntPtr value, int temptype, IntPtr s, int interp)
+        public static IntPtr tsequence_from_base_tstzspan(ulong value, int temptype, IntPtr s, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_tstzspan(value, temptype, s, interp));
 
         public static IntPtr tsequence_make_exp(IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
@@ -6730,10 +6924,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tseqsetarr_to_tseqset(IntPtr seqsets, int count, int totalseqs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqsetarr_to_tseqset(seqsets, count, totalseqs));
 
-        public static IntPtr tsequenceset_from_base_temp(IntPtr value, int temptype, IntPtr ss)
+        public static IntPtr tsequenceset_from_base_temp(ulong value, int temptype, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_from_base_temp(value, temptype, ss));
 
-        public static IntPtr tsequenceset_from_base_tstzspanset(IntPtr value, int temptype, IntPtr ss, int interp)
+        public static IntPtr tsequenceset_from_base_tstzspanset(ulong value, int temptype, IntPtr ss, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_from_base_tstzspanset(value, temptype, ss, interp));
 
         public static IntPtr tsequenceset_make_exp(IntPtr sequences, int count, int maxcount, bool normalize)
@@ -6769,8 +6963,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_end_inst(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_end_inst(temp));
 
-        public static int temporal_end_value(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_end_value(temp));
+        public static ulong temporal_end_value(IntPtr temp)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_end_value(temp));
 
         public static IntPtr temporal_inst_n(IntPtr temp, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_inst_n(temp, n));
@@ -6781,8 +6975,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_max_inst_p(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_max_inst_p(temp));
 
-        public static int temporal_max_value(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_max_value(temp));
+        public static ulong temporal_max_value(IntPtr temp)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_max_value(temp));
 
         public static ulong temporal_mem_size(IntPtr temp)
             => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_mem_size(temp));
@@ -6790,8 +6984,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_min_inst_p(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_min_inst_p(temp));
 
-        public static int temporal_min_value(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_min_value(temp));
+        public static ulong temporal_min_value(IntPtr temp)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_min_value(temp));
 
         public static IntPtr temporal_sequences_p(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_sequences_p(temp, count));
@@ -6802,8 +6996,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_start_inst(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_start_inst(temp));
 
-        public static int temporal_start_value(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_start_value(temp));
+        public static ulong temporal_start_value(IntPtr temp)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_start_value(temp));
 
         public static IntPtr temporal_values_p(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_values_p(temp, count));
@@ -6814,8 +7008,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_values(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_values(temp, count));
 
-        public static int tinstant_hash(IntPtr inst)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_hash(inst));
+        public static uint tinstant_hash(IntPtr inst)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.tinstant_hash(inst));
 
         public static IntPtr tinstant_insts(IntPtr inst, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_insts(inst, count));
@@ -6829,13 +7023,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_timestamps(IntPtr inst, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_timestamps(inst, count));
 
-        public static int tinstant_value_p(IntPtr inst)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_value_p(inst));
+        public static ulong tinstant_value_p(IntPtr inst)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tinstant_value_p(inst));
 
-        public static int tinstant_value(IntPtr inst)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_value(inst));
+        public static ulong tinstant_value(IntPtr inst)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tinstant_value(inst));
 
-        public static bool tinstant_value_at_timestamptz(IntPtr inst, int t, IntPtr result)
+        public static bool tinstant_value_at_timestamptz(IntPtr inst, long t, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_value_at_timestamptz(inst, t, result));
 
         public static IntPtr tinstant_values_p(IntPtr inst, IntPtr count)
@@ -6862,11 +7056,11 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_duration(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_duration(seq));
 
-        public static int tsequence_end_timestamptz(IntPtr seq)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_end_timestamptz(seq));
+        public static long tsequence_end_timestamptz(IntPtr seq)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tsequence_end_timestamptz(seq));
 
-        public static int tsequence_hash(IntPtr seq)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_hash(seq));
+        public static uint tsequence_hash(IntPtr seq)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.tsequence_hash(seq));
 
         public static IntPtr[] tsequence_insts_p(IntPtr seq)
         {
@@ -6881,14 +7075,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_max_inst_p(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_max_inst_p(seq));
 
-        public static int tsequence_max_val(IntPtr seq)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_max_val(seq));
+        public static ulong tsequence_max_val(IntPtr seq)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequence_max_val(seq));
 
         public static IntPtr tsequence_min_inst_p(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_min_inst_p(seq));
 
-        public static int tsequence_min_val(IntPtr seq)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_min_val(seq));
+        public static ulong tsequence_min_val(IntPtr seq)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequence_min_val(seq));
 
         public static IntPtr tsequence_segments(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_segments(seq, count));
@@ -6896,8 +7090,8 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_seqs(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_seqs(seq, count));
 
-        public static int tsequence_start_timestamptz(IntPtr seq)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_start_timestamptz(seq));
+        public static long tsequence_start_timestamptz(IntPtr seq)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tsequence_start_timestamptz(seq));
 
         public static IntPtr tsequence_time(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_time(seq));
@@ -6905,7 +7099,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_timestamps(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_timestamps(seq, count));
 
-        public static bool tsequence_value_at_timestamptz(IntPtr seq, int t, bool strict, IntPtr result)
+        public static bool tsequence_value_at_timestamptz(IntPtr seq, long t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_value_at_timestamptz(seq, t, strict, result));
 
         public static IntPtr tsequence_values_p(IntPtr seq, IntPtr count)
@@ -6914,11 +7108,11 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_duration(IntPtr ss, bool boundspan)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_duration(ss, boundspan));
 
-        public static int tsequenceset_end_timestamptz(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_end_timestamptz(ss));
+        public static long tsequenceset_end_timestamptz(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tsequenceset_end_timestamptz(ss));
 
-        public static int tsequenceset_hash(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_hash(ss));
+        public static uint tsequenceset_hash(IntPtr ss)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.tsequenceset_hash(ss));
 
         public static IntPtr tsequenceset_inst_n(IntPtr ss, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_inst_n(ss, n));
@@ -6936,14 +7130,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_max_inst_p(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_max_inst_p(ss));
 
-        public static int tsequenceset_max_val(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_max_val(ss));
+        public static ulong tsequenceset_max_val(IntPtr ss)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequenceset_max_val(ss));
 
         public static IntPtr tsequenceset_min_inst_p(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_min_inst_p(ss));
 
-        public static int tsequenceset_min_val(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_min_val(ss));
+        public static ulong tsequenceset_min_val(IntPtr ss)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequenceset_min_val(ss));
 
         public static int tsequenceset_num_instants(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_num_instants(ss));
@@ -6964,8 +7158,8 @@ namespace MEOS.NET.Internal
             return _out;
         }
 
-        public static int tsequenceset_start_timestamptz(IntPtr ss)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_start_timestamptz(ss));
+        public static long tsequenceset_start_timestamptz(IntPtr ss)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tsequenceset_start_timestamptz(ss));
 
         public static IntPtr tsequenceset_time(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_time(ss));
@@ -6976,7 +7170,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_timestamps(IntPtr ss, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_timestamps(ss, count));
 
-        public static bool tsequenceset_value_at_timestamptz(IntPtr ss, int t, bool strict, IntPtr result)
+        public static bool tsequenceset_value_at_timestamptz(IntPtr ss, long t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_value_at_timestamptz(ss, t, strict, result));
 
         public static bool tsequenceset_value_n(IntPtr ss, int n, IntPtr result)
@@ -7006,16 +7200,16 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_to_tsequenceset(IntPtr inst, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_to_tsequenceset(inst, interp));
 
-        public static IntPtr tnumber_shift_scale_value(IntPtr temp, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr tnumber_shift_scale_value(IntPtr temp, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_shift_scale_value(temp, shift, width, hasshift, haswidth));
 
-        public static IntPtr tnumberinst_shift_value(IntPtr inst, IntPtr shift)
+        public static IntPtr tnumberinst_shift_value(IntPtr inst, ulong shift)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberinst_shift_value(inst, shift));
 
-        public static IntPtr tnumberseq_shift_scale_value(IntPtr seq, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr tnumberseq_shift_scale_value(IntPtr seq, ulong shift, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_shift_scale_value(seq, shift, width, hasshift, haswidth));
 
-        public static IntPtr tnumberseqset_shift_scale_value(IntPtr ss, IntPtr start, IntPtr width, bool hasshift, bool haswidth)
+        public static IntPtr tnumberseqset_shift_scale_value(IntPtr ss, ulong start, ulong width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_shift_scale_value(ss, start, width, hasshift, haswidth));
 
         public static void tsequence_restart(IntPtr seq, int count)
@@ -7078,7 +7272,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_append_tsequence(IntPtr seq1, IntPtr seq2, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_append_tsequence(seq1, seq2, expand));
 
-        public static IntPtr tsequence_delete_timestamptz(IntPtr seq, int t, bool connect)
+        public static IntPtr tsequence_delete_timestamptz(IntPtr seq, long t, bool connect)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_delete_timestamptz(seq, t, connect));
 
         public static IntPtr tsequence_delete_tstzset(IntPtr seq, IntPtr s, bool connect)
@@ -7105,7 +7299,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_append_tsequence(IntPtr ss, IntPtr seq, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_append_tsequence(ss, seq, expand));
 
-        public static IntPtr tsequenceset_delete_timestamptz(IntPtr ss, int t)
+        public static IntPtr tsequenceset_delete_timestamptz(IntPtr ss, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_delete_timestamptz(ss, t));
 
         public static IntPtr tsequenceset_delete_tstzset(IntPtr ss, IntPtr s)
@@ -7138,19 +7332,19 @@ namespace MEOS.NET.Internal
         public static void tsequenceset_set_bbox(IntPtr ss, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tsequenceset_set_bbox(ss, box));
 
-        public static IntPtr tcontseq_after_timestamptz(IntPtr seq, int t, bool strict)
+        public static IntPtr tcontseq_after_timestamptz(IntPtr seq, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_after_timestamptz(seq, t, strict));
 
-        public static IntPtr tcontseq_before_timestamptz(IntPtr seq, int t, bool strict)
+        public static IntPtr tcontseq_before_timestamptz(IntPtr seq, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_before_timestamptz(seq, t, strict));
 
         public static IntPtr tcontseq_restrict_minmax(IntPtr seq, bool min, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_minmax(seq, min, atfunc));
 
-        public static IntPtr tdiscseq_after_timestamptz(IntPtr seq, int t, bool strict)
+        public static IntPtr tdiscseq_after_timestamptz(IntPtr seq, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_after_timestamptz(seq, t, strict));
 
-        public static IntPtr tdiscseq_before_timestamptz(IntPtr seq, int t, bool strict)
+        public static IntPtr tdiscseq_before_timestamptz(IntPtr seq, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_before_timestamptz(seq, t, strict));
 
         public static IntPtr tdiscseq_restrict_minmax(IntPtr seq, bool min, bool atfunc)
@@ -7162,7 +7356,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_restrict_minmax(IntPtr temp, bool min, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_minmax(temp, min, atfunc));
 
-        public static IntPtr temporal_restrict_timestamptz(IntPtr temp, int t, bool atfunc)
+        public static IntPtr temporal_restrict_timestamptz(IntPtr temp, long t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_timestamptz(temp, t, atfunc));
 
         public static IntPtr temporal_restrict_tstzset(IntPtr temp, IntPtr s, bool atfunc)
@@ -7174,19 +7368,19 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_restrict_tstzspanset(IntPtr temp, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_tstzspanset(temp, ss, atfunc));
 
-        public static IntPtr temporal_restrict_value(IntPtr temp, IntPtr value, bool atfunc)
+        public static IntPtr temporal_restrict_value(IntPtr temp, ulong value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_value(temp, value, atfunc));
 
         public static IntPtr temporal_restrict_values(IntPtr temp, IntPtr set, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_values(temp, set, atfunc));
 
-        public static bool temporal_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr result)
+        public static bool temporal_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_value_at_timestamptz(temp, t, strict, result));
 
-        public static IntPtr tinstant_after_timestamptz(IntPtr inst, int t, bool strict)
+        public static IntPtr tinstant_after_timestamptz(IntPtr inst, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_after_timestamptz(inst, t, strict));
 
-        public static IntPtr tinstant_before_timestamptz(IntPtr inst, int t, bool strict)
+        public static IntPtr tinstant_before_timestamptz(IntPtr inst, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_before_timestamptz(inst, t, strict));
 
         public static IntPtr tinstant_restrict_tstzspan(IntPtr inst, IntPtr period, bool atfunc)
@@ -7195,13 +7389,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_restrict_tstzspanset(IntPtr inst, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_tstzspanset(inst, ss, atfunc));
 
-        public static IntPtr tinstant_restrict_timestamptz(IntPtr inst, int t, bool atfunc)
+        public static IntPtr tinstant_restrict_timestamptz(IntPtr inst, long t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_timestamptz(inst, t, atfunc));
 
         public static IntPtr tinstant_restrict_tstzset(IntPtr inst, IntPtr s, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_tstzset(inst, s, atfunc));
 
-        public static IntPtr tinstant_restrict_value(IntPtr inst, IntPtr value, bool atfunc)
+        public static IntPtr tinstant_restrict_value(IntPtr inst, ulong value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_value(inst, value, atfunc));
 
         public static IntPtr tinstant_restrict_values(IntPtr inst, IntPtr set, bool atfunc)
@@ -7225,7 +7419,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tnumberseqset_restrict_spanset(IntPtr ss, IntPtr spanset, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_restrict_spanset(ss, spanset, atfunc));
 
-        public static IntPtr tsequence_at_timestamptz(IntPtr seq, int t)
+        public static IntPtr tsequence_at_timestamptz(IntPtr seq, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_at_timestamptz(seq, t));
 
         public static IntPtr tsequence_restrict_tstzspan(IntPtr seq, IntPtr s, bool atfunc)
@@ -7234,10 +7428,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_restrict_tstzspanset(seq, ss, atfunc));
 
-        public static IntPtr tsequenceset_after_timestamptz(IntPtr ss, int t, bool strict)
+        public static IntPtr tsequenceset_after_timestamptz(IntPtr ss, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_after_timestamptz(ss, t, strict));
 
-        public static IntPtr tsequenceset_before_timestamptz(IntPtr ss, int t, bool strict)
+        public static IntPtr tsequenceset_before_timestamptz(IntPtr ss, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_before_timestamptz(ss, t, strict));
 
         public static IntPtr tsequenceset_restrict_minmax(IntPtr ss, bool min, bool atfunc)
@@ -7249,13 +7443,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_restrict_tstzspanset(IntPtr ss, IntPtr ps, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_tstzspanset(ss, ps, atfunc));
 
-        public static IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, int t, bool atfunc)
+        public static IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, long t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_timestamptz(ss, t, atfunc));
 
         public static IntPtr tsequenceset_restrict_tstzset(IntPtr ss, IntPtr s, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_tstzset(ss, s, atfunc));
 
-        public static IntPtr tsequenceset_restrict_value(IntPtr ss, IntPtr value, bool atfunc)
+        public static IntPtr tsequenceset_restrict_value(IntPtr ss, ulong value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_value(ss, value, atfunc));
 
         public static IntPtr tsequenceset_restrict_values(IntPtr ss, IntPtr s, bool atfunc)
@@ -7279,76 +7473,76 @@ namespace MEOS.NET.Internal
         public static bool tsequenceset_eq(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_eq(ss1, ss2));
 
-        public static int always_eq_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_eq_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_base_temporal(value, temp));
 
-        public static int always_eq_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_eq_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_temporal_base(temp, value));
 
-        public static int always_ne_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_ne_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_base_temporal(value, temp));
 
-        public static int always_ne_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_ne_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_temporal_base(temp, value));
 
-        public static int always_ge_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_ge_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ge_base_temporal(value, temp));
 
-        public static int always_ge_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_ge_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ge_temporal_base(temp, value));
 
-        public static int always_gt_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_gt_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_gt_base_temporal(value, temp));
 
-        public static int always_gt_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_gt_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_gt_temporal_base(temp, value));
 
-        public static int always_le_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_le_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_le_base_temporal(value, temp));
 
-        public static int always_le_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_le_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_le_temporal_base(temp, value));
 
-        public static int always_lt_base_temporal(IntPtr value, IntPtr temp)
+        public static int always_lt_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_lt_base_temporal(value, temp));
 
-        public static int always_lt_temporal_base(IntPtr temp, IntPtr value)
+        public static int always_lt_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_lt_temporal_base(temp, value));
 
-        public static int ever_eq_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_eq_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_base_temporal(value, temp));
 
-        public static int ever_eq_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_eq_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_temporal_base(temp, value));
 
-        public static int ever_ne_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_ne_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_base_temporal(value, temp));
 
-        public static int ever_ne_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_ne_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_temporal_base(temp, value));
 
-        public static int ever_ge_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_ge_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ge_base_temporal(value, temp));
 
-        public static int ever_ge_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_ge_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ge_temporal_base(temp, value));
 
-        public static int ever_gt_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_gt_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_gt_base_temporal(value, temp));
 
-        public static int ever_gt_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_gt_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_gt_temporal_base(temp, value));
 
-        public static int ever_le_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_le_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_le_base_temporal(value, temp));
 
-        public static int ever_le_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_le_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_le_temporal_base(temp, value));
 
-        public static int ever_lt_base_temporal(IntPtr value, IntPtr temp)
+        public static int ever_lt_base_temporal(ulong value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_lt_base_temporal(value, temp));
 
-        public static int ever_lt_temporal_base(IntPtr temp, IntPtr value)
+        public static int ever_lt_temporal_base(IntPtr temp, ulong value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_lt_temporal_base(temp, value));
 
         public static IntPtr tnumberinst_abs(IntPtr inst)
@@ -7372,13 +7566,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tnumberseqset_delta_value(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_delta_value(ss));
 
-        public static IntPtr tdistance_tnumber_number(IntPtr temp, IntPtr value)
+        public static IntPtr tdistance_tnumber_number(IntPtr temp, ulong value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tnumber_number(temp, value));
 
         public static double nad_tbox_tbox(IntPtr box1, IntPtr box2)
             => SafeExecution<double>(() => MEOSExternalFunctions.nad_tbox_tbox(box1, box2));
 
-        public static double nad_tnumber_number(IntPtr temp, IntPtr value)
+        public static double nad_tnumber_number(IntPtr temp, ulong value)
             => SafeExecution<double>(() => MEOSExternalFunctions.nad_tnumber_number(temp, value));
 
         public static double nad_tnumber_tbox(IntPtr temp, IntPtr box)
@@ -7438,950 +7632,32 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_app_tseq_transfn(IntPtr state, IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_app_tseq_transfn(state, seq));
 
-        public static IntPtr span_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr count)
+        public static IntPtr span_bins(IntPtr s, ulong size, ulong origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_bins(s, size, origin, count));
 
-        public static IntPtr spanset_bins(IntPtr ss, IntPtr size, IntPtr origin, IntPtr count)
+        public static IntPtr spanset_bins(IntPtr ss, ulong size, ulong origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_bins(ss, size, origin, count));
 
-        public static IntPtr tnumber_value_bins(IntPtr temp, IntPtr size, IntPtr origin, IntPtr count)
+        public static IntPtr tnumber_value_bins(IntPtr temp, ulong size, ulong origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_bins(temp, size, origin, count));
 
-        public static IntPtr tnumber_value_time_boxes(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, IntPtr count)
+        public static IntPtr tnumber_value_time_boxes(IntPtr temp, ulong vsize, IntPtr duration, ulong vorigin, long torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static IntPtr tnumber_value_split(IntPtr temp, IntPtr vsize, IntPtr vorigin, IntPtr bins, IntPtr count)
+        public static IntPtr tnumber_value_split(IntPtr temp, ulong vsize, ulong vorigin, IntPtr bins, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_split(temp, vsize, vorigin, bins, count));
 
-        public static IntPtr tbox_get_value_time_tile(IntPtr value, int t, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, int basetype, int spantype)
+        public static IntPtr tbox_get_value_time_tile(ulong value, long t, ulong vsize, IntPtr duration, ulong vorigin, long torigin, int basetype, int spantype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_get_value_time_tile(value, t, vsize, duration, vorigin, torigin, basetype, spantype));
 
-        public static IntPtr tnumber_value_time_split(IntPtr temp, IntPtr size, IntPtr duration, IntPtr vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count)
+        public static IntPtr tnumber_value_time_split(IntPtr temp, ulong size, IntPtr duration, ulong vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_split(temp, size, duration, vorigin, torigin, value_bins, time_bins, count));
-
-        public static string double2_out(IntPtr d, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.double2_out(d, maxdd));
-
-        public static void double2_set(double a, double b, IntPtr result)
-            => SafeExecution(() => MEOSExternalFunctions.double2_set(a, b, result));
-
-        public static IntPtr double2_add(IntPtr d1, IntPtr d2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double2_add(d1, d2));
-
-        public static bool double2_eq(IntPtr d1, IntPtr d2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double2_eq(d1, d2));
-
-        public static string double3_out(IntPtr d, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.double3_out(d, maxdd));
-
-        public static void double3_set(double a, double b, double c, IntPtr result)
-            => SafeExecution(() => MEOSExternalFunctions.double3_set(a, b, c, result));
-
-        public static IntPtr double3_add(IntPtr d1, IntPtr d2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double3_add(d1, d2));
-
-        public static bool double3_eq(IntPtr d1, IntPtr d2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double3_eq(d1, d2));
-
-        public static string double4_out(IntPtr d, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.double4_out(d, maxdd));
-
-        public static void double4_set(double a, double b, double c, double d, IntPtr result)
-            => SafeExecution(() => MEOSExternalFunctions.double4_set(a, b, c, d, result));
-
-        public static IntPtr double4_add(IntPtr d1, IntPtr d2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double4_add(d1, d2));
-
-        public static bool double4_eq(IntPtr d1, IntPtr d2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double4_eq(d1, d2));
-
-        public static bool double2_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double2_collinear(x1, x2, x3, ratio));
-
-        public static bool double3_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double3_collinear(x1, x2, x3, ratio));
-
-        public static bool double4_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double4_collinear(x1, x2, x3, ratio));
-
-        public static IntPtr double2segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double2segm_interpolate(start, end, ratio));
-
-        public static IntPtr double3segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double3segm_interpolate(start, end, ratio));
-
-        public static IntPtr double4segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double4segm_interpolate(start, end, ratio));
-
-        public static int pg_atoi(string s, int size, int c)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_atoi(s, size, c));
-
-        public static bool ensure_has_X(int type, short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_X(type, flags));
-
-        public static bool ensure_has_Z(int type, short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_Z(type, flags));
-
-        public static bool ensure_has_T(int type, short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_T(type, flags));
-
-        public static bool ensure_has_not_Z(int type, short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_Z(type, flags));
-
-        public static bool ensure_not_null(IntPtr ptr)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_null(ptr));
-
-        public static bool ensure_one_not_null(IntPtr ptr1, IntPtr ptr2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_one_not_null(ptr1, ptr2));
-
-        public static bool ensure_one_true(bool hasshift, bool haswidth)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_one_true(hasshift, haswidth));
-
-        public static bool ensure_valid_interp(int temptype, int interp)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_interp(temptype, interp));
-
-        public static bool ensure_continuous(IntPtr temp)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_continuous(temp));
-
-        public static bool ensure_same_interp(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_interp(temp1, temp2));
-
-        public static bool ensure_same_continuous_interp(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_continuous_interp(flags1, flags2));
-
-        public static bool ensure_linear_interp(short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_linear_interp(flags));
-
-        public static bool ensure_nonlinear_interp(short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_nonlinear_interp(flags));
-
-        public static bool ensure_common_dimension(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_common_dimension(flags1, flags2));
-
-        public static bool ensure_temporal_isof_type(IntPtr temp, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_type(temp, type));
-
-        public static bool ensure_temporal_isof_basetype(IntPtr temp, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_basetype(temp, basetype));
-
-        public static bool ensure_temporal_isof_subtype(IntPtr temp, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_subtype(temp, type));
-
-        public static bool ensure_same_temporal_type(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_temporal_type(temp1, temp2));
-
-        public static bool ensure_valid_tnumber_numspan(IntPtr temp, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_numspan(temp, s));
-
-        public static bool ensure_valid_tnumber_numspanset(IntPtr temp, IntPtr ss)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_numspanset(temp, ss));
-
-        public static bool ensure_valid_tnumber_tbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_tbox(temp, box));
-
-        public static bool ensure_valid_temporal_set(IntPtr temp, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_temporal_set(temp, s));
-
-        public static bool ensure_valid_temporal_temporal(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_temporal_temporal(temp1, temp2));
-
-        public static bool ensure_valid_tnumber_tnumber(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_tnumber(temp1, temp2));
-
-        public static bool ensure_not_negative(int i)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_negative(i));
-
-        public static bool ensure_positive(int i)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive(i));
-
-        public static bool not_negative_datum(IntPtr size, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.not_negative_datum(size, basetype));
-
-        public static bool ensure_not_negative_datum(IntPtr size, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_negative_datum(size, basetype));
-
-        public static bool positive_datum(IntPtr size, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.positive_datum(size, basetype));
-
-        public static bool ensure_positive_datum(IntPtr size, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive_datum(size, basetype));
-
-        public static bool ensure_valid_day_duration(IntPtr duration)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_day_duration(duration));
-
-        public static bool positive_duration(IntPtr duration)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.positive_duration(duration));
-
-        public static bool ensure_positive_duration(IntPtr duration)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive_duration(duration));
-
-        public static IntPtr temporal_bbox_ptr(IntPtr temp)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_bbox_ptr(temp));
-
-        public static bool intersection_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr mode, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_temporal_temporal(temp1, temp2, mode, inter1, inter2));
-
-        public static string mobilitydb_version()
-            => SafeExecution<string>(() => MEOSExternalFunctions.mobilitydb_version());
-
-        public static string mobilitydb_full_version()
-            => SafeExecution<string>(() => MEOSExternalFunctions.mobilitydb_full_version());
-
-        public static IntPtr round_fn(int basetype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.round_fn(basetype));
-
-        public static bool temporal_bbox_restrict_value(IntPtr temp, IntPtr value)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_bbox_restrict_value(temp, value));
-
-        public static bool ensure_valid_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_cbuffer(temp, cb));
-
-        public static bool ensure_valid_tcbuffer_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_geo(temp, gs));
-
-        public static bool ensure_valid_tcbuffer_stbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_stbox(temp, box));
-
-        public static bool ensure_valid_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_tcbuffer(temp1, temp2));
-
-        public static int tcbuffersegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_intersection_value(start, end, value, lower, upper, t1, t2));
-
-        public static int tcbuffersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static int tcbuffersegm_dwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_dwithin_turnpt(start1, end1, start2, end2, dist, lower, upper, t1, t2));
-
-        public static int tcbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_distance_turnpt(start1, end1, start2, end2, dist, lower, upper, t1, t2));
-
-        public static bool cbuffer_set_stbox(IntPtr cb, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_set_stbox(cb, box));
-
-        public static void cbufferarr_set_stbox(IntPtr values, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.cbufferarr_set_stbox(values, count, box));
-
-        public static bool cbuffer_timestamptz_set_stbox(IntPtr cb, int t, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_timestamptz_set_stbox(cb, t, box));
-
-        public static bool cbuffer_tstzspan_set_stbox(IntPtr cb, IntPtr s, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_tstzspan_set_stbox(cb, s, box));
-
-        public static void tcbufferinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tcbufferinst_set_stbox(inst, box));
-
-        public static void tcbufferinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tcbufferinstarr_set_stbox(instants, count, box));
-
-        public static void tcbufferseq_expand_stbox(IntPtr seq, IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.tcbufferseq_expand_stbox(seq, inst));
-
-        public static IntPtr tcbufferinst_trav_area(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferinst_trav_area(inst));
-
-        public static IntPtr tcbufferseq_trav_area(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferseq_trav_area(seq));
-
-        public static IntPtr tcbufferseqset_trav_area(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferseqset_trav_area(ss));
-
-        public static IntPtr tcbuffersegm_trav_area(IntPtr inst1, IntPtr inst2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffersegm_trav_area(inst1, inst2));
-
-        public static IntPtr tcbuffer_restrict_cbuffer(IntPtr temp, IntPtr cb, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_cbuffer(temp, cb, atfunc));
-
-        public static IntPtr tcbuffer_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_stbox(temp, box, border_inc, atfunc));
-
-        public static IntPtr tcbuffer_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_geom(temp, gs, atfunc));
-
-        public static int ea_contains_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_tcbuffer(gs, temp, ever));
-
-        public static int ea_contains_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tcbuffer_geo(temp, gs, ever));
-
-        public static int ea_contains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tcbuffer_cbuffer(temp, cb, ever));
-
-        public static int ea_contains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_cbuffer_tcbuffer(cb, temp, ever));
-
-        public static int ea_covers_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_tcbuffer(gs, temp, ever));
-
-        public static int ea_covers_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_geo(temp, gs, ever));
-
-        public static int ea_covers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_cbuffer(temp, cb, ever));
-
-        public static int ea_covers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_cbuffer_tcbuffer(cb, temp, ever));
-
-        public static int ea_covers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_tcbuffer(temp1, temp2, ever));
-
-        public static int ea_disjoint_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_geo(temp, gs, ever));
-
-        public static int ea_disjoint_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_geo_tcbuffer(gs, temp, ever));
-
-        public static int ea_disjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_cbuffer(temp, cb, ever));
-
-        public static int ea_disjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_cbuffer_tcbuffer(cb, temp, ever));
-
-        public static int ea_disjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, ever));
-
-        public static int ea_intersects_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_geo(temp, gs, ever));
-
-        public static int ea_intersects_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_geo_tcbuffer(gs, temp, ever));
-
-        public static int ea_intersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_cbuffer(temp, cb, ever));
-
-        public static int ea_intersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_cbuffer_tcbuffer(cb, temp, ever));
-
-        public static int ea_intersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_tcbuffer(temp1, temp2, ever));
-
-        public static int ea_touches_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_geo(temp, gs, ever));
-
-        public static int ea_touches_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_geo_tcbuffer(gs, temp, ever));
-
-        public static int ea_touches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_cbuffer(temp, cb, ever));
-
-        public static int ea_touches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_cbuffer_tcbuffer(cb, temp, ever));
-
-        public static int ea_touches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_tcbuffer(temp1, temp2, ever));
-
-        public static IntPtr tinterrel_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool tinter)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tcbuffer_cbuffer(temp, cb, tinter));
-
-        public static IntPtr tinterrel_tcbuffer_geo(IntPtr temp, IntPtr gs, bool tinter)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tcbuffer_geo(temp, gs, tinter));
-
-        public static int lwproj_lookup(int srid_from, int srid_to, IntPtr pj)
-            => SafeExecution<int>(() => MEOSExternalFunctions.lwproj_lookup(srid_from, srid_to, pj));
-
-        public static int spheroid_init_from_srid(int srid, IntPtr s)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spheroid_init_from_srid(srid, s));
-
-        public static void srid_check_latlong(int srid)
-            => SafeExecution(() => MEOSExternalFunctions.srid_check_latlong(srid));
-
-        public static int srid_is_latlong(int srid)
-            => SafeExecution<int>(() => MEOSExternalFunctions.srid_is_latlong(srid));
-
-        public static IntPtr geom_serialize(IntPtr lwgeom)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geom_serialize(lwgeom));
-
-        public static IntPtr geog_serialize(IntPtr lwgeom)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geog_serialize(lwgeom));
-
-        public static IntPtr postgis_valid_typmod(IntPtr gs, int typmod)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.postgis_valid_typmod(gs, typmod));
-
-        public static string geo_as_wkt(IntPtr gs, int precision, bool extended)
-            => SafeExecution<string>(() => MEOSExternalFunctions.geo_as_wkt(gs, precision, extended));
-
-        public static IntPtr box2d_to_lwgeom(IntPtr box, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.box2d_to_lwgeom(box, srid));
-
-        public static IntPtr box3d_to_lwgeom(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.box3d_to_lwgeom(box));
-
-        public static IntPtr POSTGIS2GEOS(IntPtr pglwgeom)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.POSTGIS2GEOS(pglwgeom));
-
-        public static IntPtr GEOS2POSTGIS(IntPtr geom, byte want3d)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.GEOS2POSTGIS(geom, want3d));
-
-        public static bool geom_spatialrel(IntPtr gs1, IntPtr gs2, IntPtr rel)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geom_spatialrel(gs1, gs2, rel));
-
-        public static IntPtr lwgeom_line_interpolate_point(IntPtr geom, double fraction, int srid, byte repeat)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwgeom_line_interpolate_point(geom, fraction, srid, repeat));
-
-        public static void point_get_coords(IntPtr point, bool hasz, IntPtr x, IntPtr y, IntPtr z)
-            => SafeExecution(() => MEOSExternalFunctions.point_get_coords(point, hasz, x, y, z));
-
-        public static void tstzset_stbox_slice(IntPtr tsdatum, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tstzset_stbox_slice(tsdatum, box));
-
-        public static void tstzspanset_stbox_slice(IntPtr psdatum, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tstzspanset_stbox_slice(psdatum, box));
-
-        public static bool stbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_index_leaf_consistent(key, query, strategy));
-
-        public static bool stbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_gist_inner_consistent(key, query, strategy));
-
-        public static bool stbox_index_recheck(int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_index_recheck(strategy));
-
-        public static void mobilitydb_init()
-            => SafeExecution(() => MEOSExternalFunctions.mobilitydb_init());
-
-        public static IntPtr geo_stbox(IntPtr gs)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_stbox(gs));
-
-        public static IntPtr stbox_geo(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_geo(box));
-
-        public static IntPtr tcomp_geo_tgeo(IntPtr gs, IntPtr temp, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_geo_tgeo(gs, temp, func));
-
-        public static IntPtr tcomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_tgeo_geo(temp, gs, func));
-
-        public static bool ensure_geoaggstate(IntPtr state, int srid, bool hasz)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoaggstate(state, srid, hasz));
-
-        public static bool ensure_geoaggstate_state(IntPtr state1, IntPtr state2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoaggstate_state(state1, state2));
-
-        public static IntPtr tpoint_transform_tcentroid(IntPtr temp, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_transform_tcentroid(temp, count));
-
-        public static IntPtr tpointinst_tcentroid_finalfn(IntPtr instants, int count, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointinst_tcentroid_finalfn(instants, count, srid));
-
-        public static IntPtr tpointseq_tcentroid_finalfn(IntPtr sequences, int count, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_tcentroid_finalfn(sequences, count, srid));
-
-        public static bool point3d_min_dist(IntPtr p1, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr fraction)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.point3d_min_dist(p1, p2, p3, p4, fraction));
-
-        public static int tgeompointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tgeompointsegm_distance_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
-
-        public static int tgeogpointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tgeogpointsegm_distance_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
-
-        public static double tnumberinst_distance(IntPtr inst1, IntPtr inst2)
-            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberinst_distance(inst1, inst2));
-
-        public static double tinstant_distance(IntPtr inst1, IntPtr inst2, IntPtr func)
-            => SafeExecution<double>(() => MEOSExternalFunctions.tinstant_distance(inst1, inst2, func));
-
-        public static IntPtr tpointseq_at_geom(IntPtr seq, IntPtr gs, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_at_geom(seq, gs, count));
-
-        public static IntPtr tpointseq_interperiods(IntPtr seq, IntPtr gs, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_interperiods(seq, gs, count));
-
-        public static void datum_point4d(IntPtr value, IntPtr p)
-            => SafeExecution(() => MEOSExternalFunctions.datum_point4d(value, p));
-
-        public static int geopoint_cmp(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.geopoint_cmp(gs1, gs2));
-
-        public static bool geopoint_eq(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_eq(gs1, gs2));
-
-        public static bool geopoint_same(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_same(gs1, gs2));
-
-        public static bool datum_point_eq(IntPtr point1, IntPtr point2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_point_eq(point1, point2));
-
-        public static bool datum_point_same(IntPtr point1, IntPtr point2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_point_same(point1, point2));
-
-        public static int datum2_point_eq(IntPtr point1, IntPtr point2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_eq(point1, point2));
-
-        public static int datum2_point_ne(IntPtr point1, IntPtr point2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_ne(point1, point2));
-
-        public static int datum2_point_same(IntPtr point1, IntPtr point2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_same(point1, point2));
-
-        public static int datum2_point_nsame(IntPtr point1, IntPtr point2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_nsame(point1, point2));
-
-        public static int datum2_geom_centroid(IntPtr geo)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_geom_centroid(geo));
-
-        public static int datum2_geog_centroid(IntPtr geo)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_geog_centroid(geo));
-
-        public static IntPtr geo_extract_elements(IntPtr gs, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_extract_elements(gs, count));
-
-        public static IntPtr geo_serialize(IntPtr geom)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_serialize(geom));
-
-        public static IntPtr geo_distance_fn(short flags)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_distance_fn(flags));
-
-        public static IntPtr pt_distance_fn(short flags)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pt_distance_fn(flags));
-
-        public static int datum_geom_distance2d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_distance2d(geom1, geom2));
-
-        public static int datum_geom_distance3d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_distance3d(geom1, geom2));
-
-        public static int datum_geog_distance(IntPtr geog1, IntPtr geog2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_distance(geog1, geog2));
-
-        public static int datum_pt_distance2d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pt_distance2d(geom1, geom2));
-
-        public static int datum_pt_distance3d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pt_distance3d(geom1, geom2));
-
-        public static short spatial_flags(IntPtr d, int basetype)
-            => SafeExecution<short>(() => MEOSExternalFunctions.spatial_flags(d, basetype));
-
-        public static bool ensure_srid_is_latlong(int srid)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_srid_is_latlong(srid));
-
-        public static bool ensure_spatial_validity(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatial_validity(temp1, temp2));
-
-        public static bool ensure_not_geodetic(short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_geodetic(flags));
-
-        public static bool ensure_same_geodetic(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic(flags1, flags2));
-
-        public static bool ensure_same_geodetic_geo(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_geo(gs1, gs2));
-
-        public static bool ensure_same_geodetic_tspatial_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_tspatial_geo(temp, gs));
-
-        public static bool ensure_same_geodetic_tspatial_base(IntPtr temp, IntPtr @base)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_tspatial_base(temp, @base));
-
-        public static bool ensure_srid_known(int srid)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_srid_known(srid));
-
-        public static bool ensure_same_srid(int srid1, int srid2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_srid(srid1, srid2));
-
-        public static bool ensure_same_dimensionality(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality(flags1, flags2));
-
-        public static bool same_spatial_dimensionality(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_spatial_dimensionality(flags1, flags2));
-
-        public static bool ensure_same_spatial_dimensionality(short flags1, short flags2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spatial_dimensionality(flags1, flags2));
-
-        public static bool ensure_same_dimensionality_geo(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_geo(gs1, gs2));
-
-        public static bool same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_dimensionality_tspatial_geo(temp, gs));
-
-        public static bool ensure_same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_tspatial_geo(temp, gs));
-
-        public static bool ensure_same_spatial_dimensionality_stbox_geo(IntPtr box, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spatial_dimensionality_stbox_geo(box, gs));
-
-        public static bool ensure_same_geodetic_stbox_geo(IntPtr box, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_stbox_geo(box, gs));
-
-        public static bool ensure_has_Z_geo(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_Z_geo(gs));
-
-        public static bool ensure_has_not_Z_geo(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_Z_geo(gs));
-
-        public static bool ensure_has_M_geo(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_M_geo(gs));
-
-        public static bool ensure_has_not_M_geo(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_M_geo(gs));
-
-        public static bool ensure_not_geodetic_geo(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_geodetic_geo(gs));
-
-        public static bool ensure_point_type(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_point_type(gs));
-
-        public static bool ensure_mline_type(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_mline_type(gs));
-
-        public static bool circle_type(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.circle_type(gs));
-
-        public static bool ensure_circle_type(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_circle_type(gs));
-
-        public static bool ensure_not_empty(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_empty(gs));
-
-        public static bool ensure_valid_stbox_geo(IntPtr box, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_stbox_geo(box, gs));
-
-        public static bool ensure_valid_tspatial_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_geo(temp, gs));
-
-        public static bool ensure_valid_tspatial_base(IntPtr temp, IntPtr @base)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_base(temp, @base));
-
-        public static bool ensure_valid_tspatial_tspatial(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_tspatial(temp1, temp2));
-
-        public static bool ensure_valid_spatial_stbox_stbox(IntPtr box1, IntPtr box2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spatial_stbox_stbox(box1, box2));
-
-        public static bool ensure_valid_tgeo_stbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_stbox(temp, box));
-
-        public static bool ensure_valid_geo_geo(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_geo_geo(gs1, gs2));
-
-        public static bool ensure_valid_tgeo_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_geo(temp, gs));
-
-        public static bool ensure_valid_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_tgeo(temp1, temp2));
-
-        public static bool ensure_valid_tpoint_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpoint_geo(temp, gs));
-
-        public static bool ensure_valid_tpoint_tpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpoint_tpoint(temp1, temp2));
-
-        public static bool mline_type(IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.mline_type(gs));
-
-        public static IntPtr tpoint_get_coord(IntPtr temp, int coord)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_get_coord(temp, coord));
-
-        public static int eacomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_tgeo_geo(temp, gs, func, ever));
-
-        public static IntPtr closest_point2d_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point2d_on_segment_ratio(p, A, B, closest));
-
-        public static IntPtr closest_point3dz_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point3dz_on_segment_ratio(p, A, B, closest));
-
-        public static IntPtr closest_point_on_segment_sphere(IntPtr p, IntPtr A, IntPtr B, IntPtr closest, IntPtr dist)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point_on_segment_sphere(p, A, B, closest, dist));
-
-        public static void interpolate_point4d_spheroid(IntPtr p1, IntPtr p2, IntPtr p, IntPtr s, double f)
-            => SafeExecution(() => MEOSExternalFunctions.interpolate_point4d_spheroid(p1, p2, p, s, f));
-
-        public static IntPtr geopoint_make(double x, double y, double z, bool hasz, bool geodetic, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geopoint_make(x, y, z, hasz, geodetic, srid));
-
-        public static IntPtr lwcircle_make(double x, double y, double radius, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwcircle_make(x, y, radius, srid));
-
-        public static IntPtr geocircle_make(double x, double y, double radius, int srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geocircle_make(x, y, radius, srid));
-
-        public static int pointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pointsegm_interpolate(start, end, ratio));
-
-        public static IntPtr pointsegm_locate(IntPtr start, IntPtr end, IntPtr point, IntPtr dist)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pointsegm_locate(start, end, point, dist));
-
-        public static int tgeompointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tgeompointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static int tgeogpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tgeogpointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static bool geopoint_collinear(IntPtr value1, IntPtr value2, IntPtr value3, double ratio, bool hasz, bool geodetic)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_collinear(value1, value2, value3, ratio, hasz, geodetic));
-
-        public static IntPtr lwpointarr_remove_duplicates(IntPtr points, int count, IntPtr newcount)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwpointarr_remove_duplicates(points, count, newcount));
-
-        public static IntPtr lwpointarr_make_trajectory(IntPtr points, int count, int interp)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwpointarr_make_trajectory(points, count, interp));
-
-        public static IntPtr lwline_make(IntPtr value1, IntPtr value2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwline_make(value1, value2));
-
-        public static IntPtr lwcoll_from_points_lines(IntPtr points, IntPtr lines, int npoints, int nlines)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwcoll_from_points_lines(points, lines, npoints, nlines));
-
-        public static int tpointseq_stops_iter(IntPtr seq, double maxdist, int mintunits, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tpointseq_stops_iter(seq, maxdist, mintunits, result));
-
-        public static int datum_geom_contains(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_contains(geom1, geom2));
-
-        public static int datum_geom_covers(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_covers(geom1, geom2));
-
-        public static int datum_geom_disjoint2d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_disjoint2d(geom1, geom2));
-
-        public static int datum_geom_disjoint3d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_disjoint3d(geom1, geom2));
-
-        public static int datum_geog_disjoint(IntPtr geog1, IntPtr geog2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_disjoint(geog1, geog2));
-
-        public static int datum_geom_intersects2d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_intersects2d(geom1, geom2));
-
-        public static int datum_geom_intersects3d(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_intersects3d(geom1, geom2));
-
-        public static int datum_geog_intersects(IntPtr geog1, IntPtr geog2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_intersects(geog1, geog2));
-
-        public static int datum_geom_touches(IntPtr geom1, IntPtr geom2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_touches(geom1, geom2));
-
-        public static int datum_geom_dwithin2d(IntPtr geom1, IntPtr geom2, IntPtr dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_dwithin2d(geom1, geom2, dist));
-
-        public static int datum_geom_dwithin3d(IntPtr geom1, IntPtr geom2, IntPtr dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_dwithin3d(geom1, geom2, dist));
-
-        public static int datum_geog_dwithin(IntPtr geog1, IntPtr geog2, IntPtr dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_dwithin(geog1, geog2, dist));
-
-        public static int datum_geom_relate_pattern(IntPtr geog1, IntPtr geog2, IntPtr p)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_relate_pattern(geog1, geog2, p));
-
-        public static IntPtr geo_disjoint_fn(short flags1, short flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_disjoint_fn(flags1, flags2));
-
-        public static IntPtr geo_disjoint_fn_geo(short flags1, IntPtr flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_disjoint_fn_geo(flags1, flags2));
-
-        public static IntPtr geo_intersects_fn(short flags1, short flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_intersects_fn(flags1, flags2));
-
-        public static IntPtr geo_intersects_fn_geo(short flags1, IntPtr flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_intersects_fn_geo(flags1, flags2));
-
-        public static IntPtr geo_dwithin_fn(short flags1, short flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_dwithin_fn(flags1, flags2));
-
-        public static IntPtr geo_dwithin_fn_geo(short flags1, IntPtr flags2)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_dwithin_fn_geo(flags1, flags2));
-
-        public static int tpointsegm_tdwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tpointsegm_tdwithin_turnpt(start1, end1, start2, end2, value, lower, upper, t1, t2));
-
-        public static int spatialrel_geo_geo(IntPtr gs1, IntPtr gs2, IntPtr param, IntPtr func, int numparam, bool invert)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spatialrel_geo_geo(gs1, gs2, param, func, numparam, invert));
-
-        public static int spatialrel_tgeo_tgeo(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spatialrel_tgeo_tgeo(temp1, temp2, param, func, numparam));
-
-        public static int ea_contains_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_tgeo(gs, temp, ever));
-
-        public static int ea_contains_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tgeo_geo(temp, gs, ever));
-
-        public static int ea_contains_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tgeo_tgeo(temp, temp2, ever));
-
-        public static int ea_covers_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_tgeo(gs, temp, ever));
-
-        public static int ea_covers_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tgeo_geo(temp, gs, ever));
-
-        public static int ea_covers_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tgeo_tgeo(temp, temp2, ever));
-
-        public static int ea_disjoint_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_geo_tgeo(gs, temp, ever));
-
-        public static int ea_disjoint_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tgeo_geo(temp, gs, ever));
-
-        public static int ea_disjoint_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tgeo_tgeo(temp, temp2, ever));
-
-        public static int ea_intersects_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_geo_tgeo(gs, temp, ever));
-
-        public static int ea_intersects_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tgeo_geo(temp, gs, ever));
-
-        public static int ea_intersects_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tgeo_tgeo(temp, temp2, ever));
-
-        public static int ea_touches_tpoint_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tpoint_geo(temp, gs, ever));
-
-        public static int ea_touches_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tgeo_geo(temp, gs, ever));
-
-        public static int ea_touches_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tgeo_tgeo(temp, temp2, ever));
-
-        public static int ea_dwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_dwithin_tgeo_geo(temp, gs, dist, ever));
-
-        public static int ea_dwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_dwithin_tgeo_tgeo(temp1, temp2, dist, ever));
-
-        public static int ea_spatialrel_tspatial_geo(IntPtr temp, IntPtr gs, IntPtr func, bool ever, bool invert)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_spatialrel_tspatial_geo(temp, gs, func, ever, invert));
-
-        public static int ea_spatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_spatialrel_tspatial_tspatial(temp1, temp2, func, ever));
-
-        public static IntPtr tspatialrel_tspatial_base(IntPtr temp, IntPtr @base, IntPtr param, IntPtr func, int numparam, bool invert)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialrel_tspatial_base(temp, @base, param, func, numparam, invert));
-
-        public static IntPtr tspatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam, bool invert)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialrel_tspatial_tspatial(temp1, temp2, param, func, numparam, invert));
-
-        public static IntPtr tinterrel_tgeo_geo(IntPtr temp, IntPtr gs, bool tinter)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tgeo_geo(temp, gs, tinter));
-
-        public static IntPtr tinterrel_tspatial_base(IntPtr temp, IntPtr @base, bool tinter, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tspatial_base(temp, @base, tinter, func));
-
-        public static IntPtr tinterrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, bool tinter)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tspatial_tspatial(temp1, temp2, tinter));
-
-        public static IntPtr tdwithin_tspatial_tspatial(IntPtr sync1, IntPtr sync2, IntPtr dist, IntPtr func, IntPtr tpfn)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tspatial_tspatial(sync1, sync2, dist, func, tpfn));
-
-        public static int tdwithin_add_solutions(int solutions, int lower, int upper, bool lower_inc, bool upper_inc, bool upper_inc1, int t1, int t2, IntPtr instants, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tdwithin_add_solutions(solutions, lower, upper, lower_inc, upper_inc, upper_inc1, t1, t2, instants, result));
-
-        public static IntPtr tdwithin_tspatial_spatial(IntPtr temp, IntPtr @base, IntPtr dist, IntPtr func, IntPtr tpfn)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tspatial_spatial(temp, @base, dist, func, tpfn));
-
-        public static IntPtr bitmatrix_make(IntPtr count, int ndims)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bitmatrix_make(count, ndims));
-
-        public static int tpoint_set_tiles(IntPtr temp, IntPtr state, IntPtr bm)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tpoint_set_tiles(temp, state, bm));
-
-        public static IntPtr tpoint_at_tile(IntPtr temp, IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_tile(temp, box));
-
-        public static void stbox_tile_state_set(double x, double y, double z, int t, double xsize, double ysize, double zsize, int tunits, bool hasx, bool hasz, bool hast, int srid, IntPtr result)
-            => SafeExecution(() => MEOSExternalFunctions.stbox_tile_state_set(x, y, z, t, xsize, ysize, zsize, tunits, hasx, hasz, hast, srid, result));
-
-        public static IntPtr stbox_tile_state_make(IntPtr temp, IntPtr box, double xsize, double ysize, double zsize, IntPtr duration, int sorigin, int torigin, bool border_inc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_tile_state_make(temp, box, xsize, ysize, zsize, duration, sorigin, torigin, border_inc));
-
-        public static void stbox_tile_state_next(IntPtr state)
-            => SafeExecution(() => MEOSExternalFunctions.stbox_tile_state_next(state));
-
-        public static bool stbox_tile_state_get(IntPtr state, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_tile_state_get(state, box));
-
-        public static IntPtr tgeo_space_time_tile_init(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc, IntPtr ntiles)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_time_tile_init(temp, xsize, ysize, zsize, duration, sorigin, torigin, bitmatrix, border_inc, ntiles));
-
-        public static IntPtr stbox_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool hasx, bool hast)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_time_tile(point, t, xsize, ysize, zsize, duration, sorigin, torigin, hasx, hast));
-
-        public static IntPtr create_trip(IntPtr lines, IntPtr maxSpeeds, IntPtr categories, uint noEdges, int startTime, bool disturbData, int verbosity)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.create_trip(lines, maxSpeeds, categories, noEdges, startTime, disturbData, verbosity));
-
-        public static IntPtr spatialarr_wkt_out(IntPtr spatialarr, int basetype, int count, int maxdd, bool extended)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spatialarr_wkt_out(spatialarr, basetype, count, maxdd, extended));
-
-        public static string spatialbase_as_text(IntPtr value, int type, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.spatialbase_as_text(value, type, maxdd));
-
-        public static string spatialbase_as_ewkt(IntPtr value, int type, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.spatialbase_as_ewkt(value, type, maxdd));
-
-        public static bool point_transf_pj(IntPtr gs, int srid_to, IntPtr pj)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.point_transf_pj(gs, srid_to, pj));
-
-        public static void tgeoinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tgeoinst_set_stbox(inst, box));
-
-        public static void tgeoinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tgeoinstarr_set_stbox(instants, count, box));
-
-        public static void tgeoseq_expand_stbox(IntPtr seq, IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.tgeoseq_expand_stbox(seq, inst));
-
-        public static void tspatialinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tspatialinst_set_stbox(inst, box));
-
-        public static void tspatialinstarr_set_stbox(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tspatialinstarr_set_stbox(instants, count, lower_inc, upper_inc, interp, box));
-
-        public static void tspatialseqarr_set_stbox(IntPtr sequences, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tspatialseqarr_set_stbox(sequences, count, box));
-
-        public static void tspatialseq_expand_stbox(IntPtr seq, IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.tspatialseq_expand_stbox(seq, inst));
-
-        public static void spatialarr_set_bbox(IntPtr values, int basetype, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.spatialarr_set_bbox(values, basetype, count, box));
-
-        public static bool boxop_tspatial_stbox(IntPtr temp, IntPtr box, IntPtr func, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tspatial_stbox(temp, box, func, invert));
-
-        public static bool boxop_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tspatial_tspatial(temp1, temp2, func));
-
-        public static bool srid_parse(IntPtr str, IntPtr srid)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.srid_parse(str, srid));
-
-        public static bool spatial_parse_elem(IntPtr str, int temptype, byte delim, IntPtr temp_srid, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_parse_elem(str, temptype, delim, temp_srid, result));
-
-        public static bool geo_parse(IntPtr str, int basetype, byte delim, IntPtr srid, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_parse(str, basetype, delim, srid, result));
-
-        public static IntPtr stbox_parse(IntPtr str)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_parse(str));
-
-        public static IntPtr tpoint_parse(IntPtr str, int temptype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_parse(str, temptype));
-
-        public static IntPtr tspatialinst_parse(IntPtr str, int temptype, bool end, IntPtr temp_srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialinst_parse(str, temptype, end, temp_srid));
-
-        public static IntPtr tspatialseq_disc_parse(IntPtr str, int temptype, IntPtr temp_srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseq_disc_parse(str, temptype, temp_srid));
-
-        public static IntPtr tspatialseq_cont_parse(IntPtr str, int temptype, int interp, bool end, IntPtr temp_srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseq_cont_parse(str, temptype, interp, end, temp_srid));
-
-        public static IntPtr tspatialseqset_parse(IntPtr str, int temptype, int interp, IntPtr temp_srid)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseqset_parse(str, temptype, interp, temp_srid));
-
-        public static IntPtr tspatial_parse(IntPtr str, int temptype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatial_parse(str, temptype));
 
         public static IntPtr proj_get_context()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.proj_get_context());
 
-        public static int datum_geo_round(IntPtr value, IntPtr size)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geo_round(value, size));
+        public static ulong datum_geo_round(ulong value, ulong size)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_geo_round(value, size));
 
         public static IntPtr point_round(IntPtr gs, int maxdd)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.point_round(gs, maxdd));
@@ -8398,7 +7674,7 @@ namespace MEOS.NET.Internal
         public static void geoarr_set_stbox(IntPtr values, int count, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.geoarr_set_stbox(values, count, box));
 
-        public static bool spatial_set_stbox(IntPtr d, int basetype, IntPtr box)
+        public static bool spatial_set_stbox(ulong d, int basetype, IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_set_stbox(d, basetype, box));
 
         public static void spatialset_set_stbox(IntPtr set, IntPtr box)
@@ -8424,6 +7700,9 @@ namespace MEOS.NET.Internal
 
         public static bool inter_stbox_stbox(IntPtr box1, IntPtr box2, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.inter_stbox_stbox(box1, box2, result));
+
+        public static IntPtr stbox_geo(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_geo(box));
 
         public static IntPtr tgeogpointinst_from_mfjson(IntPtr mfjson, int srid)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeogpointinst_from_mfjson(mfjson, srid));
@@ -8500,6 +7779,9 @@ namespace MEOS.NET.Internal
         public static void tspatial_set_stbox(IntPtr temp, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tspatial_set_stbox(temp, box));
 
+        public static void tgeoinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tgeoinst_set_stbox(inst, box));
+
         public static void tspatialseq_set_stbox(IntPtr seq, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tspatialseq_set_stbox(seq, box));
 
@@ -8533,10 +7815,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeoseqset_restrict_stbox(IntPtr ss, IntPtr box, bool border_inc, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_restrict_stbox(ss, box, border_inc, atfunc));
 
-        public static int spatial_srid(IntPtr d, int basetype)
+        public static int spatial_srid(ulong d, int basetype)
             => SafeExecution<int>(() => MEOSExternalFunctions.spatial_srid(d, basetype));
 
-        public static bool spatial_set_srid(IntPtr d, int basetype, int srid)
+        public static bool spatial_set_srid(ulong d, int basetype, int srid)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_set_srid(d, basetype, srid));
 
         public static int tspatialinst_srid(IntPtr inst)
@@ -8580,6 +7862,9 @@ namespace MEOS.NET.Internal
 
         public static IntPtr tgeoseqset_split_n_stboxes(IntPtr ss, int max_count, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_split_n_stboxes(ss, max_count, count));
+
+        public static IntPtr tpoint_get_coord(IntPtr temp, int coord)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_get_coord(temp, coord));
 
         public static IntPtr tgeominst_tgeoginst(IntPtr inst, bool oper)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeominst_tgeoginst(inst, oper));
@@ -8647,10 +7932,10 @@ namespace MEOS.NET.Internal
         public static string nsegment_out(IntPtr ns, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.nsegment_out(ns, maxdd));
 
-        public static IntPtr npoint_make(int rid, double pos)
+        public static IntPtr npoint_make(long rid, double pos)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_make(rid, pos));
 
-        public static IntPtr nsegment_make(int rid, double pos1, double pos2)
+        public static IntPtr nsegment_make(long rid, double pos1, double pos2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_make(rid, pos1, pos2));
 
         public static IntPtr geompoint_to_npoint(IntPtr gs)
@@ -8674,34 +7959,34 @@ namespace MEOS.NET.Internal
         public static IntPtr nsegment_to_stbox(IntPtr np)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_to_stbox(np));
 
-        public static int npoint_hash(IntPtr np)
-            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_hash(np));
+        public static uint npoint_hash(IntPtr np)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.npoint_hash(np));
 
-        public static int npoint_hash_extended(IntPtr np, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_hash_extended(np, seed));
+        public static ulong npoint_hash_extended(IntPtr np, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.npoint_hash_extended(np, seed));
 
         public static double npoint_position(IntPtr np)
             => SafeExecution<double>(() => MEOSExternalFunctions.npoint_position(np));
 
-        public static int npoint_route(IntPtr np)
-            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_route(np));
+        public static long npoint_route(IntPtr np)
+            => SafeExecution<long>(() => MEOSExternalFunctions.npoint_route(np));
 
         public static double nsegment_end_position(IntPtr ns)
             => SafeExecution<double>(() => MEOSExternalFunctions.nsegment_end_position(ns));
 
-        public static int nsegment_route(IntPtr ns)
-            => SafeExecution<int>(() => MEOSExternalFunctions.nsegment_route(ns));
+        public static long nsegment_route(IntPtr ns)
+            => SafeExecution<long>(() => MEOSExternalFunctions.nsegment_route(ns));
 
         public static double nsegment_start_position(IntPtr ns)
             => SafeExecution<double>(() => MEOSExternalFunctions.nsegment_start_position(ns));
 
-        public static bool route_exists(int rid)
+        public static bool route_exists(long rid)
             => SafeExecution<bool>(() => MEOSExternalFunctions.route_exists(rid));
 
-        public static IntPtr route_geom(int rid)
+        public static IntPtr route_geom(long rid)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.route_geom(rid));
 
-        public static double route_length(int rid)
+        public static double route_length(long rid)
             => SafeExecution<double>(() => MEOSExternalFunctions.route_length(rid));
 
         public static IntPtr npoint_round(IntPtr np, int maxdd)
@@ -8719,7 +8004,7 @@ namespace MEOS.NET.Internal
         public static int nsegment_srid(IntPtr ns)
             => SafeExecution<int>(() => MEOSExternalFunctions.nsegment_srid(ns));
 
-        public static IntPtr npoint_timestamptz_to_stbox(IntPtr np, int t)
+        public static IntPtr npoint_timestamptz_to_stbox(IntPtr np, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_timestamptz_to_stbox(np, t));
 
         public static IntPtr npoint_tstzspan_to_stbox(IntPtr np, IntPtr s)
@@ -8837,7 +8122,7 @@ namespace MEOS.NET.Internal
         public static string tnpoint_out(IntPtr temp, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.tnpoint_out(temp, maxdd));
 
-        public static IntPtr tnpointinst_make(IntPtr np, int t)
+        public static IntPtr tnpointinst_make(IntPtr np, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_make(np, t));
 
         public static IntPtr tgeompoint_to_tnpoint(IntPtr temp)
@@ -8855,8 +8140,8 @@ namespace MEOS.NET.Internal
         public static IntPtr tnpoint_positions(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_positions(temp, count));
 
-        public static int tnpoint_route(IntPtr temp)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnpoint_route(temp));
+        public static long tnpoint_route(IntPtr temp)
+            => SafeExecution<long>(() => MEOSExternalFunctions.tnpoint_route(temp));
 
         public static IntPtr tnpoint_routes(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_routes(temp));
@@ -9023,11 +8308,11 @@ namespace MEOS.NET.Internal
         public static IntPtr pose_to_stbox(IntPtr pose)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_to_stbox(pose));
 
-        public static int pose_hash(IntPtr pose)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pose_hash(pose));
+        public static uint pose_hash(IntPtr pose)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.pose_hash(pose));
 
-        public static int pose_hash_extended(IntPtr pose, int seed)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pose_hash_extended(pose, seed));
+        public static ulong pose_hash_extended(IntPtr pose, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.pose_hash_extended(pose, seed));
 
         public static IntPtr pose_orientation(IntPtr pose)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_orientation(pose));
@@ -9056,7 +8341,7 @@ namespace MEOS.NET.Internal
         public static IntPtr pose_tstzspan_to_stbox(IntPtr pose, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_tstzspan_to_stbox(pose, s));
 
-        public static IntPtr pose_timestamptz_to_stbox(IntPtr pose, int t)
+        public static IntPtr pose_timestamptz_to_stbox(IntPtr pose, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_timestamptz_to_stbox(pose, t));
 
         public static double distance_pose_geo(IntPtr pose, IntPtr gs)
@@ -9170,7 +8455,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tpose_trajectory(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_trajectory(temp));
 
-        public static bool tpose_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+        public static bool tpose_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tpose_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tpose_value_n(IntPtr temp, int n, IntPtr result)
@@ -9287,7 +8572,7 @@ namespace MEOS.NET.Internal
         public static string trgeo_out(IntPtr temp)
             => SafeExecution<string>(() => MEOSExternalFunctions.trgeo_out(temp));
 
-        public static IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, int t)
+        public static IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, long t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_make(geom, pose, t));
 
         public static IntPtr geo_tpose_to_trgeo(IntPtr gs, IntPtr temp)
@@ -9353,7 +8638,7 @@ namespace MEOS.NET.Internal
         public static IntPtr trgeo_append_tsequence(IntPtr temp, IntPtr seq, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_append_tsequence(temp, seq, expand));
 
-        public static IntPtr trgeo_delete_timestamptz(IntPtr temp, int t, bool connect)
+        public static IntPtr trgeo_delete_timestamptz(IntPtr temp, long t, bool connect)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_delete_timestamptz(temp, t, connect));
 
         public static IntPtr trgeo_delete_tstzset(IntPtr temp, IntPtr s, bool connect)
@@ -9374,19 +8659,19 @@ namespace MEOS.NET.Internal
         public static IntPtr trgeo_to_tinstant(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tinstant(temp));
 
-        public static IntPtr trgeo_after_timestamptz(IntPtr temp, int t, bool strict)
+        public static IntPtr trgeo_after_timestamptz(IntPtr temp, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_after_timestamptz(temp, t, strict));
 
-        public static IntPtr trgeo_before_timestamptz(IntPtr temp, int t, bool strict)
+        public static IntPtr trgeo_before_timestamptz(IntPtr temp, long t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_before_timestamptz(temp, t, strict));
 
-        public static IntPtr trgeo_restrict_value(IntPtr temp, IntPtr value, bool atfunc)
+        public static IntPtr trgeo_restrict_value(IntPtr temp, ulong value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_value(temp, value, atfunc));
 
         public static IntPtr trgeo_restrict_values(IntPtr temp, IntPtr s, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_values(temp, s, atfunc));
 
-        public static IntPtr trgeo_restrict_timestamptz(IntPtr temp, int t, bool atfunc)
+        public static IntPtr trgeo_restrict_timestamptz(IntPtr temp, long t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_timestamptz(temp, t, atfunc));
 
         public static IntPtr trgeo_restrict_tstzset(IntPtr temp, IntPtr s, bool atfunc)
@@ -9487,1419 +8772,6 @@ namespace MEOS.NET.Internal
 
         public static IntPtr tne_trgeo_geo(IntPtr temp, IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_trgeo_geo(temp, gs));
-
-        public static bool ensure_valid_tnpoint_npoint(IntPtr temp, IntPtr np)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_npoint(temp, np));
-
-        public static bool ensure_valid_tnpoint_npointset(IntPtr temp, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_npointset(temp, s));
-
-        public static bool ensure_valid_tnpoint_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_geo(temp, gs));
-
-        public static bool ensure_valid_tnpoint_stbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_stbox(temp, box));
-
-        public static bool ensure_valid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_tnpoint(temp1, temp2));
-
-        public static int tnpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnpointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static bool common_rid_tnpoint_npoint(IntPtr temp, IntPtr np)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_npoint(temp, np));
-
-        public static bool common_rid_tnpoint_npointset(IntPtr temp, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_npointset(temp, s));
-
-        public static bool common_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_tnpoint(temp1, temp2));
-
-        public static bool npoint_collinear(IntPtr np1, IntPtr np2, IntPtr np3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_collinear(np1, np2, np3, ratio));
-
-        public static IntPtr npointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointsegm_interpolate(start, end, ratio));
-
-        public static IntPtr npointsegm_locate(IntPtr start, IntPtr end, IntPtr value)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointsegm_locate(start, end, value));
-
-        public static IntPtr npointarr_geom(IntPtr points, int count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointarr_geom(points, count));
-
-        public static IntPtr nsegmentarr_geom(IntPtr segments, int count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegmentarr_geom(segments, count));
-
-        public static IntPtr nsegmentarr_normalize(IntPtr segments, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegmentarr_normalize(segments, count));
-
-        public static string npoint_wkt_out(IntPtr value, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.npoint_wkt_out(value, maxdd));
-
-        public static void npoint_set(int rid, double pos, IntPtr np)
-            => SafeExecution(() => MEOSExternalFunctions.npoint_set(rid, pos, np));
-
-        public static void nsegment_set(int rid, double pos1, double pos2, IntPtr ns)
-            => SafeExecution(() => MEOSExternalFunctions.nsegment_set(rid, pos1, pos2, ns));
-
-        public static int datum_npoint_round(IntPtr npoint, IntPtr size)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_npoint_round(npoint, size));
-
-        public static IntPtr tnpointinst_tgeompointinst(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_tgeompointinst(inst));
-
-        public static IntPtr tnpointseq_tgeompointseq_disc(IntPtr @is)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_tgeompointseq_disc(@is));
-
-        public static IntPtr tnpointseq_tgeompointseq_cont(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_tgeompointseq_cont(seq));
-
-        public static IntPtr tnpointseqset_tgeompointseqset(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_tgeompointseqset(ss));
-
-        public static IntPtr tgeompointinst_tnpointinst(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointinst_tnpointinst(inst));
-
-        public static IntPtr tgeompointseq_tnpointseq(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointseq_tnpointseq(seq));
-
-        public static IntPtr tgeompointseqset_tnpointseqset(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointseqset_tnpointseqset(ss));
-
-        public static IntPtr tnpointinst_positions(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_positions(inst));
-
-        public static IntPtr tnpointseq_positions(IntPtr seq, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_positions(seq, count));
-
-        public static IntPtr tnpointseqset_positions(IntPtr ss, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_positions(ss, count));
-
-        public static int tnpointinst_route(IntPtr inst)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnpointinst_route(inst));
-
-        public static IntPtr tnpointinst_routes(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_routes(inst));
-
-        public static IntPtr tnpointseq_disc_routes(IntPtr @is)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_disc_routes(@is));
-
-        public static IntPtr tnpointseq_cont_routes(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_cont_routes(seq));
-
-        public static IntPtr tnpointseqset_routes(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_routes(ss));
-
-        public static IntPtr tnpointseq_linear_positions(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_linear_positions(seq));
-
-        public static IntPtr tnpoint_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_stbox(temp, box, border_inc, atfunc));
-
-        public static IntPtr tnpoint_restrict_npoint(IntPtr temp, IntPtr np, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_npoint(temp, np, atfunc));
-
-        public static IntPtr tnpoint_restrict_npointset(IntPtr temp, IntPtr s, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_npointset(temp, s, atfunc));
-
-        public static bool npoint_set_stbox(IntPtr np, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_set_stbox(np, box));
-
-        public static void npointarr_set_stbox(IntPtr values, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.npointarr_set_stbox(values, count, box));
-
-        public static bool nsegment_set_stbox(IntPtr ns, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.nsegment_set_stbox(ns, box));
-
-        public static bool npoint_timestamptz_set_stbox(IntPtr np, int t, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_timestamptz_set_stbox(np, t, box));
-
-        public static bool npoint_tstzspan_set_stbox(IntPtr np, IntPtr s, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_tstzspan_set_stbox(np, s, box));
-
-        public static void tnpointinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tnpointinst_set_stbox(inst, box));
-
-        public static void tnpointinstarr_set_stbox(IntPtr inst, int count, int interp, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tnpointinstarr_set_stbox(inst, count, interp, box));
-
-        public static void tnpointseq_expand_stbox(IntPtr seq, IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.tnpointseq_expand_stbox(seq, inst));
-
-        public static int datum_npoint_distance(IntPtr np1, IntPtr np2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_npoint_distance(np1, np2));
-
-        public static IntPtr npoint_parse(IntPtr str, bool end)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_parse(str, end));
-
-        public static IntPtr nsegment_parse(IntPtr str)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_parse(str));
-
-        public static bool contains_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_bigint(temp, rid, invert));
-
-        public static bool contained_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_bigint(temp, rid, invert));
-
-        public static bool same_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_bigint(temp, rid, invert));
-
-        public static bool overlaps_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.overlaps_rid_tnpoint_bigintset(temp, s, invert));
-
-        public static bool contains_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_bigintset(temp, s, invert));
-
-        public static bool contained_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_bigintset(temp, s, invert));
-
-        public static bool same_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_bigintset(temp, s, invert));
-
-        public static bool contains_rid_tnpoint_npoint(IntPtr temp, IntPtr np, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_npoint(temp, np, invert));
-
-        public static bool contained_rid_npoint_tnpoint(IntPtr temp, IntPtr np, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_npoint_tnpoint(temp, np, invert));
-
-        public static bool same_rid_tnpoint_npoint(IntPtr temp, IntPtr np, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_npoint(temp, np, invert));
-
-        public static bool overlaps_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.overlaps_rid_tnpoint_tnpoint(temp1, temp2));
-
-        public static bool contains_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_tnpoint(temp1, temp2));
-
-        public static bool contained_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_tnpoint(temp1, temp2));
-
-        public static bool same_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_tnpoint(temp1, temp2));
-
-        public static bool ensure_same_rid_tnpointinst(IntPtr inst1, IntPtr inst2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_rid_tnpointinst(inst1, inst2));
-
-        public static IntPtr tnpoint_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_geom(temp, gs, atfunc));
-
-        public static bool ensure_valid_pose_geo(IntPtr pose, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_geo(pose, gs));
-
-        public static bool ensure_valid_pose_stbox(IntPtr pose, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_stbox(pose, box));
-
-        public static bool ensure_valid_pose_pose(IntPtr pose1, IntPtr pose2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_pose(pose1, pose2));
-
-        public static bool ensure_valid_poseset_pose(IntPtr s, IntPtr pose)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_poseset_pose(s, pose));
-
-        public static bool pose_collinear(IntPtr pose1, IntPtr pose2, IntPtr pose3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_collinear(pose1, pose2, pose3, ratio));
-
-        public static IntPtr posesegm_interpolate(IntPtr start, IntPtr end, double ratio)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.posesegm_interpolate(start, end, ratio));
-
-        public static IntPtr posesegm_locate(IntPtr start, IntPtr end, IntPtr value)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.posesegm_locate(start, end, value));
-
-        public static string pose_wkt_out(IntPtr pose, bool extended, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.pose_wkt_out(pose, extended, maxdd));
-
-        public static IntPtr pose_parse(IntPtr str, bool end)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_parse(str, end));
-
-        public static int datum_pose_point(IntPtr pose)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_point(pose));
-
-        public static int datum_pose_rotation(IntPtr pose)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_rotation(pose));
-
-        public static int datum_pose_round(IntPtr pose, IntPtr size)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_round(pose, size));
-
-        public static int pose_distance(IntPtr pose1, IntPtr pose2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pose_distance(pose1, pose2));
-
-        public static bool pose_set_stbox(IntPtr pose, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_set_stbox(pose, box));
-
-        public static void posearr_set_stbox(IntPtr values, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.posearr_set_stbox(values, count, box));
-
-        public static bool pose_timestamptz_set_stbox(IntPtr pose, int t, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_timestamptz_set_stbox(pose, t, box));
-
-        public static bool pose_tstzspan_set_stbox(IntPtr pose, IntPtr p, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_tstzspan_set_stbox(pose, p, box));
-
-        public static bool ensure_valid_tpose_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_geo(temp, gs));
-
-        public static bool ensure_valid_tpose_pose(IntPtr temp, IntPtr pose)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_pose(temp, pose));
-
-        public static bool ensure_valid_tpose_stbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_stbox(temp, box));
-
-        public static bool ensure_valid_tpose_tpose(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_tpose(temp1, temp2));
-
-        public static int tposesegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tposesegm_intersection_value(start, end, value, lower, upper, t1, t2));
-
-        public static int tposesegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tposesegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
-
-        public static void tposeinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tposeinst_set_stbox(inst, box));
-
-        public static void tposeinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tposeinstarr_set_stbox(instants, count, box));
-
-        public static void tposeseq_expand_stbox(IntPtr seq, IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.tposeseq_expand_stbox(seq, inst));
-
-        public static IntPtr tpose_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_geom(temp, gs, atfunc));
-
-        public static IntPtr tpose_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_stbox(temp, box, border_inc, atfunc));
-
-        public static IntPtr tpose_restrict_elevation(IntPtr temp, IntPtr s, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_elevation(temp, s, atfunc));
-
-        public static int geo_get_srid(IntPtr g)
-            => SafeExecution<int>(() => MEOSExternalFunctions.geo_get_srid(g));
-
-        public static int date_in(string str)
-            => SafeExecution<int>(() => MEOSExternalFunctions.date_in(str));
-
-        public static string date_out(int d)
-            => SafeExecution<string>(() => MEOSExternalFunctions.date_out(d));
-
-        public static int interval_cmp(IntPtr interv1, IntPtr interv2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.interval_cmp(interv1, interv2));
-
-        public static IntPtr interval_in(string str, int typmod)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_in(str, typmod));
-
-        public static string interval_out(IntPtr interv)
-            => SafeExecution<string>(() => MEOSExternalFunctions.interval_out(interv));
-
-        public static long time_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.time_in(str, typmod));
-
-        public static string time_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.time_out(t));
-
-        public static long timestamp_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_in(str, typmod));
-
-        public static string timestamp_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.timestamp_out(t));
-
-        public static long timestamptz_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_in(str, typmod));
-
-        public static string timestamptz_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.timestamptz_out(t));
-
-        public static bool ensure_has_geom(short flags)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_geom(flags));
-
-        public static bool ensure_valid_trgeo_geo(IntPtr temp, IntPtr gs)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_geo(temp, gs));
-
-        public static bool ensure_valid_trgeo_stbox(IntPtr temp, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_stbox(temp, box));
-
-        public static bool ensure_valid_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_trgeo(temp1, temp2));
-
-        public static bool ensure_valid_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_tpoint(temp1, temp2));
-
-        public static IntPtr trgeo_geom_p(IntPtr temp)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_geom_p(temp));
-
-        public static string trgeo_wkt_out(IntPtr temp, int maxdd, bool extended)
-            => SafeExecution<string>(() => MEOSExternalFunctions.trgeo_wkt_out(temp, maxdd, extended));
-
-        public static IntPtr geo_tposeinst_to_trgeo(IntPtr gs, IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeinst_to_trgeo(gs, inst));
-
-        public static IntPtr geo_tposeseq_to_trgeo(IntPtr gs, IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeseq_to_trgeo(gs, seq));
-
-        public static IntPtr geo_tposeseqset_to_trgeo(IntPtr gs, IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeseqset_to_trgeo(gs, ss));
-
-        public static bool trgeo_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.trgeo_value_at_timestamptz(temp, t, strict, result));
-
-        public static IntPtr trgeoinst_geom_p(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_geom_p(inst));
-
-        public static ulong trgeoinst_pose_varsize(IntPtr inst)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.trgeoinst_pose_varsize(inst));
-
-        public static void trgeoinst_set_pose(IntPtr inst)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoinst_set_pose(inst));
-
-        public static IntPtr trgeoinst_tposeinst(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_tposeinst(inst));
-
-        public static IntPtr trgeoinst_make1(IntPtr geom, IntPtr pose, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_make1(geom, pose, t));
-
-        public static IntPtr trgeoseq_to_tinstant(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_to_tinstant(seq));
-
-        public static IntPtr trgeoseqset_to_tinstant(IntPtr ts)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_to_tinstant(ts));
-
-        public static IntPtr trgeoseq_geom_p(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_geom_p(seq));
-
-        public static ulong trgeoseq_pose_varsize(IntPtr seq)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.trgeoseq_pose_varsize(seq));
-
-        public static void trgeoseq_set_pose(IntPtr seq)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoseq_set_pose(seq));
-
-        public static IntPtr trgeoseq_tposeseq(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_tposeseq(seq));
-
-        public static bool trgeoseq_make_valid(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, bool linear)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.trgeoseq_make_valid(geom, instants, count, lower_inc, upper_inc, linear));
-
-        public static IntPtr trgeoseq_make1_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make1_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoseq_make1(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make1(geom, instants, count, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoseq_make_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoseq_make(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make(geom, instants, count, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoseq_make_free_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_free_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoseq_make_free(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_free(geom, instants, count, lower_inc, upper_inc, interp, normalize));
-
-        public static IntPtr trgeoinst_to_tsequence(IntPtr inst, int interp)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_to_tsequence(inst, interp));
-
-        public static IntPtr trgeoseqset_geom_p(IntPtr ts)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_geom_p(ts));
-
-        public static IntPtr trgeoseqset_tposeseqset(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_tposeseqset(ss));
-
-        public static IntPtr trgeoseqset_make1_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make1_exp(geom, sequences, count, maxcount, normalize));
-
-        public static IntPtr trgeoseqset_make_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_exp(geom, sequences, count, maxcount, normalize));
-
-        public static IntPtr trgeoseqset_make(IntPtr geom, IntPtr sequences, int count, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make(geom, sequences, count, normalize));
-
-        public static IntPtr trgeoseqset_make_free(IntPtr geom, IntPtr sequences, int count, bool normalize)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_free(geom, sequences, count, normalize));
-
-        public static IntPtr trgeoseqset_make_gaps(IntPtr geom, IntPtr instants, int count, int interp, IntPtr maxt, double maxdist)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_gaps(geom, instants, count, interp, maxt, maxdist));
-
-        public static IntPtr trgeoseqset_to_tsequence(IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_to_tsequence(ss));
-
-        public static IntPtr trgeo_to_tsequence(IntPtr temp, string interp_str)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tsequence(temp, interp_str));
-
-        public static IntPtr trgeo_to_tsequenceset(IntPtr temp, string interp_str)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tsequenceset(temp, interp_str));
-
-        public static void trgeoinst_set_stbox(IntPtr geom, IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoinst_set_stbox(geom, inst, box));
-
-        public static void trgeoinstarr_static_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_static_stbox(geom, instants, count, box));
-
-        public static void trgeoinstarr_rotating_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_rotating_stbox(geom, instants, count, box));
-
-        public static void trgeoinstarr_compute_bbox(IntPtr geom, IntPtr instants, int count, int interp, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_compute_bbox(geom, instants, count, interp, box));
-
-        public static IntPtr trgeo_parse(IntPtr str, int temptype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_parse(str, temptype));
-
-        public static int ea_contains_geo_trgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_trgeo(gs, temp, ever));
-
-        public static int ea_covers_geo_trgeo(IntPtr gs, IntPtr temp, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_trgeo(gs, temp, ever));
-
-        public static int ea_covers_trgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_trgeo_geo(temp, gs, ever));
-
-        public static int ea_disjoint_trgeo_geo(IntPtr temp, IntPtr gs, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_trgeo_geo(temp, gs, ever));
-
-        public static bool ensure_same_geom(IntPtr gs1, IntPtr gs2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geom(gs1, gs2));
-
-        public static void lwgeom_apply_pose(IntPtr pose, IntPtr geom)
-            => SafeExecution(() => MEOSExternalFunctions.lwgeom_apply_pose(pose, geom));
-
-        public static double geom_radius(IntPtr gs)
-            => SafeExecution<double>(() => MEOSExternalFunctions.geom_radius(gs));
-
-        public static int v_clip_tpoly_point(IntPtr poly, IntPtr point, IntPtr pose, IntPtr poly_feature, IntPtr dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.v_clip_tpoly_point(poly, point, pose, poly_feature, dist));
-
-        public static int v_clip_tpoly_tpoly(IntPtr poly1, IntPtr poly2, IntPtr pose1, IntPtr pose2, IntPtr poly1_feature, IntPtr poly2_feature, IntPtr dist)
-            => SafeExecution<int>(() => MEOSExternalFunctions.v_clip_tpoly_tpoly(poly1, poly2, pose1, pose2, poly1_feature, poly2_feature, dist));
-
-        public static void apply_pose_point4d(IntPtr p, IntPtr pose)
-            => SafeExecution(() => MEOSExternalFunctions.apply_pose_point4d(p, pose));
-
-        public static IntPtr tfunc_tinstant(IntPtr inst, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant(inst, lfinfo));
-
-        public static IntPtr tfunc_tsequence(IntPtr seq, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequence(seq, lfinfo));
-
-        public static IntPtr tfunc_tsequenceset(IntPtr ss, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset(ss, lfinfo));
-
-        public static IntPtr tfunc_temporal(IntPtr temp, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal(temp, lfinfo));
-
-        public static IntPtr tfunc_tinstant_base(IntPtr inst, IntPtr value, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant_base(inst, value, lfinfo));
-
-        public static IntPtr tfunc_tsequence_base(IntPtr seq, IntPtr value, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequence_base(seq, value, lfinfo));
-
-        public static IntPtr tfunc_tsequenceset_base(IntPtr ss, IntPtr value, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset_base(ss, value, lfinfo));
-
-        public static IntPtr tfunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal_base(temp, value, lfinfo));
-
-        public static IntPtr tfunc_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant_tinstant(inst1, inst2, lfinfo));
-
-        public static IntPtr tfunc_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tdiscseq_tdiscseq(seq1, seq2, lfinfo));
-
-        public static IntPtr tfunc_tcontseq_tcontseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tcontseq_tcontseq(seq1, seq2, lfinfo));
-
-        public static IntPtr tfunc_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset_tsequenceset(ss1, ss2, lfinfo));
-
-        public static IntPtr tfunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal_temporal(temp1, temp2, lfinfo));
-
-        public static int eafunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eafunc_temporal_base(temp, value, lfinfo));
-
-        public static int eafunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eafunc_temporal_temporal(temp1, temp2, lfinfo));
-
-        public static int int4_in(string str)
-            => SafeExecution<int>(() => MEOSExternalFunctions.int4_in(str));
-
-        public static string int4_out(int val)
-            => SafeExecution<string>(() => MEOSExternalFunctions.int4_out(val));
-
-        public static long int8_in(string str)
-            => SafeExecution<long>(() => MEOSExternalFunctions.int8_in(str));
-
-        public static string int8_out(long val)
-            => SafeExecution<string>(() => MEOSExternalFunctions.int8_out(val));
-
-        public static int float8_in(string num, string type_name, string orig_string)
-            => SafeExecution<int>(() => MEOSExternalFunctions.float8_in(num, type_name, orig_string));
-
-        public static int pg_dsin(int arg1)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_dsin(arg1));
-
-        public static int pg_dcos(int arg1)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_dcos(arg1));
-
-        public static int pg_datan(int arg1)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_datan(arg1));
-
-        public static int pg_datan2(int arg1, int arg2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.pg_datan2(arg1, arg2));
-
-        public static IntPtr interval_negate(IntPtr interval)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_negate(interval));
-
-        public static IntPtr pg_interval_justify_hours(IntPtr span)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pg_interval_justify_hours(span));
-
-        public static uint hash_bytes_uint32(uint k)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.hash_bytes_uint32(k));
-
-        public static uint pg_hashint8(long val)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashint8(val));
-
-        public static uint pg_hashfloat8(int key)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashfloat8(key));
-
-        public static ulong hash_bytes_uint32_extended(uint k, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.hash_bytes_uint32_extended(k, seed));
-
-        public static ulong pg_hashint8extended(long val, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashint8extended(val, seed));
-
-        public static ulong pg_hashfloat8extended(int key, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashfloat8extended(key, seed));
-
-        public static uint pg_hashtext(IntPtr key)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashtext(key));
-
-        public static ulong pg_hashtextextended(IntPtr key, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashtextextended(key, seed));
-
-        public static string set_out_fn(IntPtr s, int maxdd, IntPtr value_out)
-            => SafeExecution<string>(() => MEOSExternalFunctions.set_out_fn(s, maxdd, value_out));
-
-        public static bool ensure_set_isof_type(IntPtr s, int settype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_isof_type(s, settype));
-
-        public static bool ensure_valid_set_set(IntPtr s1, IntPtr s2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_set_set(s1, s2));
-
-        public static bool set_find_value(IntPtr s, IntPtr arg1, IntPtr loc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_find_value(s, arg1, loc));
-
-        public static IntPtr set_unnest_state_make(IntPtr set)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_unnest_state_make(set));
-
-        public static void set_unnest_state_next(IntPtr state)
-            => SafeExecution(() => MEOSExternalFunctions.set_unnest_state_next(state));
-
-        public static bool ensure_same_skiplist_subtype(IntPtr state, IntPtr subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_skiplist_subtype(state, subtype));
-
-        public static void skiplist_set_extra(IntPtr state, IntPtr data, ulong size)
-            => SafeExecution(() => MEOSExternalFunctions.skiplist_set_extra(state, data, size));
-
-        public static IntPtr skiplist_headval(IntPtr list)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.skiplist_headval(list));
-
-        public static bool ensure_span_isof_type(IntPtr s, int spantype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_isof_type(s, spantype));
-
-        public static bool ensure_span_isof_basetype(IntPtr s, int basetype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_isof_basetype(s, basetype));
-
-        public static bool ensure_same_span_type(IntPtr s1, IntPtr s2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_span_type(s1, s2));
-
-        public static bool ensure_valid_span_span(IntPtr s1, IntPtr s2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_span_span(s1, s2));
-
-        public static void span_deserialize(IntPtr s, IntPtr lower, IntPtr upper)
-            => SafeExecution(() => MEOSExternalFunctions.span_deserialize(s, lower, upper));
-
-        public static int span_bound_cmp(IntPtr b1, IntPtr b2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_bound_cmp(b1, b2));
-
-        public static int span_bound_qsort_cmp(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_bound_qsort_cmp(s1, s2));
-
-        public static int span_lower_cmp(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_lower_cmp(s1, s2));
-
-        public static int span_upper_cmp(IntPtr s1, IntPtr s2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_upper_cmp(s1, s2));
-
-        public static int span_decr_bound(IntPtr upper, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_decr_bound(upper, basetype));
-
-        public static int span_incr_bound(IntPtr upper, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_incr_bound(upper, basetype));
-
-        public static IntPtr spanarr_normalize(IntPtr spans, int count, bool sort, IntPtr newcount)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanarr_normalize(spans, count, sort, newcount));
-
-        public static void span_bounds_shift_scale_value(IntPtr shift, IntPtr width, int type, bool hasshift, bool haswidth, IntPtr lower, IntPtr upper)
-            => SafeExecution(() => MEOSExternalFunctions.span_bounds_shift_scale_value(shift, width, type, hasshift, haswidth, lower, upper));
-
-        public static void span_bounds_shift_scale_time(IntPtr shift, IntPtr duration, IntPtr lower, IntPtr upper)
-            => SafeExecution(() => MEOSExternalFunctions.span_bounds_shift_scale_time(shift, duration, lower, upper));
-
-        public static void floatspan_floor_ceil_iter(IntPtr s, int func)
-            => SafeExecution(() => MEOSExternalFunctions.floatspan_floor_ceil_iter(s, func));
-
-        public static void numspan_delta_scale_iter(IntPtr s, IntPtr origin, IntPtr delta, bool hasdelta, double scale)
-            => SafeExecution(() => MEOSExternalFunctions.numspan_delta_scale_iter(s, origin, delta, hasdelta, scale));
-
-        public static void tstzspan_delta_scale_iter(IntPtr s, long origin, long delta, double scale)
-            => SafeExecution(() => MEOSExternalFunctions.tstzspan_delta_scale_iter(s, origin, delta, scale));
-
-        public static void numspan_shift_scale_iter(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth, IntPtr delta, IntPtr scale)
-            => SafeExecution(() => MEOSExternalFunctions.numspan_shift_scale_iter(s, shift, width, hasshift, haswidth, delta, scale));
-
-        public static void tstzspan_shift_scale1(IntPtr s, IntPtr shift, IntPtr duration, IntPtr delta, IntPtr scale)
-            => SafeExecution(() => MEOSExternalFunctions.tstzspan_shift_scale1(s, shift, duration, delta, scale));
-
-        public static int mi_span_value(IntPtr s, IntPtr value, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.mi_span_value(s, value, result));
-
-        public static double dist_double_value_value(IntPtr l, IntPtr r, int type)
-            => SafeExecution<double>(() => MEOSExternalFunctions.dist_double_value_value(l, r, type));
-
-        public static int common_entry_cmp(IntPtr i1, IntPtr i2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.common_entry_cmp(i1, i2));
-
-        public static bool span_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_index_leaf_consistent(key, query, strategy));
-
-        public static bool span_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_gist_inner_consistent(key, query, strategy));
-
-        public static bool span_index_recheck(int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_index_recheck(strategy));
-
-        public static bool ensure_spanset_isof_type(IntPtr ss, int spansettype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spanset_isof_type(ss, spansettype));
-
-        public static bool ensure_same_spanset_type(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spanset_type(ss1, ss2));
-
-        public static bool ensure_same_spanset_span_type(IntPtr ss, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spanset_span_type(ss, s));
-
-        public static bool ensure_valid_spanset_span(IntPtr ss, IntPtr s)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spanset_span(ss, s));
-
-        public static bool ensure_valid_spanset_spanset(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spanset_spanset(ss1, ss2));
-
-        public static bool spanset_find_value(IntPtr ss, IntPtr v, IntPtr loc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_find_value(ss, v, loc));
-
-        public static int datum_and(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_and(l, r));
-
-        public static int datum_or(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_or(l, r));
-
-        public static IntPtr boolop_tbool_bool(IntPtr temp, IntPtr b, IntPtr func, bool invert)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.boolop_tbool_bool(temp, b, func, invert));
-
-        public static IntPtr boolop_tbool_tbool(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.boolop_tbool_tbool(temp1, temp2, func));
-
-        public static bool ensure_same_dimensionality_tbox(IntPtr box1, IntPtr box2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_tbox(box1, box2));
-
-        public static IntPtr set_tbox(IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_tbox(s));
-
-        public static IntPtr span_tbox(IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_tbox(s));
-
-        public static IntPtr tbox_tstzspan(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_tstzspan(box));
-
-        public static IntPtr tbox_intspan(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_intspan(box));
-
-        public static IntPtr tbox_floatspan(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_floatspan(box));
-
-        public static bool tbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_index_leaf_consistent(key, query, strategy));
-
-        public static bool tbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_gist_inner_consistent(key, query, strategy));
-
-        public static bool tbox_index_recheck(int strategy)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_index_recheck(strategy));
-
-        public static int datum_min_int32(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_int32(l, r));
-
-        public static int datum_max_int32(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_int32(l, r));
-
-        public static int datum_min_float8(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_float8(l, r));
-
-        public static int datum_max_float8(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_float8(l, r));
-
-        public static int datum_sum_int32(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_int32(l, r));
-
-        public static int datum_sum_float8(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_float8(l, r));
-
-        public static int datum_min_text(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_text(l, r));
-
-        public static int datum_max_text(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_text(l, r));
-
-        public static int datum_sum_double2(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double2(l, r));
-
-        public static int datum_sum_double3(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double3(l, r));
-
-        public static int datum_sum_double4(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double4(l, r));
-
-        public static int temporal_skiplist_common(IntPtr list, IntPtr values, int count, IntPtr lower, IntPtr upper, IntPtr update)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_skiplist_common(list, values, count, lower, upper, update));
-
-        public static IntPtr temporal_skiplist_merge(IntPtr spliced, int spliced_count, IntPtr values, int count, IntPtr func, bool crossings, IntPtr newcount, IntPtr tofree, IntPtr nfree)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_skiplist_merge(spliced, spliced_count, values, count, func, crossings, newcount, tofree, nfree));
-
-        public static IntPtr tinstant_tagg(IntPtr instants1, int count1, IntPtr instants2, int count2, IntPtr func, IntPtr newcount, IntPtr tofree, IntPtr nfree)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tagg(instants1, count1, instants2, count2, func, newcount, tofree, nfree));
-
-        public static IntPtr tsequence_tagg(IntPtr sequences1, int count1, IntPtr sequences2, int count2, IntPtr func, bool crossings, IntPtr newcount)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_tagg(sequences1, count1, sequences2, count2, func, crossings, newcount));
-
-        public static IntPtr tcontseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func, bool interpoint)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_tagg_transfn(state, seq, func, interpoint));
-
-        public static IntPtr temporal_tagg_combinefn(IntPtr state1, IntPtr state2, IntPtr func, bool crossings)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_combinefn(state1, state2, func, crossings));
-
-        public static IntPtr tinstant_tagg_transfn(IntPtr state, IntPtr inst, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tagg_transfn(state, inst, func));
-
-        public static IntPtr tinstant_tavg_finalfn(IntPtr instants, int count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tavg_finalfn(instants, count));
-
-        public static IntPtr tsequence_tavg_finalfn(IntPtr sequences, int count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_tavg_finalfn(sequences, count));
-
-        public static IntPtr tnumberinst_transform_tavg(IntPtr inst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberinst_transform_tavg(inst));
-
-        public static IntPtr temporal_transform_tcount(IntPtr temp, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_tcount(temp, count));
-
-        public static IntPtr temporal_transform_tagg(IntPtr temp, IntPtr count, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_tagg(temp, count, func));
-
-        public static IntPtr tsequenceset_tagg_transfn(IntPtr state, IntPtr ss, IntPtr func, bool crossings)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_tagg_transfn(state, ss, func, crossings));
-
-        public static IntPtr tdiscseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_tagg_transfn(state, seq, func));
-
-        public static IntPtr temporal_tagg_transfn(IntPtr state, IntPtr temp, IntPtr arg2, bool crossings)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_transfn(state, temp, arg2, crossings));
-
-        public static IntPtr temporal_tagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr func, bool crossings, IntPtr transform)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_transform_transfn(state, temp, func, crossings, transform));
-
-        public static double temporal_similarity(IntPtr temp1, IntPtr temp2, IntPtr simfunc)
-            => SafeExecution<double>(() => MEOSExternalFunctions.temporal_similarity(temp1, temp2, simfunc));
-
-        public static IntPtr temporal_similarity_path(IntPtr temp1, IntPtr temp2, IntPtr count, IntPtr simfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_similarity_path(temp1, temp2, count, simfunc));
-
-        public static ulong temporal_bbox_size(int tempype)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_bbox_size(tempype));
-
-        public static void tinstarr_set_bbox(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, IntPtr bbox)
-            => SafeExecution(() => MEOSExternalFunctions.tinstarr_set_bbox(instants, count, lower_inc, upper_inc, interp, bbox));
-
-        public static void tsequence_compute_bbox(IntPtr seq)
-            => SafeExecution(() => MEOSExternalFunctions.tsequence_compute_bbox(seq));
-
-        public static void tseqarr_compute_bbox(IntPtr sequences, int count, IntPtr bbox)
-            => SafeExecution(() => MEOSExternalFunctions.tseqarr_compute_bbox(sequences, count, bbox));
-
-        public static void tsequenceset_compute_bbox(IntPtr ss)
-            => SafeExecution(() => MEOSExternalFunctions.tsequenceset_compute_bbox(ss));
-
-        public static bool boxop_temporal_tstzspan(IntPtr temp, IntPtr s, IntPtr func, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_temporal_tstzspan(temp, s, func, invert));
-
-        public static bool boxop_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_temporal_temporal(temp1, temp2, func));
-
-        public static bool boxop_tnumber_numspan(IntPtr temp, IntPtr span, IntPtr func, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_numspan(temp, span, func, invert));
-
-        public static bool boxop_tnumber_tbox(IntPtr temp, IntPtr box, IntPtr func, bool invert)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_tbox(temp, box, func, invert));
-
-        public static bool boxop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_tnumber(temp1, temp2, func));
-
-        public static int eacomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_base_temporal(value, temp, func, ever));
-
-        public static int eacomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_temporal_base(temp, value, func, ever));
-
-        public static int eacomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func, bool ever)
-            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_temporal_temporal(temp1, temp2, func, ever));
-
-        public static IntPtr tcomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_base_temporal(value, temp, func));
-
-        public static IntPtr tcomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_temporal_base(temp, value, func));
-
-        public static IntPtr tcomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_temporal_temporal(temp1, temp2, func));
-
-        public static IntPtr tdiscseq_at_timestamptz(IntPtr seq, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_at_timestamptz(seq, t));
-
-        public static IntPtr tdiscseq_restrict_value(IntPtr seq, IntPtr value, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_value(seq, value, atfunc));
-
-        public static IntPtr tdiscseq_restrict_values(IntPtr seq, IntPtr s, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_values(seq, s, atfunc));
-
-        public static IntPtr tdiscseq_minus_timestamptz(IntPtr seq, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_minus_timestamptz(seq, t));
-
-        public static IntPtr tdiscseq_restrict_tstzset(IntPtr seq, IntPtr s, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_tstzset(seq, s, atfunc));
-
-        public static IntPtr tdiscseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_tstzspanset(seq, ss, atfunc));
-
-        public static int tcontseq_restrict_value_iter(IntPtr seq, IntPtr value, bool atfunc, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_restrict_value_iter(seq, value, atfunc, result));
-
-        public static IntPtr tcontseq_delete_timestamptz(IntPtr seq, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_timestamptz(seq, t));
-
-        public static IntPtr tcontseq_delete_tstzset(IntPtr seq, IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_tstzset(seq, s));
-
-        public static IntPtr tcontseq_delete_tstzspanset(IntPtr seq, IntPtr ss)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_tstzspanset(seq, ss));
-
-        public static IntPtr tcontseq_at_tstzset(IntPtr seq, IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_tstzset(seq, s));
-
-        public static IntPtr tcontseq_minus_timestamptz(IntPtr seq, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_timestamptz(seq, t));
-
-        public static IntPtr tcontseq_minus_tstzset(IntPtr seq, IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_tstzset(seq, s));
-
-        public static IntPtr tcontseq_minus_tstzspan(IntPtr seq, IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_tstzspan(seq, s));
-
-        public static IntPtr tcontseq_restrict_value(IntPtr seq, IntPtr value, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_value(seq, value, atfunc));
-
-        public static IntPtr tcontseq_restrict_values(IntPtr seq, IntPtr s, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_values(seq, s, atfunc));
-
-        public static int tsequence_at_values_iter(IntPtr seq, IntPtr set, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_at_values_iter(seq, set, result));
-
-        public static int tnumberseq_cont_restrict_span_iter(IntPtr seq, IntPtr span, bool atfunc, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_span_iter(seq, span, atfunc, result));
-
-        public static int tnumberseq_cont_restrict_spanset_iter(IntPtr seq, IntPtr ss, bool atfunc, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_spanset_iter(seq, ss, atfunc, result));
-
-        public static IntPtr tsegment_at_timestamptz(IntPtr inst1, IntPtr inst2, int interp, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsegment_at_timestamptz(inst1, inst2, interp, t));
-
-        public static int tcontseq_minus_timestamp_iter(IntPtr seq, long t, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_timestamp_iter(seq, t, result));
-
-        public static int tcontseq_minus_tstzset_iter(IntPtr seq, IntPtr s, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_tstzset_iter(seq, s, result));
-
-        public static int tcontseq_at_tstzspanset1(IntPtr seq, IntPtr ss, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_at_tstzspanset1(seq, ss, result));
-
-        public static int tcontseq_minus_tstzspanset_iter(IntPtr seq, IntPtr ss, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_tstzspanset_iter(seq, ss, result));
-
-        public static IntPtr tcontseq_at_tstzspan(IntPtr seq, IntPtr s)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_tstzspan(seq, s));
-
-        public static IntPtr tcontseq_at_timestamptz(IntPtr seq, long t)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_timestamptz(seq, t));
-
-        public static IntPtr tcontseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_tstzspanset(seq, ss, atfunc));
-
-        public static bool tdiscseq_value_at_timestamptz(IntPtr seq, long t, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tdiscseq_value_at_timestamptz(seq, t, result));
-
-        public static IntPtr tnumberseq_disc_restrict_span(IntPtr seq, IntPtr span, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_disc_restrict_span(seq, span, atfunc));
-
-        public static IntPtr tnumberseq_disc_restrict_spanset(IntPtr seq, IntPtr ss, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_disc_restrict_spanset(seq, ss, atfunc));
-
-        public static IntPtr tnumberseq_cont_restrict_span(IntPtr seq, IntPtr span, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_span(seq, span, atfunc));
-
-        public static IntPtr tnumberseq_cont_restrict_spanset(IntPtr seq, IntPtr ss, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_spanset(seq, ss, atfunc));
-
-        public static double tnumberseq_cont_twavg(IntPtr seq)
-            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberseq_cont_twavg(seq));
-
-        public static int span_num_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr start_bin, IntPtr end_bin)
-            => SafeExecution<int>(() => MEOSExternalFunctions.span_num_bins(s, size, origin, start_bin, end_bin));
-
-        public static IntPtr temporal_time_bin_init(IntPtr temp, IntPtr duration, long torigin, IntPtr nbins)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_time_bin_init(temp, duration, torigin, nbins));
-
-        public static IntPtr tbox_tile_state_make(IntPtr temp, IntPtr box, IntPtr vsize, IntPtr duration, IntPtr xorigin, long torigin)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_tile_state_make(temp, box, vsize, duration, xorigin, torigin));
-
-        public static void tbox_tile_state_next(IntPtr state)
-            => SafeExecution(() => MEOSExternalFunctions.tbox_tile_state_next(state));
-
-        public static void tbox_tile_state_set(IntPtr value, long t, IntPtr vsize, long tunits, int basetype, int spantype, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tbox_tile_state_set(value, t, vsize, tunits, basetype, spantype, box));
-
-        public static long interval_units(IntPtr interval)
-            => SafeExecution<long>(() => MEOSExternalFunctions.interval_units(interval));
-
-        public static long timestamptz_bin_start(long timestamp, long tunits, long torigin)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_bin_start(timestamp, tunits, torigin));
-
-        public static int datum_bin(IntPtr value, IntPtr size, IntPtr offset, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_bin(value, size, offset, basetype));
-
-        public static IntPtr tnumber_value_time_tile_init(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, long torigin, IntPtr ntiles)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_tile_init(temp, vsize, duration, vorigin, torigin, ntiles));
-
-        public static bool tbox_tile_state_get(IntPtr state, IntPtr box)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_tile_state_get(state, box));
-
-        public static IntPtr temporal_transform_wcount(IntPtr temp, IntPtr interval, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_wcount(temp, interval, count));
-
-        public static IntPtr tnumber_transform_wavg(IntPtr temp, IntPtr interval, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_transform_wavg(temp, interval, count));
-
-        public static IntPtr temporal_wagg_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, bool min, bool crossings)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_wagg_transfn(state, temp, interval, func, min, crossings));
-
-        public static IntPtr temporal_wagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, IntPtr transform)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_wagg_transform_transfn(state, temp, interval, func, transform));
-
-        public static void tinstant_set(IntPtr inst, IntPtr value, long t)
-            => SafeExecution(() => MEOSExternalFunctions.tinstant_set(inst, value, t));
-
-        public static double tnumberinst_double(IntPtr inst)
-            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberinst_double(inst));
-
-        public static string tinstant_to_string(IntPtr inst, int maxdd, IntPtr value_out)
-            => SafeExecution<string>(() => MEOSExternalFunctions.tinstant_to_string(inst, maxdd, value_out));
-
-        public static bool tinstant_restrict_values_test(IntPtr inst, IntPtr s, bool atfunc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_values_test(inst, s, atfunc));
-
-        public static bool tnumberinst_restrict_span_test(IntPtr inst, IntPtr s, bool atfunc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumberinst_restrict_span_test(inst, s, atfunc));
-
-        public static bool tnumberinst_restrict_spanset_test(IntPtr inst, IntPtr ss, bool atfunc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumberinst_restrict_spanset_test(inst, ss, atfunc));
-
-        public static bool tinstant_restrict_tstzset_test(IntPtr inst, IntPtr s, bool atfunc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_tstzset_test(inst, s, atfunc));
-
-        public static bool tinstant_restrict_tstzspanset_test(IntPtr inst, IntPtr ss, bool atfunc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_tstzspanset_test(inst, ss, atfunc));
-
-        public static bool intersection_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tinstant(inst1, inst2, inter1, inter2));
-
-        public static int tfloat_arithop_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, long lower, long upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tfloat_arithop_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
-
-        public static IntPtr arithop_tnumber_number(IntPtr temp, IntPtr value, IntPtr oper, IntPtr func, bool invert)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.arithop_tnumber_number(temp, value, oper, func, invert));
-
-        public static IntPtr arithop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr oper, IntPtr func, IntPtr tpfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.arithop_tnumber_tnumber(temp1, temp2, oper, func, tpfunc));
-
-        public static bool float_collinear(double x1, double x2, double x3, double ratio)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.float_collinear(x1, x2, x3, ratio));
-
-        public static double floatsegm_interpolate(double value1, double value2, IntPtr value)
-            => SafeExecution<double>(() => MEOSExternalFunctions.floatsegm_interpolate(value1, value2, value));
-
-        public static IntPtr floatsegm_locate(double value1, double value2, double value)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.floatsegm_locate(value1, value2, value));
-
-        public static int tnumbersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int basetype, long lower, long upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tnumbersegm_intersection(start1, end1, start2, end2, basetype, lower, upper, t1, t2));
-
-        public static bool tsequence_norm_test(IntPtr value1, IntPtr value2, IntPtr value3, int basetype, int interp, long t1, long t2, long t3)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_norm_test(value1, value2, value3, basetype, interp, t1, t2, t3));
-
-        public static bool tsequence_join_test(IntPtr seq1, IntPtr seq2, IntPtr removelast, IntPtr removefirst)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_join_test(seq1, seq2, removelast, removefirst));
-
-        public static IntPtr tsequence_join(IntPtr seq1, IntPtr seq2, bool removelast, bool removefirst)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_join(seq1, seq2, removelast, removefirst));
-
-        public static IntPtr tinstarr_normalize(IntPtr instants, int interp, int count, IntPtr newcount)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstarr_normalize(instants, interp, count, newcount));
-
-        public static int tcontseq_find_timestamptz(IntPtr seq, long t)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_find_timestamptz(seq, t));
-
-        public static int tdiscseq_find_timestamptz(IntPtr seq, long t)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tdiscseq_find_timestamptz(seq, t));
-
-        public static IntPtr tseqarr2_to_tseqarr(IntPtr sequences, IntPtr countseqs, int count, int totalseqs)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqarr2_to_tseqarr(sequences, countseqs, count, totalseqs));
-
-        public static bool ensure_valid_tinstarr_common(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tinstarr_common(instants, count, lower_inc, upper_inc, interp));
-
-        public static IntPtr tsequence_make_exp1(IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize, IntPtr bbox)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_make_exp1(instants, count, maxcount, lower_inc, upper_inc, interp, normalize, bbox));
-
-        public static bool synchronize_tsequence_tsequence(IntPtr seq1, IntPtr seq2, IntPtr sync1, IntPtr sync2, bool interpoint)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequence_tsequence(seq1, seq2, sync1, sync2, interpoint));
-
-        public static int tfloatsegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, long lower, long upper, IntPtr t)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tfloatsegm_intersection_value(start, end, value, lower, upper, t));
-
-        public static int tsegment_intersection_value(IntPtr start, IntPtr end, IntPtr value, int temptype, long lower, long upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_intersection_value(start, end, value, temptype, lower, upper, t1, t2));
-
-        public static int tsegment_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int temptype, long lower, long upper, IntPtr t1, IntPtr t2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_intersection(start1, end1, start2, end2, temptype, lower, upper, t1, t2));
-
-        public static int tsegment_value_at_timestamptz(IntPtr start, IntPtr end, int temptype, long lower, long upper, long t)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_value_at_timestamptz(start, end, temptype, lower, upper, t));
-
-        public static bool intersection_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tdiscseq(seq1, seq2, inter1, inter2));
-
-        public static bool intersection_tcontseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tcontseq_tdiscseq(seq1, seq2, inter1, inter2));
-
-        public static bool intersection_tdiscseq_tcontseq(IntPtr @is, IntPtr seq2, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tcontseq(@is, seq2, inter1, inter2));
-
-        public static bool intersection_tsequence_tinstant(IntPtr seq, IntPtr inst, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequence_tinstant(seq, inst, inter1, inter2));
-
-        public static bool intersection_tinstant_tsequence(IntPtr inst, IntPtr seq, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tsequence(inst, seq, inter1, inter2));
-
-        public static string tsequence_to_string(IntPtr seq, int maxdd, bool component, IntPtr value_out)
-            => SafeExecution<string>(() => MEOSExternalFunctions.tsequence_to_string(seq, maxdd, component, value_out));
-
-        public static bool ensure_increasing_timestamps(IntPtr inst1, IntPtr inst2, bool strict)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_increasing_timestamps(inst1, inst2, strict));
-
-        public static void bbox_expand(IntPtr box1, IntPtr box2, int temptype)
-            => SafeExecution(() => MEOSExternalFunctions.bbox_expand(box1, box2, temptype));
-
-        public static bool ensure_valid_tinstarr(IntPtr instants, int count, bool merge, int interp)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tinstarr(instants, count, merge, interp));
-
-        public static bool tsequence_make_valid(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_make_valid(instants, count, lower_inc, upper_inc, interp));
-
-        public static void tnumberseq_shift_scale_value_iter(IntPtr seq, IntPtr origin, IntPtr delta, bool hasdelta, double scale)
-            => SafeExecution(() => MEOSExternalFunctions.tnumberseq_shift_scale_value_iter(seq, origin, delta, hasdelta, scale));
-
-        public static void tsequence_shift_scale_time_iter(IntPtr seq, long delta, double scale)
-            => SafeExecution(() => MEOSExternalFunctions.tsequence_shift_scale_time_iter(seq, delta, scale));
-
-        public static int tstepseq_to_linear_iter(IntPtr seq, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstepseq_to_linear_iter(seq, result));
-
-        public static IntPtr tstepseq_to_linear(IntPtr seq)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstepseq_to_linear(seq));
-
-        public static int tsequence_segments_iter(IntPtr seq, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_segments_iter(seq, result));
-
-        public static int tsequence_timestamps_iter(IntPtr seq, IntPtr result)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_timestamps_iter(seq, result));
-
-        public static bool tsequenceset_find_timestamptz(IntPtr ss, long t, IntPtr loc)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_find_timestamptz(ss, t, loc));
-
-        public static IntPtr tseqarr_normalize(IntPtr sequences, int count, IntPtr newcount)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqarr_normalize(sequences, count, newcount));
-
-        public static double datum_distance(IntPtr value1, IntPtr value2, int basetype, short flags)
-            => SafeExecution<double>(() => MEOSExternalFunctions.datum_distance(value1, value2, basetype, flags));
-
-        public static IntPtr ensure_valid_tinstarr_gaps(IntPtr instants, int count, bool merge, double maxdist, IntPtr maxt, IntPtr nsplits)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ensure_valid_tinstarr_gaps(instants, count, merge, maxdist, maxt, nsplits));
-
-        public static bool ensure_valid_tseqarr(IntPtr sequences, int count)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tseqarr(sequences, count));
-
-        public static bool synchronize_tsequenceset_tsequence(IntPtr ss, IntPtr seq, IntPtr mode, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequenceset_tsequence(ss, seq, mode, inter1, inter2));
-
-        public static bool synchronize_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr mode, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequenceset_tsequenceset(ss1, ss2, mode, inter1, inter2));
-
-        public static bool intersection_tsequenceset_tinstant(IntPtr ss, IntPtr inst, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequenceset_tinstant(ss, inst, inter1, inter2));
-
-        public static bool intersection_tinstant_tsequenceset(IntPtr inst, IntPtr ss, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tsequenceset(inst, ss, inter1, inter2));
-
-        public static bool intersection_tsequenceset_tdiscseq(IntPtr ss, IntPtr @is, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequenceset_tdiscseq(ss, @is, inter1, inter2));
-
-        public static bool intersection_tdiscseq_tsequenceset(IntPtr @is, IntPtr ss, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tsequenceset(@is, ss, inter1, inter2));
-
-        public static bool intersection_tsequence_tsequenceset(IntPtr seq, IntPtr ss, IntPtr mode, IntPtr inter1, IntPtr inter2)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequence_tsequenceset(seq, ss, mode, inter1, inter2));
-
-        public static string tsequenceset_to_string(IntPtr ss, int maxdd, IntPtr value_out)
-            => SafeExecution<string>(() => MEOSExternalFunctions.tsequenceset_to_string(ss, maxdd, value_out));
-
-        public static int datum_textcat(IntPtr l, IntPtr r)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_textcat(l, r));
-
-        public static int datum_lower(IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_lower(value));
-
-        public static int datum_upper(IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_upper(value));
-
-        public static int datum_initcap(IntPtr value)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_initcap(value));
-
-        public static IntPtr textfunc_ttext(IntPtr temp, int func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext(temp, func));
-
-        public static IntPtr textfunc_ttext_text(IntPtr temp, IntPtr value, IntPtr func, bool invert)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext_text(temp, value, func, invert));
-
-        public static IntPtr textfunc_ttext_ttext(IntPtr temp1, IntPtr temp2, IntPtr func)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext_ttext(temp1, temp2, func));
-
-        public static IntPtr datum_as_wkb(IntPtr value, int type, IntPtr variant, IntPtr size_out)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.datum_as_wkb(value, type, variant, size_out));
-
-        public static string datum_as_hexwkb(IntPtr value, int type, IntPtr variant, IntPtr size)
-            => SafeExecution<string>(() => MEOSExternalFunctions.datum_as_hexwkb(value, type, variant, size));
-
-        public static int type_from_wkb(IntPtr wkb, ulong size, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.type_from_wkb(wkb, size, type));
-
-        public static int type_from_hexwkb(string hexwkb, ulong size, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.type_from_hexwkb(hexwkb, size, type));
-
-        public static bool ensure_end_input(IntPtr str, string type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_end_input(str, type));
-
-        public static void p_whitespace(IntPtr str)
-            => SafeExecution(() => MEOSExternalFunctions.p_whitespace(str));
-
-        public static bool p_delimchar(IntPtr str, byte delim)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_delimchar(str, delim));
-
-        public static bool p_obrace(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_obrace(str));
-
-        public static bool ensure_obrace(IntPtr str, string type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_obrace(str, type));
-
-        public static bool p_cbrace(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cbrace(str));
-
-        public static bool ensure_cbrace(IntPtr str, string type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_cbrace(str, type));
-
-        public static bool p_obracket(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_obracket(str));
-
-        public static bool p_cbracket(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cbracket(str));
-
-        public static bool p_oparen(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_oparen(str));
-
-        public static bool ensure_oparen(IntPtr str, string type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_oparen(str, type));
-
-        public static bool p_cparen(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cparen(str));
-
-        public static bool ensure_cparen(IntPtr str, string type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_cparen(str, type));
-
-        public static bool p_comma(IntPtr str)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.p_comma(str));
-
-        public static bool basetype_parse(IntPtr str, int basetypid, byte delim, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_parse(str, basetypid, delim, result));
-
-        public static bool double_parse(IntPtr str, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.double_parse(str, result));
-
-        public static bool elem_parse(IntPtr str, int basetype, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.elem_parse(str, basetype, result));
-
-        public static IntPtr set_parse(IntPtr str, int basetype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_parse(str, basetype));
-
-        public static bool span_parse(IntPtr str, int spantype, bool end, IntPtr span)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_parse(str, spantype, end, span));
-
-        public static IntPtr spanset_parse(IntPtr str, int spantype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_parse(str, spantype));
-
-        public static IntPtr tbox_parse(IntPtr str)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_parse(str));
-
-        public static long timestamp_parse(IntPtr str)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_parse(str));
-
-        public static IntPtr tinstant_parse(IntPtr str, int temptype, bool end)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_parse(str, temptype, end));
-
-        public static IntPtr tdiscseq_parse(IntPtr str, int temptype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_parse(str, temptype));
-
-        public static IntPtr tcontseq_parse(IntPtr str, int temptype, int interp, bool end)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_parse(str, temptype, interp, end));
-
-        public static IntPtr tsequenceset_parse(IntPtr str, int temptype, int interp)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_parse(str, temptype, interp));
-
-        public static IntPtr temporal_parse(IntPtr str, int temptype)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_parse(str, temptype));
-
-        public static int datum_copy(IntPtr value, int typid)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_copy(value, typid));
-
-        public static double datum_double(IntPtr d, int type)
-            => SafeExecution<double>(() => MEOSExternalFunctions.datum_double(d, type));
-
-        public static int double_datum(double d, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.double_datum(d, type));
-
-        public static IntPtr bstring2bytea(IntPtr wkb, ulong size)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bstring2bytea(wkb, size));
-
-        public static bool basetype_in(string str, int type, bool end, IntPtr result)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_in(str, type, end, result));
-
-        public static string basetype_out(IntPtr value, int type, int maxdd)
-            => SafeExecution<string>(() => MEOSExternalFunctions.basetype_out(value, type, maxdd));
-
-        public static void pfree_array(IntPtr array, int count)
-            => SafeExecution(() => MEOSExternalFunctions.pfree_array(array, count));
-
-        public static string stringarr_to_string(IntPtr strings, int count, ulong outlen, string prefix, byte open, byte close, bool quotes, bool spaces)
-            => SafeExecution<string>(() => MEOSExternalFunctions.stringarr_to_string(strings, count, outlen, prefix, open, close, quotes, spaces));
-
-        public static void datumarr_sort(IntPtr values, int count, int basetype)
-            => SafeExecution(() => MEOSExternalFunctions.datumarr_sort(values, count, basetype));
-
-        public static void tstzarr_sort(IntPtr times, int count)
-            => SafeExecution(() => MEOSExternalFunctions.tstzarr_sort(times, count));
-
-        public static void spanarr_sort(IntPtr spans, int count)
-            => SafeExecution(() => MEOSExternalFunctions.spanarr_sort(spans, count));
-
-        public static void tinstarr_sort(IntPtr instants, int count)
-            => SafeExecution(() => MEOSExternalFunctions.tinstarr_sort(instants, count));
-
-        public static void tseqarr_sort(IntPtr sequences, int count)
-            => SafeExecution(() => MEOSExternalFunctions.tseqarr_sort(sequences, count));
-
-        public static int datumarr_remove_duplicates(IntPtr values, int count, int basetype)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datumarr_remove_duplicates(values, count, basetype));
-
-        public static int tstzarr_remove_duplicates(IntPtr values, int count)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tstzarr_remove_duplicates(values, count));
-
-        public static int tinstarr_remove_duplicates(IntPtr instants, int count)
-            => SafeExecution<int>(() => MEOSExternalFunctions.tinstarr_remove_duplicates(instants, count));
-
-        public static int datum_add(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_add(l, r, type));
-
-        public static int datum_sub(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sub(l, r, type));
-
-        public static int datum_mult(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_mult(l, r, type));
-
-        public static int datum_div(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_div(l, r, type));
-
-        public static int datum_cmp(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cmp(l, r, type));
-
-        public static bool datum_eq(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_eq(l, r, type));
-
-        public static bool datum_ne(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_ne(l, r, type));
-
-        public static bool datum_lt(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_lt(l, r, type));
-
-        public static bool datum_le(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_le(l, r, type));
-
-        public static bool datum_gt(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_gt(l, r, type));
-
-        public static bool datum_ge(IntPtr l, IntPtr r, int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_ge(l, r, type));
-
-        public static int datum2_eq(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_eq(l, r, type));
-
-        public static int datum2_ne(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_ne(l, r, type));
-
-        public static int datum2_lt(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_lt(l, r, type));
-
-        public static int datum2_le(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_le(l, r, type));
-
-        public static int datum2_gt(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_gt(l, r, type));
-
-        public static int datum2_ge(IntPtr l, IntPtr r, int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_ge(l, r, type));
-
-        public static double hypot3d(double x, double y, double z)
-            => SafeExecution<double>(() => MEOSExternalFunctions.hypot3d(x, y, z));
 
     }
 }

--- a/MEOS.NET/Internal/MEOSExposedFunctions.cs
+++ b/MEOS.NET/Internal/MEOSExposedFunctions.cs
@@ -8,38 +8,29 @@ namespace MEOS.NET.Internal
     [GeneratedCode("MEOS.NET.Builder.MEOSIDL", "0.1.0")]
     internal partial class MEOSExposedFunctions
     {
-        public static int date_in(string str)
-            => SafeExecution<int>(() => MEOSExternalFunctions.date_in(str));
+        public static IntPtr meos_array_create(int elem_size)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meos_array_create(elem_size));
 
-        public static string date_out(int d)
-            => SafeExecution<string>(() => MEOSExternalFunctions.date_out(d));
+        public static void meos_array_add(IntPtr array, IntPtr value)
+            => SafeExecution(() => MEOSExternalFunctions.meos_array_add(array, value));
 
-        public static int interval_cmp(IntPtr interv1, IntPtr interv2)
-            => SafeExecution<int>(() => MEOSExternalFunctions.interval_cmp(interv1, interv2));
+        public static IntPtr meos_array_get(IntPtr array, int n)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meos_array_get(array, n));
 
-        public static IntPtr interval_in(string str, int typmod)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_in(str, typmod));
+        public static int meos_array_count(IntPtr array)
+            => SafeExecution<int>(() => MEOSExternalFunctions.meos_array_count(array));
 
-        public static string interval_out(IntPtr interv)
-            => SafeExecution<string>(() => MEOSExternalFunctions.interval_out(interv));
+        public static void meos_array_reset(IntPtr array)
+            => SafeExecution(() => MEOSExternalFunctions.meos_array_reset(array));
 
-        public static long time_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.time_in(str, typmod));
+        public static void meos_array_reset_free(IntPtr array)
+            => SafeExecution(() => MEOSExternalFunctions.meos_array_reset_free(array));
 
-        public static string time_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.time_out(t));
+        public static void meos_array_destroy(IntPtr array)
+            => SafeExecution(() => MEOSExternalFunctions.meos_array_destroy(array));
 
-        public static long timestamp_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_in(str, typmod));
-
-        public static string timestamp_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.timestamp_out(t));
-
-        public static long timestamptz_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_in(str, typmod));
-
-        public static string timestamptz_out(long t)
-            => SafeExecution<string>(() => MEOSExternalFunctions.timestamptz_out(t));
+        public static void meos_array_destroy_free(IntPtr array)
+            => SafeExecution(() => MEOSExternalFunctions.meos_array_destroy_free(array));
 
         public static IntPtr rtree_create_intspan()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.rtree_create_intspan());
@@ -65,11 +56,17 @@ namespace MEOS.NET.Internal
         public static void rtree_free(IntPtr rtree)
             => SafeExecution(() => MEOSExternalFunctions.rtree_free(rtree));
 
-        public static void rtree_insert(IntPtr rtree, IntPtr box, long id)
+        public static void rtree_insert(IntPtr rtree, IntPtr box, int id)
             => SafeExecution(() => MEOSExternalFunctions.rtree_insert(rtree, box, id));
 
-        public static IntPtr rtree_search(IntPtr rtree, IntPtr query, IntPtr count)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.rtree_search(rtree, query, count));
+        public static void rtree_insert_temporal(IntPtr rtree, IntPtr temp, int id)
+            => SafeExecution(() => MEOSExternalFunctions.rtree_insert_temporal(rtree, temp, id));
+
+        public static int rtree_search(IntPtr rtree, IntPtr op, IntPtr query, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.rtree_search(rtree, op, query, result));
+
+        public static int rtree_search_temporal(IntPtr rtree, IntPtr op, IntPtr temp, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.rtree_search_temporal(rtree, op, temp, result));
 
         public static void meos_error(int errlevel, int errcode, string format)
             => SafeExecution(() => MEOSExternalFunctions.meos_error(errlevel, errcode, format));
@@ -128,8 +125,8 @@ namespace MEOS.NET.Internal
         public static IntPtr add_interval_interval(IntPtr interv1, IntPtr interv2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.add_interval_interval(interv1, interv2));
 
-        public static long add_timestamptz_interval(long t, IntPtr interv)
-            => SafeExecution<long>(() => MEOSExternalFunctions.add_timestamptz_interval(t, interv));
+        public static int add_timestamptz_interval(int t, IntPtr interv)
+            => SafeExecution<int>(() => MEOSExternalFunctions.add_timestamptz_interval(t, interv));
 
         public static bool bool_in(string str)
             => SafeExecution<bool>(() => MEOSExternalFunctions.bool_in(str));
@@ -140,11 +137,11 @@ namespace MEOS.NET.Internal
         public static IntPtr cstring2text(string str)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cstring2text(str));
 
-        public static long date_to_timestamp(int dateVal)
-            => SafeExecution<long>(() => MEOSExternalFunctions.date_to_timestamp(dateVal));
+        public static int date_to_timestamp(int dateVal)
+            => SafeExecution<int>(() => MEOSExternalFunctions.date_to_timestamp(dateVal));
 
-        public static long date_to_timestamptz(int d)
-            => SafeExecution<long>(() => MEOSExternalFunctions.date_to_timestamptz(d));
+        public static int date_to_timestamptz(int d)
+            => SafeExecution<int>(() => MEOSExternalFunctions.date_to_timestamptz(d));
 
         public static double float_exp(double d)
             => SafeExecution<double>(() => MEOSExternalFunctions.float_exp(d));
@@ -164,7 +161,7 @@ namespace MEOS.NET.Internal
         public static int int32_cmp(int l, int r)
             => SafeExecution<int>(() => MEOSExternalFunctions.int32_cmp(l, r));
 
-        public static int int64_cmp(long l, long r)
+        public static int int64_cmp(int l, int r)
             => SafeExecution<int>(() => MEOSExternalFunctions.int64_cmp(l, r));
 
         public static IntPtr interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs)
@@ -176,10 +173,10 @@ namespace MEOS.NET.Internal
         public static int minus_date_int(int d, int days)
             => SafeExecution<int>(() => MEOSExternalFunctions.minus_date_int(d, days));
 
-        public static long minus_timestamptz_interval(long t, IntPtr interv)
-            => SafeExecution<long>(() => MEOSExternalFunctions.minus_timestamptz_interval(t, interv));
+        public static int minus_timestamptz_interval(int t, IntPtr interv)
+            => SafeExecution<int>(() => MEOSExternalFunctions.minus_timestamptz_interval(t, interv));
 
-        public static IntPtr minus_timestamptz_timestamptz(long t1, long t2)
+        public static IntPtr minus_timestamptz_timestamptz(int t1, int t2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_timestamptz(t1, t2));
 
         public static IntPtr mul_interval_double(IntPtr interv, double factor)
@@ -200,16 +197,16 @@ namespace MEOS.NET.Internal
         public static string pg_interval_out(IntPtr interv)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_interval_out(interv));
 
-        public static long pg_timestamp_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.pg_timestamp_in(str, typmod));
+        public static int pg_timestamp_in(string str, int typmod)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_timestamp_in(str, typmod));
 
-        public static string pg_timestamp_out(long t)
+        public static string pg_timestamp_out(int t)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_timestamp_out(t));
 
-        public static long pg_timestamptz_in(string str, int typmod)
-            => SafeExecution<long>(() => MEOSExternalFunctions.pg_timestamptz_in(str, typmod));
+        public static int pg_timestamptz_in(string str, int typmod)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_timestamptz_in(str, typmod));
 
-        public static string pg_timestamptz_out(long t)
+        public static string pg_timestamptz_out(int t)
             => SafeExecution<string>(() => MEOSExternalFunctions.pg_timestamptz_out(t));
 
         public static string text2cstring(IntPtr txt)
@@ -239,13 +236,13 @@ namespace MEOS.NET.Internal
         public static IntPtr textcat_text_text(IntPtr txt1, IntPtr txt2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textcat_text_text(txt1, txt2));
 
-        public static long timestamptz_shift(long t, IntPtr interv)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_shift(t, interv));
+        public static int timestamptz_shift(int t, IntPtr interv)
+            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_shift(t, interv));
 
-        public static int timestamp_to_date(long t)
+        public static int timestamp_to_date(int t)
             => SafeExecution<int>(() => MEOSExternalFunctions.timestamp_to_date(t));
 
-        public static int timestamptz_to_date(long t)
+        public static int timestamptz_to_date(int t)
             => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_to_date(t));
 
         public static IntPtr bigintset_in(string str)
@@ -254,7 +251,7 @@ namespace MEOS.NET.Internal
         public static string bigintset_out(IntPtr set)
             => SafeExecution<string>(() => MEOSExternalFunctions.bigintset_out(set));
 
-        public static IntPtr bigintspan_expand(IntPtr s, long value)
+        public static IntPtr bigintspan_expand(IntPtr s, int value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_expand(s, value));
 
         public static IntPtr bigintspan_in(string str)
@@ -392,7 +389,7 @@ namespace MEOS.NET.Internal
         public static IntPtr bigintset_make(IntPtr values, int count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_make(values, count));
 
-        public static IntPtr bigintspan_make(long lower, long upper, bool lower_inc, bool upper_inc)
+        public static IntPtr bigintspan_make(int lower, int upper, bool lower_inc, bool upper_inc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_make(lower, upper, lower_inc, upper_inc));
 
         public static IntPtr dateset_make(IntPtr values, int count)
@@ -431,10 +428,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzset_make(IntPtr values, int count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_make(values, count));
 
-        public static IntPtr tstzspan_make(long lower, long upper, bool lower_inc, bool upper_inc)
+        public static IntPtr tstzspan_make(int lower, int upper, bool lower_inc, bool upper_inc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_make(lower, upper, lower_inc, upper_inc));
 
-        public static IntPtr bigint_to_set(long i)
+        public static IntPtr bigint_to_set(int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_to_set(i));
 
         public static IntPtr bigint_to_span(int i)
@@ -509,13 +506,13 @@ namespace MEOS.NET.Internal
         public static IntPtr text_to_set(IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.text_to_set(txt));
 
-        public static IntPtr timestamptz_to_set(long t)
+        public static IntPtr timestamptz_to_set(int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_set(t));
 
-        public static IntPtr timestamptz_to_span(long t)
+        public static IntPtr timestamptz_to_span(int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_span(t));
 
-        public static IntPtr timestamptz_to_spanset(long t)
+        public static IntPtr timestamptz_to_spanset(int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_spanset(t));
 
         public static IntPtr tstzset_to_dateset(IntPtr s)
@@ -527,41 +524,41 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzspanset_to_datespanset(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_to_datespanset(ss));
 
-        public static long bigintset_end_value(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintset_end_value(s));
+        public static int bigintset_end_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintset_end_value(s));
 
-        public static long bigintset_start_value(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintset_start_value(s));
+        public static int bigintset_start_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintset_start_value(s));
 
         public static bool bigintset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.bigintset_value_n(s, n, result));
 
-        public static long[] bigintset_values(IntPtr s)
+        public static int[] bigintset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_values(s));
-            long[] _out = new long[_n];
+            int[] _out = new int[_n];
             Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
 
-        public static long bigintspan_lower(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_lower(s));
+        public static int bigintspan_lower(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_lower(s));
 
-        public static long bigintspan_upper(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_upper(s));
+        public static int bigintspan_upper(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_upper(s));
 
-        public static long bigintspan_width(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspan_width(s));
+        public static int bigintspan_width(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspan_width(s));
 
-        public static long bigintspanset_lower(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_lower(ss));
+        public static int bigintspanset_lower(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_lower(ss));
 
-        public static long bigintspanset_upper(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_upper(ss));
+        public static int bigintspanset_upper(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_upper(ss));
 
-        public static long bigintspanset_width(IntPtr ss, bool boundspan)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigintspanset_width(ss, boundspan));
+        public static int bigintspanset_width(IntPtr ss, bool boundspan)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigintspanset_width(ss, boundspan));
 
         public static int dateset_end_value(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.dateset_end_value(s));
@@ -680,20 +677,20 @@ namespace MEOS.NET.Internal
         public static int intspanset_width(IntPtr ss, bool boundspan)
             => SafeExecution<int>(() => MEOSExternalFunctions.intspanset_width(ss, boundspan));
 
-        public static uint set_hash(IntPtr s)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.set_hash(s));
+        public static int set_hash(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.set_hash(s));
 
-        public static ulong set_hash_extended(IntPtr s, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_hash_extended(s, seed));
+        public static int set_hash_extended(IntPtr s, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.set_hash_extended(s, seed));
 
         public static int set_num_values(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.set_num_values(s));
 
-        public static uint span_hash(IntPtr s)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.span_hash(s));
+        public static int span_hash(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_hash(s));
 
-        public static ulong span_hash_extended(IntPtr s, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.span_hash_extended(s, seed));
+        public static int span_hash_extended(IntPtr s, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_hash_extended(s, seed));
 
         public static bool span_lower_inc(IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.span_lower_inc(s));
@@ -704,11 +701,11 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_end_span(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_end_span(ss));
 
-        public static uint spanset_hash(IntPtr ss)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.spanset_hash(ss));
+        public static int spanset_hash(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_hash(ss));
 
-        public static ulong spanset_hash_extended(IntPtr ss, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_hash_extended(ss, seed));
+        public static int spanset_hash_extended(IntPtr ss, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_hash_extended(ss, seed));
 
         public static bool spanset_lower_inc(IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_lower_inc(ss));
@@ -747,30 +744,29 @@ namespace MEOS.NET.Internal
         public static bool textset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.textset_value_n(s, n, result));
 
-        public static IntPtr[] textset_values(IntPtr s)
+        public static int[] textset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.textset_values(s));
-            IntPtr[] _out = new IntPtr[_n];
-            for (int _i = 0; _i < _n; _i++)
-            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
+            int[] _out = new int[_n];
+            Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
 
-        public static long tstzset_end_value(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzset_end_value(s));
+        public static int tstzset_end_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzset_end_value(s));
 
-        public static long tstzset_start_value(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzset_start_value(s));
+        public static int tstzset_start_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzset_start_value(s));
 
         public static bool tstzset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tstzset_value_n(s, n, result));
 
-        public static long[] tstzset_values(IntPtr s)
+        public static int[] tstzset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_values(s));
-            long[] _out = new long[_n];
+            int[] _out = new int[_n];
             Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
@@ -778,26 +774,26 @@ namespace MEOS.NET.Internal
         public static IntPtr tstzspan_duration(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_duration(s));
 
-        public static long tstzspan_lower(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspan_lower(s));
+        public static int tstzspan_lower(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspan_lower(s));
 
-        public static long tstzspan_upper(IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspan_upper(s));
+        public static int tstzspan_upper(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspan_upper(s));
 
         public static IntPtr tstzspanset_duration(IntPtr ss, bool boundspan)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_duration(ss, boundspan));
 
-        public static long tstzspanset_end_timestamptz(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_end_timestamptz(ss));
+        public static int tstzspanset_end_timestamptz(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_end_timestamptz(ss));
 
-        public static long tstzspanset_lower(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_lower(ss));
+        public static int tstzspanset_lower(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_lower(ss));
 
         public static int tstzspanset_num_timestamps(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_num_timestamps(ss));
 
-        public static long tstzspanset_start_timestamptz(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_start_timestamptz(ss));
+        public static int tstzspanset_start_timestamptz(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_start_timestamptz(ss));
 
         public static IntPtr tstzspanset_timestamps(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_timestamps(ss));
@@ -805,16 +801,16 @@ namespace MEOS.NET.Internal
         public static bool tstzspanset_timestamptz_n(IntPtr ss, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tstzspanset_timestamptz_n(ss, n, result));
 
-        public static long tstzspanset_upper(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tstzspanset_upper(ss));
+        public static int tstzspanset_upper(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzspanset_upper(ss));
 
-        public static IntPtr bigintset_shift_scale(IntPtr s, long shift, long width, bool hasshift, bool haswidth)
+        public static IntPtr bigintset_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintset_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr bigintspan_shift_scale(IntPtr s, long shift, long width, bool hasshift, bool haswidth)
+        public static IntPtr bigintspan_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr bigintspanset_shift_scale(IntPtr ss, long shift, long width, bool hasshift, bool haswidth)
+        public static IntPtr bigintspanset_shift_scale(IntPtr ss, int shift, int width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspanset_shift_scale(ss, shift, width, hasshift, haswidth));
 
         public static IntPtr dateset_shift_scale(IntPtr s, int shift, int width, bool hasshift, bool haswidth)
@@ -907,25 +903,25 @@ namespace MEOS.NET.Internal
         public static IntPtr textset_upper(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textset_upper(s));
 
-        public static long timestamptz_tprecision(long t, IntPtr duration, long torigin)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_tprecision(t, duration, torigin));
+        public static int timestamptz_tprecision(int t, IntPtr duration, int torigin)
+            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_tprecision(t, duration, torigin));
 
         public static IntPtr tstzset_shift_scale(IntPtr s, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_shift_scale(s, shift, duration));
 
-        public static IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, long torigin)
+        public static IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, int torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzset_tprecision(s, duration, torigin));
 
         public static IntPtr tstzspan_shift_scale(IntPtr s, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_shift_scale(s, shift, duration));
 
-        public static IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, long torigin)
+        public static IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, int torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_tprecision(s, duration, torigin));
 
         public static IntPtr tstzspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr duration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_shift_scale(ss, shift, duration));
 
-        public static IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, long torigin)
+        public static IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, int torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_tprecision(ss, duration, torigin));
 
         public static int set_cmp(IntPtr s1, IntPtr s2)
@@ -1009,7 +1005,7 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_split_n_spans(IntPtr ss, int span_count, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_split_n_spans(ss, span_count, count));
 
-        public static bool adjacent_span_bigint(IntPtr s, long i)
+        public static bool adjacent_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_bigint(s, i));
 
         public static bool adjacent_span_date(IntPtr s, int d)
@@ -1027,10 +1023,10 @@ namespace MEOS.NET.Internal
         public static bool adjacent_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_spanset(s, ss));
 
-        public static bool adjacent_span_timestamptz(IntPtr s, long t)
+        public static bool adjacent_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_timestamptz(s, t));
 
-        public static bool adjacent_spanset_bigint(IntPtr ss, long i)
+        public static bool adjacent_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_bigint(ss, i));
 
         public static bool adjacent_spanset_date(IntPtr ss, int d)
@@ -1042,7 +1038,7 @@ namespace MEOS.NET.Internal
         public static bool adjacent_spanset_int(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_int(ss, i));
 
-        public static bool adjacent_spanset_timestamptz(IntPtr ss, long t)
+        public static bool adjacent_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_timestamptz(ss, t));
 
         public static bool adjacent_spanset_span(IntPtr ss, IntPtr s)
@@ -1051,13 +1047,13 @@ namespace MEOS.NET.Internal
         public static bool adjacent_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_spanset(ss1, ss2));
 
-        public static bool contained_bigint_set(long i, IntPtr s)
+        public static bool contained_bigint_set(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_set(i, s));
 
-        public static bool contained_bigint_span(long i, IntPtr s)
+        public static bool contained_bigint_span(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_span(i, s));
 
-        public static bool contained_bigint_spanset(long i, IntPtr ss)
+        public static bool contained_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_bigint_spanset(i, ss));
 
         public static bool contained_date_set(int d, IntPtr s)
@@ -1105,16 +1101,16 @@ namespace MEOS.NET.Internal
         public static bool contained_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_text_set(txt, s));
 
-        public static bool contained_timestamptz_set(long t, IntPtr s)
+        public static bool contained_timestamptz_set(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_set(t, s));
 
-        public static bool contained_timestamptz_span(long t, IntPtr s)
+        public static bool contained_timestamptz_span(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_span(t, s));
 
-        public static bool contained_timestamptz_spanset(long t, IntPtr ss)
+        public static bool contained_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_timestamptz_spanset(t, ss));
 
-        public static bool contains_set_bigint(IntPtr s, long i)
+        public static bool contains_set_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_bigint(s, i));
 
         public static bool contains_set_date(IntPtr s, int d)
@@ -1132,10 +1128,10 @@ namespace MEOS.NET.Internal
         public static bool contains_set_text(IntPtr s, IntPtr t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_text(s, t));
 
-        public static bool contains_set_timestamptz(IntPtr s, long t)
+        public static bool contains_set_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_timestamptz(s, t));
 
-        public static bool contains_span_bigint(IntPtr s, long i)
+        public static bool contains_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_bigint(s, i));
 
         public static bool contains_span_date(IntPtr s, int d)
@@ -1153,10 +1149,10 @@ namespace MEOS.NET.Internal
         public static bool contains_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_spanset(s, ss));
 
-        public static bool contains_span_timestamptz(IntPtr s, long t)
+        public static bool contains_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_timestamptz(s, t));
 
-        public static bool contains_spanset_bigint(IntPtr ss, long i)
+        public static bool contains_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_bigint(ss, i));
 
         public static bool contains_spanset_date(IntPtr ss, int d)
@@ -1174,7 +1170,7 @@ namespace MEOS.NET.Internal
         public static bool contains_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_spanset(ss1, ss2));
 
-        public static bool contains_spanset_timestamptz(IntPtr ss, long t)
+        public static bool contains_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_timestamptz(ss, t));
 
         public static bool overlaps_set_set(IntPtr s1, IntPtr s2)
@@ -1204,28 +1200,28 @@ namespace MEOS.NET.Internal
         public static bool after_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_set_date(s, d));
 
-        public static bool after_set_timestamptz(IntPtr s, long t)
+        public static bool after_set_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_set_timestamptz(s, t));
 
         public static bool after_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_span_date(s, d));
 
-        public static bool after_span_timestamptz(IntPtr s, long t)
+        public static bool after_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_span_timestamptz(s, t));
 
         public static bool after_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_spanset_date(ss, d));
 
-        public static bool after_spanset_timestamptz(IntPtr ss, long t)
+        public static bool after_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_spanset_timestamptz(ss, t));
 
-        public static bool after_timestamptz_set(long t, IntPtr s)
+        public static bool after_timestamptz_set(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_set(t, s));
 
-        public static bool after_timestamptz_span(long t, IntPtr s)
+        public static bool after_timestamptz_span(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_span(t, s));
 
-        public static bool after_timestamptz_spanset(long t, IntPtr ss)
+        public static bool after_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.after_timestamptz_spanset(t, ss));
 
         public static bool before_date_set(int d, IntPtr s)
@@ -1240,37 +1236,37 @@ namespace MEOS.NET.Internal
         public static bool before_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_set_date(s, d));
 
-        public static bool before_set_timestamptz(IntPtr s, long t)
+        public static bool before_set_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_set_timestamptz(s, t));
 
         public static bool before_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_span_date(s, d));
 
-        public static bool before_span_timestamptz(IntPtr s, long t)
+        public static bool before_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_span_timestamptz(s, t));
 
         public static bool before_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_spanset_date(ss, d));
 
-        public static bool before_spanset_timestamptz(IntPtr ss, long t)
+        public static bool before_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_spanset_timestamptz(ss, t));
 
-        public static bool before_timestamptz_set(long t, IntPtr s)
+        public static bool before_timestamptz_set(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_set(t, s));
 
-        public static bool before_timestamptz_span(long t, IntPtr s)
+        public static bool before_timestamptz_span(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_span(t, s));
 
-        public static bool before_timestamptz_spanset(long t, IntPtr ss)
+        public static bool before_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.before_timestamptz_spanset(t, ss));
 
-        public static bool left_bigint_set(long i, IntPtr s)
+        public static bool left_bigint_set(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_set(i, s));
 
-        public static bool left_bigint_span(long i, IntPtr s)
+        public static bool left_bigint_span(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_span(i, s));
 
-        public static bool left_bigint_spanset(long i, IntPtr ss)
+        public static bool left_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_bigint_spanset(i, ss));
 
         public static bool left_float_set(double d, IntPtr s)
@@ -1291,7 +1287,7 @@ namespace MEOS.NET.Internal
         public static bool left_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_int_spanset(i, ss));
 
-        public static bool left_set_bigint(IntPtr s, long i)
+        public static bool left_set_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_bigint(s, i));
 
         public static bool left_set_float(IntPtr s, double d)
@@ -1306,7 +1302,7 @@ namespace MEOS.NET.Internal
         public static bool left_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_text(s, txt));
 
-        public static bool left_span_bigint(IntPtr s, long i)
+        public static bool left_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_bigint(s, i));
 
         public static bool left_span_float(IntPtr s, double d)
@@ -1321,7 +1317,7 @@ namespace MEOS.NET.Internal
         public static bool left_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_spanset(s, ss));
 
-        public static bool left_spanset_bigint(IntPtr ss, long i)
+        public static bool left_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_spanset_bigint(ss, i));
 
         public static bool left_spanset_float(IntPtr ss, double d)
@@ -1351,28 +1347,28 @@ namespace MEOS.NET.Internal
         public static bool overafter_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_set_date(s, d));
 
-        public static bool overafter_set_timestamptz(IntPtr s, long t)
+        public static bool overafter_set_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_set_timestamptz(s, t));
 
         public static bool overafter_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_span_date(s, d));
 
-        public static bool overafter_span_timestamptz(IntPtr s, long t)
+        public static bool overafter_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_span_timestamptz(s, t));
 
         public static bool overafter_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_spanset_date(ss, d));
 
-        public static bool overafter_spanset_timestamptz(IntPtr ss, long t)
+        public static bool overafter_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_spanset_timestamptz(ss, t));
 
-        public static bool overafter_timestamptz_set(long t, IntPtr s)
+        public static bool overafter_timestamptz_set(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_set(t, s));
 
-        public static bool overafter_timestamptz_span(long t, IntPtr s)
+        public static bool overafter_timestamptz_span(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_span(t, s));
 
-        public static bool overafter_timestamptz_spanset(long t, IntPtr ss)
+        public static bool overafter_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overafter_timestamptz_spanset(t, ss));
 
         public static bool overbefore_date_set(int d, IntPtr s)
@@ -1387,37 +1383,37 @@ namespace MEOS.NET.Internal
         public static bool overbefore_set_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_set_date(s, d));
 
-        public static bool overbefore_set_timestamptz(IntPtr s, long t)
+        public static bool overbefore_set_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_set_timestamptz(s, t));
 
         public static bool overbefore_span_date(IntPtr s, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_span_date(s, d));
 
-        public static bool overbefore_span_timestamptz(IntPtr s, long t)
+        public static bool overbefore_span_timestamptz(IntPtr s, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_span_timestamptz(s, t));
 
         public static bool overbefore_spanset_date(IntPtr ss, int d)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_spanset_date(ss, d));
 
-        public static bool overbefore_spanset_timestamptz(IntPtr ss, long t)
+        public static bool overbefore_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_spanset_timestamptz(ss, t));
 
-        public static bool overbefore_timestamptz_set(long t, IntPtr s)
+        public static bool overbefore_timestamptz_set(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_set(t, s));
 
-        public static bool overbefore_timestamptz_span(long t, IntPtr s)
+        public static bool overbefore_timestamptz_span(int t, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_span(t, s));
 
-        public static bool overbefore_timestamptz_spanset(long t, IntPtr ss)
+        public static bool overbefore_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overbefore_timestamptz_spanset(t, ss));
 
-        public static bool overleft_bigint_set(long i, IntPtr s)
+        public static bool overleft_bigint_set(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_set(i, s));
 
-        public static bool overleft_bigint_span(long i, IntPtr s)
+        public static bool overleft_bigint_span(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_span(i, s));
 
-        public static bool overleft_bigint_spanset(long i, IntPtr ss)
+        public static bool overleft_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_bigint_spanset(i, ss));
 
         public static bool overleft_float_set(double d, IntPtr s)
@@ -1438,7 +1434,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_int_spanset(i, ss));
 
-        public static bool overleft_set_bigint(IntPtr s, long i)
+        public static bool overleft_set_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_bigint(s, i));
 
         public static bool overleft_set_float(IntPtr s, double d)
@@ -1453,7 +1449,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_text(s, txt));
 
-        public static bool overleft_span_bigint(IntPtr s, long i)
+        public static bool overleft_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_bigint(s, i));
 
         public static bool overleft_span_float(IntPtr s, double d)
@@ -1468,7 +1464,7 @@ namespace MEOS.NET.Internal
         public static bool overleft_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_spanset(s, ss));
 
-        public static bool overleft_spanset_bigint(IntPtr ss, long i)
+        public static bool overleft_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_spanset_bigint(ss, i));
 
         public static bool overleft_spanset_float(IntPtr ss, double d)
@@ -1486,13 +1482,13 @@ namespace MEOS.NET.Internal
         public static bool overleft_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_text_set(txt, s));
 
-        public static bool overright_bigint_set(long i, IntPtr s)
+        public static bool overright_bigint_set(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_set(i, s));
 
-        public static bool overright_bigint_span(long i, IntPtr s)
+        public static bool overright_bigint_span(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_span(i, s));
 
-        public static bool overright_bigint_spanset(long i, IntPtr ss)
+        public static bool overright_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_bigint_spanset(i, ss));
 
         public static bool overright_float_set(double d, IntPtr s)
@@ -1513,7 +1509,7 @@ namespace MEOS.NET.Internal
         public static bool overright_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_int_spanset(i, ss));
 
-        public static bool overright_set_bigint(IntPtr s, long i)
+        public static bool overright_set_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_bigint(s, i));
 
         public static bool overright_set_float(IntPtr s, double d)
@@ -1528,7 +1524,7 @@ namespace MEOS.NET.Internal
         public static bool overright_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_text(s, txt));
 
-        public static bool overright_span_bigint(IntPtr s, long i)
+        public static bool overright_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_bigint(s, i));
 
         public static bool overright_span_float(IntPtr s, double d)
@@ -1543,7 +1539,7 @@ namespace MEOS.NET.Internal
         public static bool overright_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_spanset(s, ss));
 
-        public static bool overright_spanset_bigint(IntPtr ss, long i)
+        public static bool overright_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_spanset_bigint(ss, i));
 
         public static bool overright_spanset_float(IntPtr ss, double d)
@@ -1561,13 +1557,13 @@ namespace MEOS.NET.Internal
         public static bool overright_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_text_set(txt, s));
 
-        public static bool right_bigint_set(long i, IntPtr s)
+        public static bool right_bigint_set(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_set(i, s));
 
-        public static bool right_bigint_span(long i, IntPtr s)
+        public static bool right_bigint_span(int i, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_span(i, s));
 
-        public static bool right_bigint_spanset(long i, IntPtr ss)
+        public static bool right_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_bigint_spanset(i, ss));
 
         public static bool right_float_set(double d, IntPtr s)
@@ -1588,7 +1584,7 @@ namespace MEOS.NET.Internal
         public static bool right_int_spanset(int i, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_int_spanset(i, ss));
 
-        public static bool right_set_bigint(IntPtr s, long i)
+        public static bool right_set_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_bigint(s, i));
 
         public static bool right_set_float(IntPtr s, double d)
@@ -1603,7 +1599,7 @@ namespace MEOS.NET.Internal
         public static bool right_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_text(s, txt));
 
-        public static bool right_span_bigint(IntPtr s, long i)
+        public static bool right_span_bigint(IntPtr s, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_bigint(s, i));
 
         public static bool right_span_float(IntPtr s, double d)
@@ -1618,7 +1614,7 @@ namespace MEOS.NET.Internal
         public static bool right_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_spanset(s, ss));
 
-        public static bool right_spanset_bigint(IntPtr ss, long i)
+        public static bool right_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_spanset_bigint(ss, i));
 
         public static bool right_spanset_float(IntPtr ss, double d)
@@ -1636,7 +1632,7 @@ namespace MEOS.NET.Internal
         public static bool right_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_text_set(txt, s));
 
-        public static IntPtr intersection_bigint_set(long i, IntPtr s)
+        public static IntPtr intersection_bigint_set(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_bigint_set(i, s));
 
         public static IntPtr intersection_date_set(int d, IntPtr s)
@@ -1648,7 +1644,7 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_int_set(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_int_set(i, s));
 
-        public static IntPtr intersection_set_bigint(IntPtr s, long i)
+        public static IntPtr intersection_set_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_bigint(s, i));
 
         public static IntPtr intersection_set_date(IntPtr s, int d)
@@ -1666,10 +1662,10 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_text(s, txt));
 
-        public static IntPtr intersection_set_timestamptz(IntPtr s, long t)
+        public static IntPtr intersection_set_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_timestamptz(s, t));
 
-        public static IntPtr intersection_span_bigint(IntPtr s, long i)
+        public static IntPtr intersection_span_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_bigint(s, i));
 
         public static IntPtr intersection_span_date(IntPtr s, int d)
@@ -1687,10 +1683,10 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_spanset(s, ss));
 
-        public static IntPtr intersection_span_timestamptz(IntPtr s, long t)
+        public static IntPtr intersection_span_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_timestamptz(s, t));
 
-        public static IntPtr intersection_spanset_bigint(IntPtr ss, long i)
+        public static IntPtr intersection_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_bigint(ss, i));
 
         public static IntPtr intersection_spanset_date(IntPtr ss, int d)
@@ -1708,22 +1704,22 @@ namespace MEOS.NET.Internal
         public static IntPtr intersection_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_spanset(ss1, ss2));
 
-        public static IntPtr intersection_spanset_timestamptz(IntPtr ss, long t)
+        public static IntPtr intersection_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_timestamptz(ss, t));
 
         public static IntPtr intersection_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_text_set(txt, s));
 
-        public static IntPtr intersection_timestamptz_set(long t, IntPtr s)
+        public static IntPtr intersection_timestamptz_set(int t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_timestamptz_set(t, s));
 
-        public static IntPtr minus_bigint_set(long i, IntPtr s)
+        public static IntPtr minus_bigint_set(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_set(i, s));
 
-        public static IntPtr minus_bigint_span(long i, IntPtr s)
+        public static IntPtr minus_bigint_span(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_span(i, s));
 
-        public static IntPtr minus_bigint_spanset(long i, IntPtr ss)
+        public static IntPtr minus_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_bigint_spanset(i, ss));
 
         public static IntPtr minus_date_set(int d, IntPtr s)
@@ -1753,7 +1749,7 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_int_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_int_spanset(i, ss));
 
-        public static IntPtr minus_set_bigint(IntPtr s, long i)
+        public static IntPtr minus_set_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_bigint(s, i));
 
         public static IntPtr minus_set_date(IntPtr s, int d)
@@ -1771,10 +1767,10 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_text(s, txt));
 
-        public static IntPtr minus_set_timestamptz(IntPtr s, long t)
+        public static IntPtr minus_set_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_timestamptz(s, t));
 
-        public static IntPtr minus_span_bigint(IntPtr s, long i)
+        public static IntPtr minus_span_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_bigint(s, i));
 
         public static IntPtr minus_span_date(IntPtr s, int d)
@@ -1792,10 +1788,10 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_spanset(s, ss));
 
-        public static IntPtr minus_span_timestamptz(IntPtr s, long t)
+        public static IntPtr minus_span_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_timestamptz(s, t));
 
-        public static IntPtr minus_spanset_bigint(IntPtr ss, long i)
+        public static IntPtr minus_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_bigint(ss, i));
 
         public static IntPtr minus_spanset_date(IntPtr ss, int d)
@@ -1813,28 +1809,28 @@ namespace MEOS.NET.Internal
         public static IntPtr minus_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_spanset(ss1, ss2));
 
-        public static IntPtr minus_spanset_timestamptz(IntPtr ss, long t)
+        public static IntPtr minus_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_timestamptz(ss, t));
 
         public static IntPtr minus_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_text_set(txt, s));
 
-        public static IntPtr minus_timestamptz_set(long t, IntPtr s)
+        public static IntPtr minus_timestamptz_set(int t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_set(t, s));
 
-        public static IntPtr minus_timestamptz_span(long t, IntPtr s)
+        public static IntPtr minus_timestamptz_span(int t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_span(t, s));
 
-        public static IntPtr minus_timestamptz_spanset(long t, IntPtr ss)
+        public static IntPtr minus_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_timestamptz_spanset(t, ss));
 
-        public static IntPtr union_bigint_set(long i, IntPtr s)
+        public static IntPtr union_bigint_set(int i, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_set(i, s));
 
-        public static IntPtr union_bigint_span(IntPtr s, long i)
+        public static IntPtr union_bigint_span(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_span(s, i));
 
-        public static IntPtr union_bigint_spanset(long i, IntPtr ss)
+        public static IntPtr union_bigint_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_bigint_spanset(i, ss));
 
         public static IntPtr union_date_set(int d, IntPtr s)
@@ -1864,7 +1860,7 @@ namespace MEOS.NET.Internal
         public static IntPtr union_int_spanset(int i, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_int_spanset(i, ss));
 
-        public static IntPtr union_set_bigint(IntPtr s, long i)
+        public static IntPtr union_set_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_bigint(s, i));
 
         public static IntPtr union_set_date(IntPtr s, int d)
@@ -1882,10 +1878,10 @@ namespace MEOS.NET.Internal
         public static IntPtr union_set_text(IntPtr s, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_text(s, txt));
 
-        public static IntPtr union_set_timestamptz(IntPtr s, long t)
+        public static IntPtr union_set_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_timestamptz(s, t));
 
-        public static IntPtr union_span_bigint(IntPtr s, long i)
+        public static IntPtr union_span_bigint(IntPtr s, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_bigint(s, i));
 
         public static IntPtr union_span_date(IntPtr s, int d)
@@ -1903,10 +1899,10 @@ namespace MEOS.NET.Internal
         public static IntPtr union_span_spanset(IntPtr s, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_spanset(s, ss));
 
-        public static IntPtr union_span_timestamptz(IntPtr s, long t)
+        public static IntPtr union_span_timestamptz(IntPtr s, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_timestamptz(s, t));
 
-        public static IntPtr union_spanset_bigint(IntPtr ss, long i)
+        public static IntPtr union_spanset_bigint(IntPtr ss, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_bigint(ss, i));
 
         public static IntPtr union_spanset_date(IntPtr ss, int d)
@@ -1924,32 +1920,32 @@ namespace MEOS.NET.Internal
         public static IntPtr union_spanset_spanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_spanset(ss1, ss2));
 
-        public static IntPtr union_spanset_timestamptz(IntPtr ss, long t)
+        public static IntPtr union_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_timestamptz(ss, t));
 
         public static IntPtr union_text_set(IntPtr txt, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_text_set(txt, s));
 
-        public static IntPtr union_timestamptz_set(long t, IntPtr s)
+        public static IntPtr union_timestamptz_set(int t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_set(t, s));
 
-        public static IntPtr union_timestamptz_span(long t, IntPtr s)
+        public static IntPtr union_timestamptz_span(int t, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_span(t, s));
 
-        public static IntPtr union_timestamptz_spanset(long t, IntPtr ss)
+        public static IntPtr union_timestamptz_spanset(int t, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_timestamptz_spanset(t, ss));
 
-        public static long distance_bigintset_bigintset(IntPtr s1, IntPtr s2)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintset_bigintset(s1, s2));
+        public static int distance_bigintset_bigintset(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintset_bigintset(s1, s2));
 
-        public static long distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspan_bigintspan(s1, s2));
+        public static int distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspan_bigintspan(s1, s2));
 
-        public static long distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspan(ss, s));
+        public static int distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspan(ss, s));
 
-        public static long distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspanset(ss1, ss2));
+        public static int distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_bigintspanset_bigintspanset(ss1, ss2));
 
         public static int distance_dateset_dateset(IntPtr s1, IntPtr s2)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_dateset_dateset(s1, s2));
@@ -1987,8 +1983,8 @@ namespace MEOS.NET.Internal
         public static int distance_intspanset_intspanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_intspanset_intspanset(ss1, ss2));
 
-        public static long distance_set_bigint(IntPtr s, long i)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_set_bigint(s, i));
+        public static int distance_set_bigint(IntPtr s, int i)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_bigint(s, i));
 
         public static int distance_set_date(IntPtr s, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_date(s, d));
@@ -1999,11 +1995,11 @@ namespace MEOS.NET.Internal
         public static int distance_set_int(IntPtr s, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_int(s, i));
 
-        public static double distance_set_timestamptz(IntPtr s, long t)
+        public static double distance_set_timestamptz(IntPtr s, int t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_set_timestamptz(s, t));
 
-        public static long distance_span_bigint(IntPtr s, long i)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_span_bigint(s, i));
+        public static int distance_span_bigint(IntPtr s, int i)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_bigint(s, i));
 
         public static int distance_span_date(IntPtr s, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_date(s, d));
@@ -2014,11 +2010,11 @@ namespace MEOS.NET.Internal
         public static int distance_span_int(IntPtr s, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_int(s, i));
 
-        public static double distance_span_timestamptz(IntPtr s, long t)
+        public static double distance_span_timestamptz(IntPtr s, int t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_span_timestamptz(s, t));
 
-        public static long distance_spanset_bigint(IntPtr ss, long i)
-            => SafeExecution<long>(() => MEOSExternalFunctions.distance_spanset_bigint(ss, i));
+        public static int distance_spanset_bigint(IntPtr ss, int i)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_bigint(ss, i));
 
         public static int distance_spanset_date(IntPtr ss, int d)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_date(ss, d));
@@ -2029,7 +2025,7 @@ namespace MEOS.NET.Internal
         public static int distance_spanset_int(IntPtr ss, int i)
             => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_int(ss, i));
 
-        public static double distance_spanset_timestamptz(IntPtr ss, long t)
+        public static double distance_spanset_timestamptz(IntPtr ss, int t)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_spanset_timestamptz(ss, t));
 
         public static double distance_tstzset_tstzset(IntPtr s1, IntPtr s2)
@@ -2044,10 +2040,10 @@ namespace MEOS.NET.Internal
         public static double distance_tstzspanset_tstzspanset(IntPtr ss1, IntPtr ss2)
             => SafeExecution<double>(() => MEOSExternalFunctions.distance_tstzspanset_tstzspanset(ss1, ss2));
 
-        public static IntPtr bigint_extent_transfn(IntPtr state, long i)
+        public static IntPtr bigint_extent_transfn(IntPtr state, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_extent_transfn(state, i));
 
-        public static IntPtr bigint_union_transfn(IntPtr state, long i)
+        public static IntPtr bigint_union_transfn(IntPtr state, int i)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigint_union_transfn(state, i));
 
         public static IntPtr date_extent_transfn(IntPtr state, int d)
@@ -2095,19 +2091,19 @@ namespace MEOS.NET.Internal
         public static IntPtr text_union_transfn(IntPtr state, IntPtr txt)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.text_union_transfn(state, txt));
 
-        public static IntPtr timestamptz_extent_transfn(IntPtr state, long t)
+        public static IntPtr timestamptz_extent_transfn(IntPtr state, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_extent_transfn(state, t));
 
-        public static IntPtr timestamptz_union_transfn(IntPtr state, long t)
+        public static IntPtr timestamptz_union_transfn(IntPtr state, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_union_transfn(state, t));
 
-        public static long bigint_get_bin(long value, long vsize, long vorigin)
-            => SafeExecution<long>(() => MEOSExternalFunctions.bigint_get_bin(value, vsize, vorigin));
+        public static int bigint_get_bin(int value, int vsize, int vorigin)
+            => SafeExecution<int>(() => MEOSExternalFunctions.bigint_get_bin(value, vsize, vorigin));
 
-        public static IntPtr bigintspan_bins(IntPtr s, long vsize, long vorigin, IntPtr count)
+        public static IntPtr bigintspan_bins(IntPtr s, int vsize, int vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspan_bins(s, vsize, vorigin, count));
 
-        public static IntPtr bigintspanset_bins(IntPtr ss, long vsize, long vorigin, IntPtr count)
+        public static IntPtr bigintspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bigintspanset_bins(ss, vsize, vorigin, count));
 
         public static int date_get_bin(int d, IntPtr duration, int torigin)
@@ -2137,13 +2133,13 @@ namespace MEOS.NET.Internal
         public static IntPtr intspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intspanset_bins(ss, vsize, vorigin, count));
 
-        public static long timestamptz_get_bin(long t, IntPtr duration, long torigin)
-            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_get_bin(t, duration, torigin));
+        public static int timestamptz_get_bin(int t, IntPtr duration, int torigin)
+            => SafeExecution<int>(() => MEOSExternalFunctions.timestamptz_get_bin(t, duration, torigin));
 
-        public static IntPtr tstzspan_bins(IntPtr s, IntPtr duration, long origin, IntPtr count)
+        public static IntPtr tstzspan_bins(IntPtr s, IntPtr duration, int origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspan_bins(s, duration, origin, count));
 
-        public static IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, long torigin, IntPtr count)
+        public static IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstzspanset_bins(ss, duration, torigin, count));
 
         public static string tbox_as_hexwkb(IntPtr box, IntPtr variant, IntPtr size)
@@ -2164,13 +2160,13 @@ namespace MEOS.NET.Internal
         public static string tbox_out(IntPtr box, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.tbox_out(box, maxdd));
 
-        public static IntPtr float_timestamptz_to_tbox(double d, long t)
+        public static IntPtr float_timestamptz_to_tbox(double d, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.float_timestamptz_to_tbox(d, t));
 
         public static IntPtr float_tstzspan_to_tbox(double d, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.float_tstzspan_to_tbox(d, s));
 
-        public static IntPtr int_timestamptz_to_tbox(int i, long t)
+        public static IntPtr int_timestamptz_to_tbox(int i, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.int_timestamptz_to_tbox(i, t));
 
         public static IntPtr int_tstzspan_to_tbox(int i, IntPtr s)
@@ -2179,7 +2175,7 @@ namespace MEOS.NET.Internal
         public static IntPtr numspan_tstzspan_to_tbox(IntPtr span, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_tstzspan_to_tbox(span, s));
 
-        public static IntPtr numspan_timestamptz_to_tbox(IntPtr span, long t)
+        public static IntPtr numspan_timestamptz_to_tbox(IntPtr span, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_timestamptz_to_tbox(span, t));
 
         public static IntPtr tbox_copy(IntPtr box)
@@ -2212,14 +2208,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tbox_to_tstzspan(IntPtr box)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_to_tstzspan(box));
 
-        public static IntPtr timestamptz_to_tbox(long t)
+        public static IntPtr timestamptz_to_tbox(int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_tbox(t));
 
-        public static uint tbox_hash(IntPtr box)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.tbox_hash(box));
+        public static int tbox_hash(IntPtr box)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tbox_hash(box));
 
-        public static ulong tbox_hash_extended(IntPtr box, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tbox_hash_extended(box, seed));
+        public static int tbox_hash_extended(IntPtr box, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tbox_hash_extended(box, seed));
 
         public static bool tbox_hast(IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_hast(box));
@@ -2404,7 +2400,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tbool_from_base_temp(bool b, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbool_from_base_temp(b, temp));
 
-        public static IntPtr tboolinst_make(bool b, long t)
+        public static IntPtr tboolinst_make(bool b, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tboolinst_make(b, t));
 
         public static IntPtr tboolseq_from_base_tstzset(bool b, IntPtr s)
@@ -2422,7 +2418,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tfloat_from_base_temp(double d, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_from_base_temp(d, temp));
 
-        public static IntPtr tfloatinst_make(double d, long t)
+        public static IntPtr tfloatinst_make(double d, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatinst_make(d, t));
 
         public static IntPtr tfloatseq_from_base_tstzset(double d, IntPtr s)
@@ -2437,7 +2433,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tint_from_base_temp(int i, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_from_base_temp(i, temp));
 
-        public static IntPtr tintinst_make(int i, long t)
+        public static IntPtr tintinst_make(int i, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintinst_make(i, t));
 
         public static IntPtr tintseq_from_base_tstzset(int i, IntPtr s)
@@ -2461,7 +2457,7 @@ namespace MEOS.NET.Internal
         public static IntPtr ttext_from_base_temp(IntPtr txt, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttext_from_base_temp(txt, temp));
 
-        public static IntPtr ttextinst_make(IntPtr txt, long t)
+        public static IntPtr ttextinst_make(IntPtr txt, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttextinst_make(txt, t));
 
         public static IntPtr ttextseq_from_base_tstzset(IntPtr txt, IntPtr s)
@@ -2497,7 +2493,7 @@ namespace MEOS.NET.Internal
         public static bool tbool_start_value(IntPtr temp)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbool_start_value(temp));
 
-        public static bool tbool_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
+        public static bool tbool_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tbool_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tbool_value_n(IntPtr temp, int n, IntPtr result)
@@ -2515,11 +2511,11 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_end_sequence(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_end_sequence(temp));
 
-        public static long temporal_end_timestamptz(IntPtr temp)
-            => SafeExecution<long>(() => MEOSExternalFunctions.temporal_end_timestamptz(temp));
+        public static int temporal_end_timestamptz(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_end_timestamptz(temp));
 
-        public static uint temporal_hash(IntPtr temp)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.temporal_hash(temp));
+        public static int temporal_hash(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_hash(temp));
 
         public static IntPtr temporal_instant_n(IntPtr temp, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_instant_n(temp, n));
@@ -2566,8 +2562,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_start_sequence(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_start_sequence(temp));
 
-        public static long temporal_start_timestamptz(IntPtr temp)
-            => SafeExecution<long>(() => MEOSExternalFunctions.temporal_start_timestamptz(temp));
+        public static int temporal_start_timestamptz(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_start_timestamptz(temp));
 
         public static IntPtr temporal_stops(IntPtr temp, double maxdist, IntPtr minduration)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_stops(temp, maxdist, minduration));
@@ -2602,7 +2598,7 @@ namespace MEOS.NET.Internal
         public static double tfloat_start_value(IntPtr temp)
             => SafeExecution<double>(() => MEOSExternalFunctions.tfloat_start_value(temp));
 
-        public static bool tfloat_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
+        public static bool tfloat_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tfloat_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tfloat_value_n(IntPtr temp, int n, IntPtr result)
@@ -2623,7 +2619,7 @@ namespace MEOS.NET.Internal
         public static int tint_start_value(IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.tint_start_value(temp));
 
-        public static bool tint_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
+        public static bool tint_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tint_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tint_value_n(IntPtr temp, int n, IntPtr result)
@@ -2656,7 +2652,7 @@ namespace MEOS.NET.Internal
         public static IntPtr ttext_start_value(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttext_start_value(temp));
 
-        public static bool ttext_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
+        public static bool ttext_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.ttext_value_at_timestamptz(temp, t, strict, value));
 
         public static bool ttext_value_n(IntPtr temp, int n, IntPtr result)
@@ -2731,7 +2727,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_append_tsequence(IntPtr temp, IntPtr seq, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_append_tsequence(temp, seq, expand));
 
-        public static IntPtr temporal_delete_timestamptz(IntPtr temp, long t, bool connect)
+        public static IntPtr temporal_delete_timestamptz(IntPtr temp, int t, bool connect)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_delete_timestamptz(temp, t, connect));
 
         public static IntPtr temporal_delete_tstzset(IntPtr temp, IntPtr s, bool connect)
@@ -2761,7 +2757,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tbool_minus_value(IntPtr temp, bool b)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbool_minus_value(temp, b));
 
-        public static IntPtr temporal_after_timestamptz(IntPtr temp, long t, bool strict)
+        public static IntPtr temporal_after_timestamptz(IntPtr temp, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_after_timestamptz(temp, t, strict));
 
         public static IntPtr temporal_at_max(IntPtr temp)
@@ -2770,7 +2766,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_at_min(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_min(temp));
 
-        public static IntPtr temporal_at_timestamptz(IntPtr temp, long t)
+        public static IntPtr temporal_at_timestamptz(IntPtr temp, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_timestamptz(temp, t));
 
         public static IntPtr temporal_at_tstzset(IntPtr temp, IntPtr s)
@@ -2785,7 +2781,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_at_values(IntPtr temp, IntPtr set)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_at_values(temp, set));
 
-        public static IntPtr temporal_before_timestamptz(IntPtr temp, long t, bool strict)
+        public static IntPtr temporal_before_timestamptz(IntPtr temp, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_before_timestamptz(temp, t, strict));
 
         public static IntPtr temporal_minus_max(IntPtr temp)
@@ -2794,7 +2790,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_minus_min(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_minus_min(temp));
 
-        public static IntPtr temporal_minus_timestamptz(IntPtr temp, long t)
+        public static IntPtr temporal_minus_timestamptz(IntPtr temp, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_minus_timestamptz(temp, t));
 
         public static IntPtr temporal_minus_tstzset(IntPtr temp, IntPtr s)
@@ -3721,6 +3717,12 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_extent_transfn(IntPtr s, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_extent_transfn(s, temp));
 
+        public static IntPtr temporal_merge_transfn(IntPtr state, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_merge_transfn(state, temp));
+
+        public static IntPtr temporal_merge_combinefn(IntPtr state1, IntPtr state2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_merge_combinefn(state1, state2));
+
         public static IntPtr temporal_tagg_finalfn(IntPtr state)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_finalfn(state));
 
@@ -3745,7 +3747,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tfloat_wsum_transfn(IntPtr state, IntPtr temp, IntPtr interv)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_wsum_transfn(state, temp, interv));
 
-        public static IntPtr timestamptz_tcount_transfn(IntPtr state, long t)
+        public static IntPtr timestamptz_tcount_transfn(IntPtr state, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_tcount_transfn(state, t));
 
         public static IntPtr tint_tmax_transfn(IntPtr state, IntPtr temp)
@@ -3805,10 +3807,10 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_simplify_min_tdelta(IntPtr temp, IntPtr mint)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_simplify_min_tdelta(temp, mint));
 
-        public static IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, long origin)
+        public static IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, int origin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tprecision(temp, duration, origin));
 
-        public static IntPtr temporal_tsample(IntPtr temp, IntPtr duration, long origin, int interp)
+        public static IntPtr temporal_tsample(IntPtr temp, IntPtr duration, int origin, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tsample(temp, duration, origin, interp));
 
         public static double temporal_dyntimewarp_distance(IntPtr temp1, IntPtr temp2)
@@ -3826,10 +3828,10 @@ namespace MEOS.NET.Internal
         public static double temporal_hausdorff_distance(IntPtr temp1, IntPtr temp2)
             => SafeExecution<double>(() => MEOSExternalFunctions.temporal_hausdorff_distance(temp1, temp2));
 
-        public static IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, long origin, IntPtr count)
+        public static IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, int origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_time_bins(temp, duration, origin, count));
 
-        public static (IntPtr[], long[]) temporal_time_split(IntPtr temp, IntPtr duration, long torigin)
+        public static (IntPtr[], int[]) temporal_time_split(IntPtr temp, IntPtr duration, int torigin)
         {
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _count_count = Marshal.AllocHGlobal(sizeof(int));
@@ -3841,7 +3843,7 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                long[] __out_time_bins_out = new long[_n];
+                int[] __out_time_bins_out = new int[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_time_bins_out);
             }
@@ -3852,7 +3854,7 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count)
+        public static IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_time_boxes(temp, duration, torigin, count));
 
         public static IntPtr tfloat_value_bins(IntPtr temp, double vsize, double vorigin, IntPtr count)
@@ -3884,10 +3886,10 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count)
+        public static IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloat_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static (IntPtr[], double[], long[]) tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin)
+        public static (IntPtr[], double[], int[]) tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin)
         {
             IntPtr _out_value_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -3903,7 +3905,7 @@ namespace MEOS.NET.Internal
                 double[] __out_value_bins_out = new double[_n];
                 Marshal.Copy(__out_value_bins_arr, __out_value_bins_out, 0, _n);
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                long[] __out_time_bins_out = new long[_n];
+                int[] __out_time_bins_out = new int[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_value_bins_out, __out_time_bins_out);
             }
@@ -3915,16 +3917,16 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count)
+        public static IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_time_tiles(box, duration, torigin, count));
 
         public static IntPtr tfloatbox_value_tiles(IntPtr box, double vsize, double vorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_value_tiles(box, vsize, vorigin, count));
 
-        public static IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count)
+        public static IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfloatbox_value_time_tiles(box, vsize, duration, vorigin, torigin, count));
 
-        public static IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count)
+        public static IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_time_boxes(temp, duration, torigin, count));
 
         public static IntPtr tint_value_bins(IntPtr temp, int vsize, int vorigin, IntPtr count)
@@ -3956,10 +3958,10 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, long torigin, IntPtr count)
+        public static IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tint_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static (IntPtr[], int[], long[]) tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, long torigin)
+        public static (IntPtr[], int[], int[]) tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, int torigin)
         {
             IntPtr _out_value_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -3975,7 +3977,7 @@ namespace MEOS.NET.Internal
                 int[] __out_value_bins_out = new int[_n];
                 Marshal.Copy(__out_value_bins_arr, __out_value_bins_out, 0, _n);
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                long[] __out_time_bins_out = new long[_n];
+                int[] __out_time_bins_out = new int[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_value_bins_out, __out_time_bins_out);
             }
@@ -3987,239 +3989,14 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count)
+        public static IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_time_tiles(box, duration, torigin, count));
 
         public static IntPtr tintbox_value_tiles(IntPtr box, int xsize, int xorigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_value_tiles(box, xsize, xorigin, count));
 
-        public static IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, long torigin, IntPtr count)
+        public static IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintbox_value_time_tiles(box, xsize, duration, xorigin, torigin, count));
-
-        public static bool temptype_subtype(int subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype(subtype));
-
-        public static bool temptype_subtype_all(int subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype_all(subtype));
-
-        public static string tempsubtype_name(int subtype)
-            => SafeExecution<string>(() => MEOSExternalFunctions.tempsubtype_name(subtype));
-
-        public static bool tempsubtype_from_string(string str, IntPtr subtype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tempsubtype_from_string(str, subtype));
-
-        public static string meosoper_name(IntPtr oper)
-            => SafeExecution<string>(() => MEOSExternalFunctions.meosoper_name(oper));
-
-        public static IntPtr meosoper_from_string(string name)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meosoper_from_string(name));
-
-        public static string interptype_name(int interp)
-            => SafeExecution<string>(() => MEOSExternalFunctions.interptype_name(interp));
-
-        public static int interptype_from_string(string interp_str)
-            => SafeExecution<int>(() => MEOSExternalFunctions.interptype_from_string(interp_str));
-
-        public static string meostype_name(int type)
-            => SafeExecution<string>(() => MEOSExternalFunctions.meostype_name(type));
-
-        public static int temptype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.temptype_basetype(type));
-
-        public static int settype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.settype_basetype(type));
-
-        public static int spantype_basetype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_basetype(type));
-
-        public static int spantype_spansettype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_spansettype(type));
-
-        public static int spansettype_spantype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.spansettype_spantype(type));
-
-        public static int basetype_spantype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_spantype(type));
-
-        public static int basetype_settype(int type)
-            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_settype(type));
-
-        public static bool tnumber_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_basetype(type));
-
-        public static bool geo_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_basetype(type));
-
-        public static bool meos_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.meos_basetype(type));
-
-        public static bool alphanum_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_basetype(type));
-
-        public static bool alphanum_temptype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_temptype(type));
-
-        public static bool time_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.time_type(type));
-
-        public static bool set_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_basetype(type));
-
-        public static bool set_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_type(type));
-
-        public static bool numset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numset_type(type));
-
-        public static bool ensure_numset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numset_type(type));
-
-        public static bool timeset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timeset_type(type));
-
-        public static bool set_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.set_spantype(type));
-
-        public static bool ensure_set_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_spantype(type));
-
-        public static bool alphanumset_type(int settype)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanumset_type(settype));
-
-        public static bool geoset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_type(type));
-
-        public static bool ensure_geoset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoset_type(type));
-
-        public static bool spatialset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spatialset_type(type));
-
-        public static bool ensure_spatialset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatialset_type(type));
-
-        public static bool span_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_basetype(type));
-
-        public static bool span_canon_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_canon_basetype(type));
-
-        public static bool span_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_type(type));
-
-        public static bool type_span_bbox(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.type_span_bbox(type));
-
-        public static bool span_tbox_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.span_tbox_type(type));
-
-        public static bool ensure_span_tbox_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_tbox_type(type));
-
-        public static bool numspan_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_basetype(type));
-
-        public static bool numspan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_type(type));
-
-        public static bool ensure_numspan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numspan_type(type));
-
-        public static bool timespan_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_basetype(type));
-
-        public static bool timespan_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_type(type));
-
-        public static bool spanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_type(type));
-
-        public static bool timespanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.timespanset_type(type));
-
-        public static bool ensure_timespanset_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_timespanset_type(type));
-
-        public static bool temporal_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_type(type));
-
-        public static bool temporal_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_basetype(type));
-
-        public static bool temptype_continuous(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_continuous(type));
-
-        public static bool basetype_byvalue(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_byvalue(type));
-
-        public static bool basetype_varlength(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_varlength(type));
-
-        public static short basetype_length(int type)
-            => SafeExecution<short>(() => MEOSExternalFunctions.basetype_length(type));
-
-        public static bool talphanum_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.talphanum_type(type));
-
-        public static bool talpha_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.talpha_type(type));
-
-        public static bool tnumber_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_type(type));
-
-        public static bool ensure_tnumber_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_type(type));
-
-        public static bool ensure_tnumber_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_basetype(type));
-
-        public static bool tnumber_spantype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_spantype(type));
-
-        public static bool spatial_basetype(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_basetype(type));
-
-        public static bool tspatial_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tspatial_type(type));
-
-        public static bool ensure_tspatial_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tspatial_type(type));
-
-        public static bool tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_type(type));
-
-        public static bool ensure_tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tpoint_type(type));
-
-        public static bool tgeo_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type(type));
-
-        public static bool ensure_tgeo_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type(type));
-
-        public static bool tgeo_type_all(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type_all(type));
-
-        public static bool ensure_tgeo_type_all(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type_all(type));
-
-        public static bool tgeometry_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeometry_type(type));
-
-        public static bool ensure_tgeometry_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeometry_type(type));
-
-        public static bool tgeodetic_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeodetic_type(type));
-
-        public static bool ensure_tgeodetic_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeodetic_type(type));
-
-        public static bool ensure_tnumber_tpoint_type(int type)
-            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_tpoint_type(type));
-
-        public static int geo_get_srid(IntPtr g)
-            => SafeExecution<int>(() => MEOSExternalFunctions.geo_get_srid(g));
 
         public static IntPtr geo_as_ewkb(IntPtr gs, string endian, IntPtr size)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_as_ewkb(gs, endian, size));
@@ -4500,13 +4277,12 @@ namespace MEOS.NET.Internal
         public static bool geoset_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_value_n(s, n, result));
 
-        public static IntPtr[] geoset_values(IntPtr s)
+        public static int[] geoset_values(IntPtr s)
         {
             int _n = (int)MEOSExposedFunctions.set_num_values(s);
             IntPtr _p = SafeExecution<IntPtr>(() => MEOSExternalFunctions.geoset_values(s));
-            IntPtr[] _out = new IntPtr[_n];
-            for (int _i = 0; _i < _n; _i++)
-            { _out[_i] = Marshal.ReadIntPtr(_p, _i * IntPtr.Size); }
+            int[] _out = new int[_n];
+            Marshal.Copy(_p, _out, 0, _n);
             return _out;
         }
 
@@ -4567,7 +4343,7 @@ namespace MEOS.NET.Internal
         public static string stbox_out(IntPtr box, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.stbox_out(box, maxdd));
 
-        public static IntPtr geo_timestamptz_to_stbox(IntPtr gs, long t)
+        public static IntPtr geo_timestamptz_to_stbox(IntPtr gs, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_timestamptz_to_stbox(gs, t));
 
         public static IntPtr geo_tstzspan_to_stbox(IntPtr gs, IntPtr s)
@@ -4597,7 +4373,7 @@ namespace MEOS.NET.Internal
         public static IntPtr stbox_to_tstzspan(IntPtr box)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_to_tstzspan(box));
 
-        public static IntPtr timestamptz_to_stbox(long t)
+        public static IntPtr timestamptz_to_stbox(int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.timestamptz_to_stbox(t));
 
         public static IntPtr tstzset_to_stbox(IntPtr s)
@@ -4612,11 +4388,11 @@ namespace MEOS.NET.Internal
         public static double stbox_area(IntPtr box, bool spheroid)
             => SafeExecution<double>(() => MEOSExternalFunctions.stbox_area(box, spheroid));
 
-        public static uint stbox_hash(IntPtr box)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.stbox_hash(box));
+        public static int stbox_hash(IntPtr box)
+            => SafeExecution<int>(() => MEOSExternalFunctions.stbox_hash(box));
 
-        public static ulong stbox_hash_extended(IntPtr box, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.stbox_hash_extended(box, seed));
+        public static int stbox_hash_extended(IntPtr box, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.stbox_hash_extended(box, seed));
 
         public static bool stbox_hast(IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_hast(box));
@@ -4825,7 +4601,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_from_base_temp(IntPtr gs, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_from_base_temp(gs, temp));
 
-        public static IntPtr tgeoinst_make(IntPtr gs, long t)
+        public static IntPtr tgeoinst_make(IntPtr gs, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoinst_make(gs, t));
 
         public static IntPtr tgeoseq_from_base_tstzset(IntPtr gs, IntPtr s)
@@ -4840,7 +4616,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tpoint_from_base_temp(IntPtr gs, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_from_base_temp(gs, temp));
 
-        public static IntPtr tpointinst_make(IntPtr gs, long t)
+        public static IntPtr tpointinst_make(IntPtr gs, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointinst_make(gs, t));
 
         public static IntPtr tpointseq_from_base_tstzset(IntPtr gs, IntPtr s)
@@ -4882,7 +4658,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeompoint_to_tgeometry(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompoint_to_tgeometry(temp));
 
-        public static (IntPtr[], long[]) tpoint_as_mvtgeom(IntPtr temp, IntPtr bounds, int extent, int buffer, bool clip_geom)
+        public static (int[], int[]) tpoint_as_mvtgeom(IntPtr temp, IntPtr bounds, int extent, int buffer, bool clip_geom)
         {
             IntPtr _out_gsarr = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_timesarr = Marshal.AllocHGlobal(IntPtr.Size);
@@ -4892,11 +4668,10 @@ namespace MEOS.NET.Internal
                 SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_as_mvtgeom(temp, bounds, extent, buffer, clip_geom, _out_gsarr, _out_timesarr, _count_count));
                 int _n = Marshal.ReadInt32(_count_count);
                 IntPtr __out_gsarr_arr = Marshal.ReadIntPtr(_out_gsarr);
-                IntPtr[] __out_gsarr_out = new IntPtr[_n];
-                for (int _i = 0; _i < _n; _i++)
-                { __out_gsarr_out[_i] = Marshal.ReadIntPtr(__out_gsarr_arr, _i * IntPtr.Size); }
+                int[] __out_gsarr_out = new int[_n];
+                Marshal.Copy(__out_gsarr_arr, __out_gsarr_out, 0, _n);
                 IntPtr __out_timesarr_arr = Marshal.ReadIntPtr(_out_timesarr);
-                long[] __out_timesarr_out = new long[_n];
+                int[] __out_timesarr_out = new int[_n];
                 Marshal.Copy(__out_timesarr_arr, __out_timesarr_out, 0, _n);
                 return (__out_gsarr_out, __out_timesarr_out);
             }
@@ -4938,7 +4713,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_traversed_area(IntPtr temp, bool unary_union)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_traversed_area(temp, unary_union));
 
-        public static bool tgeo_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr value)
+        public static bool tgeo_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_value_at_timestamptz(temp, t, strict, value));
 
         public static bool tgeo_value_n(IntPtr temp, int n, IntPtr result)
@@ -5022,14 +4797,20 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_minus_value(IntPtr temp, IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_minus_value(temp, gs));
 
-        public static IntPtr tpoint_at_geom(IntPtr temp, IntPtr gs, IntPtr zspan)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_geom(temp, gs, zspan));
+        public static IntPtr tpoint_at_elevation(IntPtr temp, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_elevation(temp, s));
+
+        public static IntPtr tpoint_at_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_geom(temp, gs));
 
         public static IntPtr tpoint_at_value(IntPtr temp, IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_value(temp, gs));
 
-        public static IntPtr tpoint_minus_geom(IntPtr temp, IntPtr gs, IntPtr zspan)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_minus_geom(temp, gs, zspan));
+        public static IntPtr tpoint_minus_elevation(IntPtr temp, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_minus_elevation(temp, s));
+
+        public static IntPtr tpoint_minus_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_minus_geom(temp, gs));
 
         public static IntPtr tpoint_minus_value(IntPtr temp, IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_minus_value(temp, gs));
@@ -5088,7 +4869,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tgeo_space_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_boxes(temp, xsize, ysize, zsize, sorigin, bitmatrix, border_inc, count));
 
-        public static IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool bitmatrix, bool border_inc, IntPtr count)
+        public static IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_time_boxes(temp, xsize, ysize, zsize, duration, sorigin, torigin, bitmatrix, border_inc, count));
 
         public static IntPtr tgeo_split_each_n_stboxes(IntPtr temp, int elem_count, IntPtr count)
@@ -5367,59 +5148,59 @@ namespace MEOS.NET.Internal
         public static int etouches_tpoint_geo(IntPtr temp, IntPtr gs)
             => SafeExecution<int>(() => MEOSExternalFunctions.etouches_tpoint_geo(temp, gs));
 
-        public static IntPtr tcontains_geo_tgeo(IntPtr gs, IntPtr temp, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_geo_tgeo(gs, temp, restr, atvalue));
+        public static IntPtr tcontains_geo_tgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_geo_tgeo(gs, temp));
 
-        public static IntPtr tcontains_tgeo_geo(IntPtr temp, IntPtr gs, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tgeo_geo(temp, gs, restr, atvalue));
+        public static IntPtr tcontains_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tgeo_geo(temp, gs));
 
-        public static IntPtr tcontains_tgeo_tgeo(IntPtr temp1, IntPtr temp2, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tgeo_tgeo(temp1, temp2, restr, atvalue));
+        public static IntPtr tcontains_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tgeo_tgeo(temp1, temp2));
 
-        public static IntPtr tcovers_geo_tgeo(IntPtr gs, IntPtr temp, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_geo_tgeo(gs, temp, restr, atvalue));
+        public static IntPtr tcovers_geo_tgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_geo_tgeo(gs, temp));
 
-        public static IntPtr tcovers_tgeo_geo(IntPtr temp, IntPtr gs, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tgeo_geo(temp, gs, restr, atvalue));
+        public static IntPtr tcovers_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tgeo_geo(temp, gs));
 
-        public static IntPtr tcovers_tgeo_tgeo(IntPtr temp1, IntPtr temp2, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tgeo_tgeo(temp1, temp2, restr, atvalue));
+        public static IntPtr tcovers_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tgeo_tgeo(temp1, temp2));
 
-        public static IntPtr tdisjoint_geo_tgeo(IntPtr gs, IntPtr temp, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_geo_tgeo(gs, temp, restr, atvalue));
+        public static IntPtr tdisjoint_geo_tgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_geo_tgeo(gs, temp));
 
-        public static IntPtr tdisjoint_tgeo_geo(IntPtr temp, IntPtr gs, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tgeo_geo(temp, gs, restr, atvalue));
+        public static IntPtr tdisjoint_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tgeo_geo(temp, gs));
 
-        public static IntPtr tdisjoint_tgeo_tgeo(IntPtr temp1, IntPtr temp2, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tgeo_tgeo(temp1, temp2, restr, atvalue));
+        public static IntPtr tdisjoint_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tgeo_tgeo(temp1, temp2));
 
-        public static IntPtr tdwithin_geo_tgeo(IntPtr gs, IntPtr temp, double dist, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_geo_tgeo(gs, temp, dist, restr, atvalue));
+        public static IntPtr tdwithin_geo_tgeo(IntPtr gs, IntPtr temp, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_geo_tgeo(gs, temp, dist));
 
-        public static IntPtr tdwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tgeo_geo(temp, gs, dist, restr, atvalue));
+        public static IntPtr tdwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tgeo_geo(temp, gs, dist));
 
-        public static IntPtr tdwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tgeo_tgeo(temp1, temp2, dist, restr, atvalue));
+        public static IntPtr tdwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tgeo_tgeo(temp1, temp2, dist));
 
-        public static IntPtr tintersects_geo_tgeo(IntPtr gs, IntPtr temp, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_geo_tgeo(gs, temp, restr, atvalue));
+        public static IntPtr tintersects_geo_tgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_geo_tgeo(gs, temp));
 
-        public static IntPtr tintersects_tgeo_geo(IntPtr temp, IntPtr gs, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tgeo_geo(temp, gs, restr, atvalue));
+        public static IntPtr tintersects_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tgeo_geo(temp, gs));
 
-        public static IntPtr tintersects_tgeo_tgeo(IntPtr temp1, IntPtr temp2, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tgeo_tgeo(temp1, temp2, restr, atvalue));
+        public static IntPtr tintersects_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tgeo_tgeo(temp1, temp2));
 
-        public static IntPtr ttouches_geo_tgeo(IntPtr gs, IntPtr temp, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_geo_tgeo(gs, temp, restr, atvalue));
+        public static IntPtr ttouches_geo_tgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_geo_tgeo(gs, temp));
 
-        public static IntPtr ttouches_tgeo_geo(IntPtr temp, IntPtr gs, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tgeo_geo(temp, gs, restr, atvalue));
+        public static IntPtr ttouches_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tgeo_geo(temp, gs));
 
-        public static IntPtr ttouches_tgeo_tgeo(IntPtr temp1, IntPtr temp2, bool restr, bool atvalue)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tgeo_tgeo(temp1, temp2, restr, atvalue));
+        public static IntPtr ttouches_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tgeo_tgeo(temp1, temp2));
 
         public static IntPtr tdistance_tgeo_geo(IntPtr temp, IntPtr gs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tgeo_geo(temp, gs));
@@ -5466,22 +5247,22 @@ namespace MEOS.NET.Internal
         public static IntPtr stbox_get_space_tile(IntPtr point, double xsize, double ysize, double zsize, IntPtr sorigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_space_tile(point, xsize, ysize, zsize, sorigin));
 
-        public static IntPtr stbox_get_space_time_tile(IntPtr point, long t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin)
+        public static IntPtr stbox_get_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_space_time_tile(point, t, xsize, ysize, zsize, duration, sorigin, torigin));
 
-        public static IntPtr stbox_get_time_tile(long t, IntPtr duration, long torigin)
+        public static IntPtr stbox_get_time_tile(int t, IntPtr duration, int torigin)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_get_time_tile(t, duration, torigin));
 
         public static IntPtr stbox_space_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr sorigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_tiles(bounds, xsize, ysize, zsize, sorigin, border_inc, count));
 
-        public static IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool border_inc, IntPtr count)
+        public static IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_time_tiles(bounds, xsize, ysize, zsize, duration, sorigin, torigin, border_inc, count));
 
-        public static IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, long torigin, bool border_inc, IntPtr count)
+        public static IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, int torigin, bool border_inc, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_time_tiles(bounds, duration, torigin, border_inc, count));
 
-        public static (IntPtr[], IntPtr[]) tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc)
+        public static (IntPtr[], int[]) tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, bool bitmatrix, bool border_inc)
         {
             IntPtr _out_space_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _count_count = Marshal.AllocHGlobal(sizeof(int));
@@ -5493,9 +5274,8 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_space_bins_arr = Marshal.ReadIntPtr(_out_space_bins);
-                IntPtr[] __out_space_bins_out = new IntPtr[_n];
-                for (int _i = 0; _i < _n; _i++)
-                { __out_space_bins_out[_i] = Marshal.ReadIntPtr(__out_space_bins_arr, _i * IntPtr.Size); }
+                int[] __out_space_bins_out = new int[_n];
+                Marshal.Copy(__out_space_bins_arr, __out_space_bins_out, 0, _n);
                 return (_resultArr, __out_space_bins_out);
             }
             finally
@@ -5505,7 +5285,7 @@ namespace MEOS.NET.Internal
             }
         }
 
-        public static (IntPtr[], IntPtr[], long[]) tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, bool bitmatrix, bool border_inc)
+        public static (IntPtr[], int[], int[]) tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc)
         {
             IntPtr _out_space_bins = Marshal.AllocHGlobal(IntPtr.Size);
             IntPtr _out_time_bins = Marshal.AllocHGlobal(IntPtr.Size);
@@ -5518,11 +5298,10 @@ namespace MEOS.NET.Internal
                 for (int _i = 0; _i < _n; _i++)
                 { _resultArr[_i] = Marshal.ReadIntPtr(_resultPtr, _i * IntPtr.Size); }
                 IntPtr __out_space_bins_arr = Marshal.ReadIntPtr(_out_space_bins);
-                IntPtr[] __out_space_bins_out = new IntPtr[_n];
-                for (int _i = 0; _i < _n; _i++)
-                { __out_space_bins_out[_i] = Marshal.ReadIntPtr(__out_space_bins_arr, _i * IntPtr.Size); }
+                int[] __out_space_bins_out = new int[_n];
+                Marshal.Copy(__out_space_bins_arr, __out_space_bins_out, 0, _n);
                 IntPtr __out_time_bins_arr = Marshal.ReadIntPtr(_out_time_bins);
-                long[] __out_time_bins_out = new long[_n];
+                int[] __out_time_bins_out = new int[_n];
                 Marshal.Copy(__out_time_bins_arr, __out_time_bins_out, 0, _n);
                 return (_resultArr, __out_space_bins_out, __out_time_bins_out);
             }
@@ -5546,32 +5325,854 @@ namespace MEOS.NET.Internal
         public static IntPtr geo_cluster_within(IntPtr geoms, uint ngeoms, double tolerance, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_cluster_within(geoms, ngeoms, tolerance, count));
 
+        public static string cbuffer_as_ewkt(IntPtr cb, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_as_ewkt(cb, maxdd));
+
+        public static string cbuffer_as_hexwkb(IntPtr cb, IntPtr variant, IntPtr size)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_as_hexwkb(cb, variant, size));
+
+        public static string cbuffer_as_text(IntPtr cb, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_as_text(cb, maxdd));
+
+        public static IntPtr cbuffer_as_wkb(IntPtr cb, IntPtr variant, IntPtr size_out)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_as_wkb(cb, variant, size_out));
+
+        public static IntPtr cbuffer_from_hexwkb(string hexwkb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_from_hexwkb(hexwkb));
+
+        public static IntPtr cbuffer_from_wkb(IntPtr wkb, ulong size)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_from_wkb(wkb, size));
+
+        public static IntPtr cbuffer_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_in(str));
+
+        public static string cbuffer_out(IntPtr cb, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_out(cb, maxdd));
+
+        public static IntPtr cbuffer_copy(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_copy(cb));
+
+        public static IntPtr cbuffer_make(IntPtr point, double radius)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_make(point, radius));
+
+        public static IntPtr cbuffer_to_geom(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_to_geom(cb));
+
+        public static IntPtr cbuffer_to_stbox(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_to_stbox(cb));
+
+        public static IntPtr cbufferarr_to_geom(IntPtr cbarr, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferarr_to_geom(cbarr, count));
+
+        public static IntPtr geom_to_cbuffer(IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geom_to_cbuffer(gs));
+
+        public static int cbuffer_hash(IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_hash(cb));
+
+        public static int cbuffer_hash_extended(IntPtr cb, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_hash_extended(cb, seed));
+
+        public static IntPtr cbuffer_point(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_point(cb));
+
+        public static double cbuffer_radius(IntPtr cb)
+            => SafeExecution<double>(() => MEOSExternalFunctions.cbuffer_radius(cb));
+
+        public static IntPtr cbuffer_round(IntPtr cb, int maxdd)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_round(cb, maxdd));
+
+        public static IntPtr cbufferarr_round(IntPtr cbarr, int count, int maxdd)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferarr_round(cbarr, count, maxdd));
+
+        public static void cbuffer_set_srid(IntPtr cb, int srid)
+            => SafeExecution(() => MEOSExternalFunctions.cbuffer_set_srid(cb, srid));
+
+        public static int cbuffer_srid(IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_srid(cb));
+
+        public static IntPtr cbuffer_transform(IntPtr cb, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_transform(cb, srid));
+
+        public static IntPtr cbuffer_transform_pipeline(IntPtr cb, string pipelinestr, int srid, bool is_forward)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_transform_pipeline(cb, pipelinestr, srid, is_forward));
+
+        public static int contains_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.contains_cbuffer_cbuffer(cb1, cb2));
+
+        public static int covers_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.covers_cbuffer_cbuffer(cb1, cb2));
+
+        public static int disjoint_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.disjoint_cbuffer_cbuffer(cb1, cb2));
+
+        public static int dwithin_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.dwithin_cbuffer_cbuffer(cb1, cb2, dist));
+
+        public static int intersects_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.intersects_cbuffer_cbuffer(cb1, cb2));
+
+        public static int touches_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.touches_cbuffer_cbuffer(cb1, cb2));
+
+        public static IntPtr cbuffer_tstzspan_to_stbox(IntPtr cb, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_tstzspan_to_stbox(cb, s));
+
+        public static IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, int t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_timestamptz_to_stbox(cb, t));
+
+        public static double distance_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_cbuffer_cbuffer(cb1, cb2));
+
+        public static double distance_cbuffer_geo(IntPtr cb, IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_cbuffer_geo(cb, gs));
+
+        public static double distance_cbuffer_stbox(IntPtr cb, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_cbuffer_stbox(cb, box));
+
+        public static double nad_cbuffer_stbox(IntPtr cb, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_cbuffer_stbox(cb, box));
+
+        public static int cbuffer_cmp(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_cmp(cb1, cb2));
+
+        public static bool cbuffer_eq(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_eq(cb1, cb2));
+
+        public static bool cbuffer_ge(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_ge(cb1, cb2));
+
+        public static bool cbuffer_gt(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_gt(cb1, cb2));
+
+        public static bool cbuffer_le(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_le(cb1, cb2));
+
+        public static bool cbuffer_lt(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_lt(cb1, cb2));
+
+        public static bool cbuffer_ne(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_ne(cb1, cb2));
+
+        public static bool cbuffer_nsame(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_nsame(cb1, cb2));
+
+        public static bool cbuffer_same(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_same(cb1, cb2));
+
+        public static IntPtr cbufferset_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_in(str));
+
+        public static string cbufferset_out(IntPtr s, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbufferset_out(s, maxdd));
+
+        public static IntPtr cbufferset_make(IntPtr values, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_make(values, count));
+
+        public static IntPtr cbuffer_to_set(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_to_set(cb));
+
+        public static IntPtr cbufferset_end_value(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_end_value(s));
+
+        public static IntPtr cbufferset_start_value(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_start_value(s));
+
+        public static bool cbufferset_value_n(IntPtr s, int n, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbufferset_value_n(s, n, result));
+
+        public static IntPtr cbufferset_values(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbufferset_values(s));
+
+        public static IntPtr cbuffer_union_transfn(IntPtr state, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_union_transfn(state, cb));
+
+        public static bool contained_cbuffer_set(IntPtr cb, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_cbuffer_set(cb, s));
+
+        public static bool contains_set_cbuffer(IntPtr s, IntPtr cb)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_cbuffer(s, cb));
+
+        public static IntPtr intersection_cbuffer_set(IntPtr cb, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_cbuffer_set(cb, s));
+
+        public static IntPtr intersection_set_cbuffer(IntPtr s, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_cbuffer(s, cb));
+
+        public static IntPtr minus_cbuffer_set(IntPtr cb, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_cbuffer_set(cb, s));
+
+        public static IntPtr minus_set_cbuffer(IntPtr s, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_cbuffer(s, cb));
+
+        public static IntPtr union_cbuffer_set(IntPtr cb, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_cbuffer_set(cb, s));
+
+        public static IntPtr union_set_cbuffer(IntPtr s, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_cbuffer(s, cb));
+
+        public static IntPtr tcbuffer_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_in(str));
+
+        public static IntPtr tcbuffer_make(IntPtr tpoint, IntPtr tfloat)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_make(tpoint, tfloat));
+
+        public static IntPtr tcbuffer_points(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_points(temp));
+
+        public static IntPtr tcbuffer_radius(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_radius(temp));
+
+        public static IntPtr tcbuffer_trav_area(IntPtr temp, bool merge_union)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_trav_area(temp, merge_union));
+
+        public static IntPtr tcbuffer_to_tfloat(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_to_tfloat(temp));
+
+        public static IntPtr tcbuffer_to_tgeompoint(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_to_tgeompoint(temp));
+
+        public static IntPtr tgeometry_to_tcbuffer(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeometry_to_tcbuffer(temp));
+
+        public static IntPtr tcbuffer_expand(IntPtr temp, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_expand(temp, dist));
+
+        public static IntPtr tcbuffer_at_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_at_cbuffer(temp, cb));
+
+        public static IntPtr tcbuffer_at_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_at_geom(temp, gs));
+
+        public static IntPtr tcbuffer_at_stbox(IntPtr temp, IntPtr box, bool border_inc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_at_stbox(temp, box, border_inc));
+
+        public static IntPtr tcbuffer_minus_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_minus_cbuffer(temp, cb));
+
+        public static IntPtr tcbuffer_minus_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_minus_geom(temp, gs));
+
+        public static IntPtr tcbuffer_minus_stbox(IntPtr temp, IntPtr box, bool border_inc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_minus_stbox(temp, box, border_inc));
+
+        public static IntPtr tdistance_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tdistance_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tcbuffer_geo(temp, gs));
+
+        public static IntPtr tdistance_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static double nad_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tcbuffer_cbuffer(temp, cb));
+
+        public static double nad_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tcbuffer_geo(temp, gs));
+
+        public static double nad_tcbuffer_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tcbuffer_stbox(temp, box));
+
+        public static double nad_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr nai_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr nai_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tcbuffer_geo(temp, gs));
+
+        public static IntPtr nai_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr shortestline_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr shortestline_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tcbuffer_geo(temp, gs));
+
+        public static IntPtr shortestline_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int always_eq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_cbuffer_tcbuffer(cb, temp));
+
+        public static int always_eq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_tcbuffer_cbuffer(temp, cb));
+
+        public static int always_eq_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int always_ne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_cbuffer_tcbuffer(cb, temp));
+
+        public static int always_ne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_tcbuffer_cbuffer(temp, cb));
+
+        public static int always_ne_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int ever_eq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_cbuffer_tcbuffer(cb, temp));
+
+        public static int ever_eq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_tcbuffer_cbuffer(temp, cb));
+
+        public static int ever_eq_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int ever_ne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_cbuffer_tcbuffer(cb, temp));
+
+        public static int ever_ne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_tcbuffer_cbuffer(temp, cb));
+
+        public static int ever_ne_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr teq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr teq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr tne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_tcbuffer_cbuffer(temp, cb));
+
+        public static int acontains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acontains_cbuffer_tcbuffer(cb, temp));
+
+        public static int acontains_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acontains_geo_tcbuffer(gs, temp));
+
+        public static int acontains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acontains_tcbuffer_cbuffer(temp, cb));
+
+        public static int acontains_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acontains_tcbuffer_geo(temp, gs));
+
+        public static int acovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acovers_cbuffer_tcbuffer(cb, temp));
+
+        public static int acovers_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acovers_geo_tcbuffer(gs, temp));
+
+        public static int acovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acovers_tcbuffer_cbuffer(temp, cb));
+
+        public static int acovers_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.acovers_tcbuffer_geo(temp, gs));
+
+        public static int adisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adisjoint_tcbuffer_geo(temp, gs));
+
+        public static int adisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adisjoint_tcbuffer_cbuffer(temp, cb));
+
+        public static int adisjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adisjoint_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int adwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adwithin_tcbuffer_geo(temp, gs, dist));
+
+        public static int adwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adwithin_tcbuffer_cbuffer(temp, cb, dist));
+
+        public static int adwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.adwithin_tcbuffer_tcbuffer(temp1, temp2, dist));
+
+        public static int aintersects_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.aintersects_tcbuffer_geo(temp, gs));
+
+        public static int aintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.aintersects_tcbuffer_cbuffer(temp, cb));
+
+        public static int aintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.aintersects_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int atouches_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.atouches_tcbuffer_geo(temp, gs));
+
+        public static int atouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.atouches_tcbuffer_cbuffer(temp, cb));
+
+        public static int atouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.atouches_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int econtains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.econtains_cbuffer_tcbuffer(cb, temp));
+
+        public static int econtains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.econtains_tcbuffer_cbuffer(temp, cb));
+
+        public static int econtains_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.econtains_tcbuffer_geo(temp, gs));
+
+        public static int ecovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ecovers_cbuffer_tcbuffer(cb, temp));
+
+        public static int ecovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ecovers_tcbuffer_cbuffer(temp, cb));
+
+        public static int ecovers_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ecovers_tcbuffer_geo(temp, gs));
+
+        public static int ecovers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ecovers_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int edisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.edisjoint_tcbuffer_geo(temp, gs));
+
+        public static int edisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.edisjoint_tcbuffer_cbuffer(temp, cb));
+
+        public static int edwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.edwithin_tcbuffer_geo(temp, gs, dist));
+
+        public static int edwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.edwithin_tcbuffer_cbuffer(temp, cb, dist));
+
+        public static int edwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.edwithin_tcbuffer_tcbuffer(temp1, temp2, dist));
+
+        public static int eintersects_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eintersects_tcbuffer_geo(temp, gs));
+
+        public static int eintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eintersects_tcbuffer_cbuffer(temp, cb));
+
+        public static int eintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eintersects_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int etouches_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.etouches_tcbuffer_geo(temp, gs));
+
+        public static int etouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<int>(() => MEOSExternalFunctions.etouches_tcbuffer_cbuffer(temp, cb));
+
+        public static int etouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.etouches_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr tcontains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr tcontains_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_geo_tcbuffer(gs, temp));
+
+        public static IntPtr tcontains_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tcbuffer_geo(temp, gs));
+
+        public static IntPtr tcontains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tcontains_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontains_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr tcovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr tcovers_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_geo_tcbuffer(gs, temp));
+
+        public static IntPtr tcovers_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tcbuffer_geo(temp, gs));
+
+        public static IntPtr tcovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tcovers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcovers_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr tdwithin_geo_tcbuffer(IntPtr gs, IntPtr temp, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_geo_tcbuffer(gs, temp, dist));
+
+        public static IntPtr tdwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tcbuffer_geo(temp, gs, dist));
+
+        public static IntPtr tdwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tcbuffer_cbuffer(temp, cb, dist));
+
+        public static IntPtr tdwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tcbuffer_tcbuffer(temp1, temp2, dist));
+
+        public static IntPtr tdisjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr tdisjoint_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_geo_tcbuffer(gs, temp));
+
+        public static IntPtr tdisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tcbuffer_geo(temp, gs));
+
+        public static IntPtr tdisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tdisjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdisjoint_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr tintersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr tintersects_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_geo_tcbuffer(gs, temp));
+
+        public static IntPtr tintersects_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tcbuffer_geo(temp, gs));
+
+        public static IntPtr tintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr tintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tintersects_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static IntPtr ttouches_geo_tcbuffer(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_geo_tcbuffer(gs, temp));
+
+        public static IntPtr ttouches_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tcbuffer_geo(temp, gs));
+
+        public static IntPtr ttouches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_cbuffer_tcbuffer(cb, temp));
+
+        public static IntPtr ttouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tcbuffer_cbuffer(temp, cb));
+
+        public static IntPtr ttouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ttouches_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static bool ensure_valid_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_cbuffer(cb1, cb2));
+
+        public static bool ensure_valid_cbuffer_geo(IntPtr cb, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_geo(cb, gs));
+
+        public static bool ensure_valid_cbuffer_stbox(IntPtr cb, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbuffer_stbox(cb, box));
+
+        public static bool ensure_valid_cbufferset_cbuffer(IntPtr s, IntPtr cb)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_cbufferset_cbuffer(s, cb));
+
+        public static bool cbuffer_collinear(IntPtr cb1, IntPtr cb2, IntPtr cbuf3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_collinear(cb1, cb2, cbuf3, ratio));
+
+        public static IntPtr cbuffersegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffersegm_interpolate(start, end, ratio));
+
+        public static IntPtr cbuffersegm_locate(IntPtr start, IntPtr end, IntPtr value)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffersegm_locate(start, end, value));
+
+        public static IntPtr cbuffer_parse(IntPtr str, bool end)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_parse(str, end));
+
+        public static string cbuffer_wkt_out(int value, int maxdd, bool extended)
+            => SafeExecution<string>(() => MEOSExternalFunctions.cbuffer_wkt_out(value, maxdd, extended));
+
+        public static IntPtr cbuffer_point_p(IntPtr cb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_point_p(cb));
+
+        public static int datum_cbuffer_round(int buffer, int size)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_round(buffer, size));
+
+        public static IntPtr cbuffer_transf_pj(IntPtr cb, int srid_to, IntPtr pj)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.cbuffer_transf_pj(cb, srid_to, pj));
+
+        public static double cbuffer_distance(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.cbuffer_distance(cb1, cb2));
+
+        public static int datum_cbuffer_distance(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_distance(cb1, cb2));
+
+        public static int cbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffersegm_distance_turnpt(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static int cbuffer_contains(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_contains(cb1, cb2));
+
+        public static int cbuffer_covers(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_covers(cb1, cb2));
+
+        public static int cbuffer_disjoint(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_disjoint(cb1, cb2));
+
+        public static int cbuffer_intersects(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_intersects(cb1, cb2));
+
+        public static int cbuffer_dwithin(IntPtr cb1, IntPtr cb2, double dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_dwithin(cb1, cb2, dist));
+
+        public static int cbuffer_touches(IntPtr cb1, IntPtr cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.cbuffer_touches(cb1, cb2));
+
+        public static int datum_cbuffer_contains(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_contains(cb1, cb2));
+
+        public static int datum_cbuffer_covers(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_covers(cb1, cb2));
+
+        public static int datum_cbuffer_disjoint(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_disjoint(cb1, cb2));
+
+        public static int datum_cbuffer_intersects(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_intersects(cb1, cb2));
+
+        public static int datum_cbuffer_dwithin(int cb1, int cb2, int dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_dwithin(cb1, cb2, dist));
+
+        public static int datum_cbuffer_touches(int cb1, int cb2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cbuffer_touches(cb1, cb2));
+
+        public static bool temptype_subtype(int subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype(subtype));
+
+        public static bool temptype_subtype_all(int subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_subtype_all(subtype));
+
+        public static string tempsubtype_name(int subtype)
+            => SafeExecution<string>(() => MEOSExternalFunctions.tempsubtype_name(subtype));
+
+        public static bool tempsubtype_from_string(string str, IntPtr subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tempsubtype_from_string(str, subtype));
+
+        public static string meosoper_name(IntPtr oper)
+            => SafeExecution<string>(() => MEOSExternalFunctions.meosoper_name(oper));
+
+        public static IntPtr meosoper_from_string(string name)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.meosoper_from_string(name));
+
+        public static string interptype_name(int interp)
+            => SafeExecution<string>(() => MEOSExternalFunctions.interptype_name(interp));
+
+        public static int interptype_from_string(string interp_str)
+            => SafeExecution<int>(() => MEOSExternalFunctions.interptype_from_string(interp_str));
+
+        public static string meostype_name(int type)
+            => SafeExecution<string>(() => MEOSExternalFunctions.meostype_name(type));
+
+        public static int temptype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temptype_basetype(type));
+
+        public static int settype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.settype_basetype(type));
+
+        public static int spantype_basetype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_basetype(type));
+
+        public static int spantype_spansettype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spantype_spansettype(type));
+
+        public static int spansettype_spantype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spansettype_spantype(type));
+
+        public static int basetype_spantype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_spantype(type));
+
+        public static int basetype_settype(int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.basetype_settype(type));
+
+        public static bool tnumber_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_basetype(type));
+
+        public static bool geo_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_basetype(type));
+
+        public static bool meos_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.meos_basetype(type));
+
+        public static bool alphanum_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_basetype(type));
+
+        public static bool alphanum_temptype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanum_temptype(type));
+
+        public static bool time_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.time_type(type));
+
+        public static bool set_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_basetype(type));
+
+        public static bool set_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_type(type));
+
+        public static bool numset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numset_type(type));
+
+        public static bool ensure_numset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numset_type(type));
+
+        public static bool timeset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timeset_type(type));
+
+        public static bool set_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_spantype(type));
+
+        public static bool ensure_set_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_spantype(type));
+
+        public static bool alphanumset_type(int settype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.alphanumset_type(settype));
+
+        public static bool geoset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geoset_type(type));
+
+        public static bool ensure_geoset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoset_type(type));
+
+        public static bool spatialset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spatialset_type(type));
+
+        public static bool ensure_spatialset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatialset_type(type));
+
+        public static bool span_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_basetype(type));
+
+        public static bool span_canon_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_canon_basetype(type));
+
+        public static bool span_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_type(type));
+
+        public static bool type_span_bbox(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.type_span_bbox(type));
+
+        public static bool span_tbox_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_tbox_type(type));
+
+        public static bool ensure_span_tbox_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_tbox_type(type));
+
+        public static bool numspan_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_basetype(type));
+
+        public static bool numspan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.numspan_type(type));
+
+        public static bool ensure_numspan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_numspan_type(type));
+
+        public static bool timespan_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_basetype(type));
+
+        public static bool timespan_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespan_type(type));
+
+        public static bool spanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_type(type));
+
+        public static bool timespanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.timespanset_type(type));
+
+        public static bool ensure_timespanset_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_timespanset_type(type));
+
+        public static bool temporal_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_type(type));
+
+        public static bool temporal_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_basetype(type));
+
+        public static bool temptype_supports_linear(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temptype_supports_linear(type));
+
+        public static bool basetype_byvalue(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_byvalue(type));
+
+        public static bool basetype_varlength(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_varlength(type));
+
+        public static short meostype_length(int type)
+            => SafeExecution<short>(() => MEOSExternalFunctions.meostype_length(type));
+
+        public static bool talphanum_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.talphanum_type(type));
+
+        public static bool talpha_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.talpha_type(type));
+
+        public static bool tnumber_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_type(type));
+
+        public static bool ensure_tnumber_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_type(type));
+
+        public static bool ensure_tnumber_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_basetype(type));
+
+        public static bool tnumber_spantype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumber_spantype(type));
+
+        public static bool spatial_basetype(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_basetype(type));
+
+        public static bool tspatial_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tspatial_type(type));
+
+        public static bool ensure_tspatial_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tspatial_type(type));
+
+        public static bool tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tpoint_type(type));
+
+        public static bool ensure_tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tpoint_type(type));
+
+        public static bool tgeo_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type(type));
+
+        public static bool ensure_tgeo_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type(type));
+
+        public static bool tgeo_type_all(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeo_type_all(type));
+
+        public static bool ensure_tgeo_type_all(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeo_type_all(type));
+
+        public static bool tgeometry_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeometry_type(type));
+
+        public static bool ensure_tgeometry_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeometry_type(type));
+
+        public static bool tgeodetic_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tgeodetic_type(type));
+
+        public static bool ensure_tgeodetic_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tgeodetic_type(type));
+
+        public static bool ensure_tnumber_tpoint_type(int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_tnumber_tpoint_type(type));
+
         public static IntPtr gsl_get_generation_rng()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.gsl_get_generation_rng());
 
         public static IntPtr gsl_get_aggregation_rng()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.gsl_get_aggregation_rng());
 
-        public static ulong datum_ceil(ulong d)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_ceil(d));
+        public static int datum_ceil(IntPtr d)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_ceil(d));
 
-        public static ulong datum_degrees(ulong d, ulong normalize)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_degrees(d, normalize));
+        public static int datum_degrees(IntPtr d, IntPtr normalize)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_degrees(d, normalize));
 
-        public static ulong datum_float_round(ulong value, ulong size)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_float_round(value, size));
+        public static int datum_float_round(IntPtr value, IntPtr size)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_float_round(value, size));
 
-        public static ulong datum_floor(ulong d)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_floor(d));
+        public static int datum_floor(IntPtr d)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_floor(d));
 
-        public static uint datum_hash(ulong d, int basetype)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.datum_hash(d, basetype));
+        public static int datum_hash(IntPtr d, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_hash(d, basetype));
 
-        public static ulong datum_hash_extended(ulong d, int basetype, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_hash_extended(d, basetype, seed));
+        public static int datum_hash_extended(IntPtr d, int basetype, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_hash_extended(d, basetype, seed));
 
-        public static ulong datum_radians(ulong d)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_radians(d));
+        public static int datum_radians(IntPtr d)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_radians(d));
 
         public static void floatspan_round_set(IntPtr s, int maxdd, IntPtr result)
             => SafeExecution(() => MEOSExternalFunctions.floatspan_round_set(s, maxdd, result));
@@ -5603,10 +6204,10 @@ namespace MEOS.NET.Internal
         public static IntPtr set_make_free(IntPtr values, int count, int basetype, bool order)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_make_free(values, count, basetype, order));
 
-        public static IntPtr span_make(ulong lower, ulong upper, bool lower_inc, bool upper_inc, int basetype)
+        public static IntPtr span_make(IntPtr lower, IntPtr upper, bool lower_inc, bool upper_inc, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_make(lower, upper, lower_inc, upper_inc, basetype));
 
-        public static void span_set(ulong lower, ulong upper, bool lower_inc, bool upper_inc, int basetype, int spantype, IntPtr s)
+        public static void span_set(IntPtr lower, IntPtr upper, bool lower_inc, bool upper_inc, int basetype, int spantype, IntPtr s)
             => SafeExecution(() => MEOSExternalFunctions.span_set(lower, upper, lower_inc, upper_inc, basetype, spantype, s));
 
         public static IntPtr spanset_make_exp(IntPtr spans, int count, int maxcount, bool normalize, bool order)
@@ -5621,26 +6222,26 @@ namespace MEOS.NET.Internal
         public static IntPtr set_spanset(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_spanset(s));
 
-        public static void value_set_span(ulong value, int basetype, IntPtr s)
+        public static void value_set_span(IntPtr value, int basetype, IntPtr s)
             => SafeExecution(() => MEOSExternalFunctions.value_set_span(value, basetype, s));
 
-        public static IntPtr value_set(ulong d, int basetype)
+        public static IntPtr value_set(IntPtr d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_set(d, basetype));
 
-        public static IntPtr value_span(ulong d, int basetype)
+        public static IntPtr value_span(IntPtr d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_span(d, basetype));
 
-        public static IntPtr value_spanset(ulong d, int basetype)
+        public static IntPtr value_spanset(IntPtr d, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_spanset(d, basetype));
 
-        public static ulong numspan_width(IntPtr s)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.numspan_width(s));
+        public static int numspan_width(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.numspan_width(s));
 
-        public static ulong numspanset_width(IntPtr ss, bool boundspan)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.numspanset_width(ss, boundspan));
+        public static int numspanset_width(IntPtr ss, bool boundspan)
+            => SafeExecution<int>(() => MEOSExternalFunctions.numspanset_width(ss, boundspan));
 
-        public static ulong set_end_value(IntPtr s)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_end_value(s));
+        public static int set_end_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.set_end_value(s));
 
         public static int set_mem_size(IntPtr s)
             => SafeExecution<int>(() => MEOSExternalFunctions.set_mem_size(s));
@@ -5651,8 +6252,8 @@ namespace MEOS.NET.Internal
         public static void set_set_span(IntPtr s, IntPtr result)
             => SafeExecution(() => MEOSExternalFunctions.set_set_span(s, result));
 
-        public static ulong set_start_value(IntPtr s)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.set_start_value(s));
+        public static int set_start_value(IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.set_start_value(s));
 
         public static bool set_value_n(IntPtr s, int n, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.set_value_n(s, n, result));
@@ -5663,8 +6264,8 @@ namespace MEOS.NET.Internal
         public static IntPtr set_values(IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_values(s));
 
-        public static ulong spanset_lower(IntPtr ss)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_lower(ss));
+        public static int spanset_lower(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_lower(ss));
 
         public static int spanset_mem_size(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.spanset_mem_size(ss));
@@ -5679,8 +6280,8 @@ namespace MEOS.NET.Internal
             return _out;
         }
 
-        public static ulong spanset_upper(IntPtr ss)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.spanset_upper(ss));
+        public static int spanset_upper(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spanset_upper(ss));
 
         public static void datespan_set_tstzspan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.datespan_set_tstzspan(s1, s2));
@@ -5691,16 +6292,16 @@ namespace MEOS.NET.Internal
         public static void intspan_set_floatspan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.intspan_set_floatspan(s1, s2));
 
-        public static IntPtr numset_shift_scale(IntPtr s, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr numset_shift_scale(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numset_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr numspan_expand(IntPtr s, ulong value)
+        public static IntPtr numspan_expand(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_expand(s, value));
 
-        public static IntPtr numspan_shift_scale(IntPtr s, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr numspan_shift_scale(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspan_shift_scale(s, shift, width, hasshift, haswidth));
 
-        public static IntPtr numspanset_shift_scale(IntPtr ss, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr numspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.numspanset_shift_scale(ss, shift, width, hasshift, haswidth));
 
         public static IntPtr set_compact(IntPtr s)
@@ -5712,7 +6313,7 @@ namespace MEOS.NET.Internal
         public static IntPtr spanset_compact(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_compact(ss));
 
-        public static IntPtr tbox_expand_value(IntPtr box, ulong value, int basetyp)
+        public static IntPtr tbox_expand_value(IntPtr box, IntPtr value, int basetyp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_expand_value(box, value, basetyp));
 
         public static IntPtr textcat_textset_text_common(IntPtr s, IntPtr txt, bool invert)
@@ -5721,109 +6322,109 @@ namespace MEOS.NET.Internal
         public static void tstzspan_set_datespan(IntPtr s1, IntPtr s2)
             => SafeExecution(() => MEOSExternalFunctions.tstzspan_set_datespan(s1, s2));
 
-        public static bool adjacent_span_value(IntPtr s, ulong value)
+        public static bool adjacent_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_span_value(s, value));
 
-        public static bool adjacent_spanset_value(IntPtr ss, ulong value)
+        public static bool adjacent_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_spanset_value(ss, value));
 
-        public static bool adjacent_value_spanset(ulong value, IntPtr ss)
+        public static bool adjacent_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.adjacent_value_spanset(value, ss));
 
-        public static bool contained_value_set(ulong value, IntPtr s)
+        public static bool contained_value_set(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_set(value, s));
 
-        public static bool contained_value_span(ulong value, IntPtr s)
+        public static bool contained_value_span(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_span(value, s));
 
-        public static bool contained_value_spanset(ulong value, IntPtr ss)
+        public static bool contained_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contained_value_spanset(value, ss));
 
-        public static bool contains_set_value(IntPtr s, ulong value)
+        public static bool contains_set_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_value(s, value));
 
-        public static bool contains_span_value(IntPtr s, ulong value)
+        public static bool contains_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_span_value(s, value));
 
-        public static bool contains_spanset_value(IntPtr ss, ulong value)
+        public static bool contains_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.contains_spanset_value(ss, value));
 
         public static bool ovadj_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.ovadj_span_span(s1, s2));
 
-        public static bool left_set_value(IntPtr s, ulong value)
+        public static bool left_set_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_set_value(s, value));
 
-        public static bool left_span_value(IntPtr s, ulong value)
+        public static bool left_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_span_value(s, value));
 
-        public static bool left_spanset_value(IntPtr ss, ulong value)
+        public static bool left_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_spanset_value(ss, value));
 
-        public static bool left_value_set(ulong value, IntPtr s)
+        public static bool left_value_set(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_set(value, s));
 
-        public static bool left_value_span(ulong value, IntPtr s)
+        public static bool left_value_span(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_span(value, s));
 
-        public static bool left_value_spanset(ulong value, IntPtr ss)
+        public static bool left_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.left_value_spanset(value, ss));
 
         public static bool lfnadj_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.lfnadj_span_span(s1, s2));
 
-        public static bool overleft_set_value(IntPtr s, ulong value)
+        public static bool overleft_set_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_set_value(s, value));
 
-        public static bool overleft_span_value(IntPtr s, ulong value)
+        public static bool overleft_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_span_value(s, value));
 
-        public static bool overleft_spanset_value(IntPtr ss, ulong value)
+        public static bool overleft_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_spanset_value(ss, value));
 
-        public static bool overleft_value_set(ulong value, IntPtr s)
+        public static bool overleft_value_set(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_set(value, s));
 
-        public static bool overleft_value_span(ulong value, IntPtr s)
+        public static bool overleft_value_span(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_span(value, s));
 
-        public static bool overleft_value_spanset(ulong value, IntPtr ss)
+        public static bool overleft_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overleft_value_spanset(value, ss));
 
-        public static bool overright_set_value(IntPtr s, ulong value)
+        public static bool overright_set_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_set_value(s, value));
 
-        public static bool overright_span_value(IntPtr s, ulong value)
+        public static bool overright_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_span_value(s, value));
 
-        public static bool overright_spanset_value(IntPtr ss, ulong value)
+        public static bool overright_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_spanset_value(ss, value));
 
-        public static bool overright_value_set(ulong value, IntPtr s)
+        public static bool overright_value_set(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_set(value, s));
 
-        public static bool overright_value_span(ulong value, IntPtr s)
+        public static bool overright_value_span(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_span(value, s));
 
-        public static bool overright_value_spanset(ulong value, IntPtr ss)
+        public static bool overright_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.overright_value_spanset(value, ss));
 
-        public static bool right_value_set(ulong value, IntPtr s)
+        public static bool right_value_set(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_set(value, s));
 
-        public static bool right_set_value(IntPtr s, ulong value)
+        public static bool right_set_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_set_value(s, value));
 
-        public static bool right_value_span(ulong value, IntPtr s)
+        public static bool right_value_span(IntPtr value, IntPtr s)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_span(value, s));
 
-        public static bool right_value_spanset(ulong value, IntPtr ss)
+        public static bool right_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_value_spanset(value, ss));
 
-        public static bool right_span_value(IntPtr s, ulong value)
+        public static bool right_span_value(IntPtr s, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_span_value(s, value));
 
-        public static bool right_spanset_value(IntPtr ss, ulong value)
+        public static bool right_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<bool>(() => MEOSExternalFunctions.right_spanset_value(ss, value));
 
         public static bool bbox_type(int bboxtype)
@@ -5847,100 +6448,100 @@ namespace MEOS.NET.Internal
         public static bool inter_span_span(IntPtr s1, IntPtr s2, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.inter_span_span(s1, s2, result));
 
-        public static IntPtr intersection_set_value(IntPtr s, ulong value)
+        public static IntPtr intersection_set_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_value(s, value));
 
-        public static IntPtr intersection_span_value(IntPtr s, ulong value)
+        public static IntPtr intersection_span_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_span_value(s, value));
 
-        public static IntPtr intersection_spanset_value(IntPtr ss, ulong value)
+        public static IntPtr intersection_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_spanset_value(ss, value));
 
-        public static IntPtr intersection_value_set(ulong value, IntPtr s)
+        public static IntPtr intersection_value_set(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_set(value, s));
 
-        public static IntPtr intersection_value_span(ulong value, IntPtr s)
+        public static IntPtr intersection_value_span(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_span(value, s));
 
-        public static IntPtr intersection_value_spanset(ulong value, IntPtr ss)
+        public static IntPtr intersection_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_value_spanset(value, ss));
 
         public static int mi_span_span(IntPtr s1, IntPtr s2, IntPtr result)
             => SafeExecution<int>(() => MEOSExternalFunctions.mi_span_span(s1, s2, result));
 
-        public static IntPtr minus_set_value(IntPtr s, ulong value)
+        public static IntPtr minus_set_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_value(s, value));
 
-        public static IntPtr minus_span_value(IntPtr s, ulong value)
+        public static IntPtr minus_span_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_span_value(s, value));
 
-        public static IntPtr minus_spanset_value(IntPtr ss, ulong value)
+        public static IntPtr minus_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_spanset_value(ss, value));
 
-        public static IntPtr minus_value_set(ulong value, IntPtr s)
+        public static IntPtr minus_value_set(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_set(value, s));
 
-        public static IntPtr minus_value_span(ulong value, IntPtr s)
+        public static IntPtr minus_value_span(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_span(value, s));
 
-        public static IntPtr minus_value_spanset(ulong value, IntPtr ss)
+        public static IntPtr minus_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_value_spanset(value, ss));
 
         public static IntPtr super_union_span_span(IntPtr s1, IntPtr s2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.super_union_span_span(s1, s2));
 
-        public static IntPtr union_set_value(IntPtr s, ulong value)
+        public static IntPtr union_set_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_value(s, value));
 
-        public static IntPtr union_span_value(IntPtr s, ulong value)
+        public static IntPtr union_span_value(IntPtr s, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_span_value(s, value));
 
-        public static IntPtr union_spanset_value(IntPtr ss, ulong value)
+        public static IntPtr union_spanset_value(IntPtr ss, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_spanset_value(ss, value));
 
-        public static IntPtr union_value_set(ulong value, IntPtr s)
+        public static IntPtr union_value_set(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_set(value, s));
 
-        public static IntPtr union_value_span(ulong value, IntPtr s)
+        public static IntPtr union_value_span(IntPtr value, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_span(value, s));
 
-        public static IntPtr union_value_spanset(ulong value, IntPtr ss)
+        public static IntPtr union_value_spanset(IntPtr value, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_value_spanset(value, ss));
 
-        public static ulong distance_set_set(IntPtr s1, IntPtr s2)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_set_set(s1, s2));
+        public static int distance_set_set(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_set(s1, s2));
 
-        public static ulong distance_set_value(IntPtr s, ulong value)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_set_value(s, value));
+        public static int distance_set_value(IntPtr s, IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_set_value(s, value));
 
-        public static ulong distance_span_span(IntPtr s1, IntPtr s2)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_span_span(s1, s2));
+        public static int distance_span_span(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_span(s1, s2));
 
-        public static ulong distance_span_value(IntPtr s, ulong value)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_span_value(s, value));
+        public static int distance_span_value(IntPtr s, IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_span_value(s, value));
 
-        public static ulong distance_spanset_span(IntPtr ss, IntPtr s)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_span(ss, s));
+        public static int distance_spanset_span(IntPtr ss, IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_span(ss, s));
 
-        public static ulong distance_spanset_spanset(IntPtr ss1, IntPtr ss2)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_spanset(ss1, ss2));
+        public static int distance_spanset_spanset(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_spanset(ss1, ss2));
 
-        public static ulong distance_spanset_value(IntPtr ss, ulong value)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_spanset_value(ss, value));
+        public static int distance_spanset_value(IntPtr ss, IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_spanset_value(ss, value));
 
-        public static ulong distance_value_value(ulong l, ulong r, int basetype)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.distance_value_value(l, r, basetype));
+        public static int distance_value_value(IntPtr l, IntPtr r, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.distance_value_value(l, r, basetype));
 
-        public static IntPtr spanbase_extent_transfn(IntPtr state, ulong value, int basetype)
+        public static IntPtr spanbase_extent_transfn(IntPtr state, IntPtr value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanbase_extent_transfn(state, value, basetype));
 
-        public static IntPtr value_union_transfn(IntPtr state, ulong value, int basetype)
+        public static IntPtr value_union_transfn(IntPtr state, IntPtr value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.value_union_transfn(state, value, basetype));
 
-        public static IntPtr number_tstzspan_to_tbox(ulong d, int basetype, IntPtr s)
+        public static IntPtr number_tstzspan_to_tbox(IntPtr d, int basetype, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_tstzspan_to_tbox(d, basetype, s));
 
-        public static IntPtr number_timestamptz_to_tbox(ulong d, int basetype, long t)
+        public static IntPtr number_timestamptz_to_tbox(IntPtr d, int basetype, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_timestamptz_to_tbox(d, basetype, t));
 
         public static void tbox_set(IntPtr s, IntPtr p, IntPtr box)
@@ -5952,10 +6553,10 @@ namespace MEOS.NET.Internal
         public static void int_set_tbox(int i, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.int_set_tbox(i, box));
 
-        public static void number_set_tbox(ulong d, int basetype, IntPtr box)
+        public static void number_set_tbox(IntPtr d, int basetype, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.number_set_tbox(d, basetype, box));
 
-        public static IntPtr number_tbox(ulong value, int basetype)
+        public static IntPtr number_tbox(IntPtr value, int basetype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.number_tbox(value, basetype));
 
         public static void numset_set_tbox(IntPtr s, IntPtr box)
@@ -5964,7 +6565,7 @@ namespace MEOS.NET.Internal
         public static void numspan_set_tbox(IntPtr span, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.numspan_set_tbox(span, box));
 
-        public static void timestamptz_set_tbox(long t, IntPtr box)
+        public static void timestamptz_set_tbox(int t, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.timestamptz_set_tbox(t, box));
 
         public static void tstzset_set_tbox(IntPtr s, IntPtr box)
@@ -5973,7 +6574,7 @@ namespace MEOS.NET.Internal
         public static void tstzspan_set_tbox(IntPtr s, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tstzspan_set_tbox(s, box));
 
-        public static IntPtr tbox_shift_scale_value(IntPtr box, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr tbox_shift_scale_value(IntPtr box, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_shift_scale_value(box, shift, width, hasshift, haswidth));
 
         public static void tbox_expand(IntPtr box1, IntPtr box2)
@@ -6093,28 +6694,28 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_from_mfjson(string mfjson, int temptype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_from_mfjson(mfjson, temptype));
 
-        public static IntPtr temporal_from_base_temp(ulong value, int temptype, IntPtr temp)
+        public static IntPtr temporal_from_base_temp(IntPtr value, int temptype, IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_from_base_temp(value, temptype, temp));
 
         public static IntPtr tinstant_copy(IntPtr inst)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_copy(inst));
 
-        public static IntPtr tinstant_make(ulong value, int temptype, long t)
+        public static IntPtr tinstant_make(IntPtr value, int temptype, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_make(value, temptype, t));
 
-        public static IntPtr tinstant_make_free(ulong value, int temptype, long t)
+        public static IntPtr tinstant_make_free(IntPtr value, int temptype, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_make_free(value, temptype, t));
 
         public static IntPtr tsequence_copy(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_copy(seq));
 
-        public static IntPtr tsequence_from_base_temp(ulong value, int temptype, IntPtr seq)
+        public static IntPtr tsequence_from_base_temp(IntPtr value, int temptype, IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_temp(value, temptype, seq));
 
-        public static IntPtr tsequence_from_base_tstzset(ulong value, int temptype, IntPtr s)
+        public static IntPtr tsequence_from_base_tstzset(IntPtr value, int temptype, IntPtr s)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_tstzset(value, temptype, s));
 
-        public static IntPtr tsequence_from_base_tstzspan(ulong value, int temptype, IntPtr s, int interp)
+        public static IntPtr tsequence_from_base_tstzspan(IntPtr value, int temptype, IntPtr s, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_from_base_tstzspan(value, temptype, s, interp));
 
         public static IntPtr tsequence_make_exp(IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
@@ -6129,10 +6730,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tseqsetarr_to_tseqset(IntPtr seqsets, int count, int totalseqs)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqsetarr_to_tseqset(seqsets, count, totalseqs));
 
-        public static IntPtr tsequenceset_from_base_temp(ulong value, int temptype, IntPtr ss)
+        public static IntPtr tsequenceset_from_base_temp(IntPtr value, int temptype, IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_from_base_temp(value, temptype, ss));
 
-        public static IntPtr tsequenceset_from_base_tstzspanset(ulong value, int temptype, IntPtr ss, int interp)
+        public static IntPtr tsequenceset_from_base_tstzspanset(IntPtr value, int temptype, IntPtr ss, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_from_base_tstzspanset(value, temptype, ss, interp));
 
         public static IntPtr tsequenceset_make_exp(IntPtr sequences, int count, int maxcount, bool normalize)
@@ -6168,8 +6769,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_end_inst(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_end_inst(temp));
 
-        public static ulong temporal_end_value(IntPtr temp)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_end_value(temp));
+        public static int temporal_end_value(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_end_value(temp));
 
         public static IntPtr temporal_inst_n(IntPtr temp, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_inst_n(temp, n));
@@ -6180,8 +6781,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_max_inst_p(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_max_inst_p(temp));
 
-        public static ulong temporal_max_value(IntPtr temp)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_max_value(temp));
+        public static int temporal_max_value(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_max_value(temp));
 
         public static ulong temporal_mem_size(IntPtr temp)
             => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_mem_size(temp));
@@ -6189,8 +6790,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_min_inst_p(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_min_inst_p(temp));
 
-        public static ulong temporal_min_value(IntPtr temp)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_min_value(temp));
+        public static int temporal_min_value(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_min_value(temp));
 
         public static IntPtr temporal_sequences_p(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_sequences_p(temp, count));
@@ -6201,8 +6802,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_start_inst(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_start_inst(temp));
 
-        public static ulong temporal_start_value(IntPtr temp)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_start_value(temp));
+        public static int temporal_start_value(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_start_value(temp));
 
         public static IntPtr temporal_values_p(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_values_p(temp, count));
@@ -6213,8 +6814,8 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_values(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_values(temp, count));
 
-        public static uint tinstant_hash(IntPtr inst)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.tinstant_hash(inst));
+        public static int tinstant_hash(IntPtr inst)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_hash(inst));
 
         public static IntPtr tinstant_insts(IntPtr inst, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_insts(inst, count));
@@ -6228,13 +6829,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_timestamps(IntPtr inst, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_timestamps(inst, count));
 
-        public static ulong tinstant_value_p(IntPtr inst)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tinstant_value_p(inst));
+        public static int tinstant_value_p(IntPtr inst)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_value_p(inst));
 
-        public static ulong tinstant_value(IntPtr inst)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tinstant_value(inst));
+        public static int tinstant_value(IntPtr inst)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tinstant_value(inst));
 
-        public static bool tinstant_value_at_timestamptz(IntPtr inst, long t, IntPtr result)
+        public static bool tinstant_value_at_timestamptz(IntPtr inst, int t, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_value_at_timestamptz(inst, t, result));
 
         public static IntPtr tinstant_values_p(IntPtr inst, IntPtr count)
@@ -6261,11 +6862,11 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_duration(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_duration(seq));
 
-        public static long tsequence_end_timestamptz(IntPtr seq)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tsequence_end_timestamptz(seq));
+        public static int tsequence_end_timestamptz(IntPtr seq)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_end_timestamptz(seq));
 
-        public static uint tsequence_hash(IntPtr seq)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.tsequence_hash(seq));
+        public static int tsequence_hash(IntPtr seq)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_hash(seq));
 
         public static IntPtr[] tsequence_insts_p(IntPtr seq)
         {
@@ -6280,14 +6881,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_max_inst_p(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_max_inst_p(seq));
 
-        public static ulong tsequence_max_val(IntPtr seq)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequence_max_val(seq));
+        public static int tsequence_max_val(IntPtr seq)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_max_val(seq));
 
         public static IntPtr tsequence_min_inst_p(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_min_inst_p(seq));
 
-        public static ulong tsequence_min_val(IntPtr seq)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequence_min_val(seq));
+        public static int tsequence_min_val(IntPtr seq)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_min_val(seq));
 
         public static IntPtr tsequence_segments(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_segments(seq, count));
@@ -6295,8 +6896,8 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_seqs(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_seqs(seq, count));
 
-        public static long tsequence_start_timestamptz(IntPtr seq)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tsequence_start_timestamptz(seq));
+        public static int tsequence_start_timestamptz(IntPtr seq)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_start_timestamptz(seq));
 
         public static IntPtr tsequence_time(IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_time(seq));
@@ -6304,7 +6905,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_timestamps(IntPtr seq, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_timestamps(seq, count));
 
-        public static bool tsequence_value_at_timestamptz(IntPtr seq, long t, bool strict, IntPtr result)
+        public static bool tsequence_value_at_timestamptz(IntPtr seq, int t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_value_at_timestamptz(seq, t, strict, result));
 
         public static IntPtr tsequence_values_p(IntPtr seq, IntPtr count)
@@ -6313,11 +6914,11 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_duration(IntPtr ss, bool boundspan)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_duration(ss, boundspan));
 
-        public static long tsequenceset_end_timestamptz(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tsequenceset_end_timestamptz(ss));
+        public static int tsequenceset_end_timestamptz(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_end_timestamptz(ss));
 
-        public static uint tsequenceset_hash(IntPtr ss)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.tsequenceset_hash(ss));
+        public static int tsequenceset_hash(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_hash(ss));
 
         public static IntPtr tsequenceset_inst_n(IntPtr ss, int n)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_inst_n(ss, n));
@@ -6335,14 +6936,14 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_max_inst_p(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_max_inst_p(ss));
 
-        public static ulong tsequenceset_max_val(IntPtr ss)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequenceset_max_val(ss));
+        public static int tsequenceset_max_val(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_max_val(ss));
 
         public static IntPtr tsequenceset_min_inst_p(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_min_inst_p(ss));
 
-        public static ulong tsequenceset_min_val(IntPtr ss)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.tsequenceset_min_val(ss));
+        public static int tsequenceset_min_val(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_min_val(ss));
 
         public static int tsequenceset_num_instants(IntPtr ss)
             => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_num_instants(ss));
@@ -6363,8 +6964,8 @@ namespace MEOS.NET.Internal
             return _out;
         }
 
-        public static long tsequenceset_start_timestamptz(IntPtr ss)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tsequenceset_start_timestamptz(ss));
+        public static int tsequenceset_start_timestamptz(IntPtr ss)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequenceset_start_timestamptz(ss));
 
         public static IntPtr tsequenceset_time(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_time(ss));
@@ -6375,7 +6976,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_timestamps(IntPtr ss, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_timestamps(ss, count));
 
-        public static bool tsequenceset_value_at_timestamptz(IntPtr ss, long t, bool strict, IntPtr result)
+        public static bool tsequenceset_value_at_timestamptz(IntPtr ss, int t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_value_at_timestamptz(ss, t, strict, result));
 
         public static bool tsequenceset_value_n(IntPtr ss, int n, IntPtr result)
@@ -6405,16 +7006,16 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_to_tsequenceset(IntPtr inst, int interp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_to_tsequenceset(inst, interp));
 
-        public static IntPtr tnumber_shift_scale_value(IntPtr temp, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr tnumber_shift_scale_value(IntPtr temp, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_shift_scale_value(temp, shift, width, hasshift, haswidth));
 
-        public static IntPtr tnumberinst_shift_value(IntPtr inst, ulong shift)
+        public static IntPtr tnumberinst_shift_value(IntPtr inst, IntPtr shift)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberinst_shift_value(inst, shift));
 
-        public static IntPtr tnumberseq_shift_scale_value(IntPtr seq, ulong shift, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr tnumberseq_shift_scale_value(IntPtr seq, IntPtr shift, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_shift_scale_value(seq, shift, width, hasshift, haswidth));
 
-        public static IntPtr tnumberseqset_shift_scale_value(IntPtr ss, ulong start, ulong width, bool hasshift, bool haswidth)
+        public static IntPtr tnumberseqset_shift_scale_value(IntPtr ss, IntPtr start, IntPtr width, bool hasshift, bool haswidth)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_shift_scale_value(ss, start, width, hasshift, haswidth));
 
         public static void tsequence_restart(IntPtr seq, int count)
@@ -6477,7 +7078,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_append_tsequence(IntPtr seq1, IntPtr seq2, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_append_tsequence(seq1, seq2, expand));
 
-        public static IntPtr tsequence_delete_timestamptz(IntPtr seq, long t, bool connect)
+        public static IntPtr tsequence_delete_timestamptz(IntPtr seq, int t, bool connect)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_delete_timestamptz(seq, t, connect));
 
         public static IntPtr tsequence_delete_tstzset(IntPtr seq, IntPtr s, bool connect)
@@ -6504,7 +7105,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_append_tsequence(IntPtr ss, IntPtr seq, bool expand)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_append_tsequence(ss, seq, expand));
 
-        public static IntPtr tsequenceset_delete_timestamptz(IntPtr ss, long t)
+        public static IntPtr tsequenceset_delete_timestamptz(IntPtr ss, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_delete_timestamptz(ss, t));
 
         public static IntPtr tsequenceset_delete_tstzset(IntPtr ss, IntPtr s)
@@ -6537,19 +7138,19 @@ namespace MEOS.NET.Internal
         public static void tsequenceset_set_bbox(IntPtr ss, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tsequenceset_set_bbox(ss, box));
 
-        public static IntPtr tcontseq_after_timestamptz(IntPtr seq, long t, bool strict)
+        public static IntPtr tcontseq_after_timestamptz(IntPtr seq, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_after_timestamptz(seq, t, strict));
 
-        public static IntPtr tcontseq_before_timestamptz(IntPtr seq, long t, bool strict)
+        public static IntPtr tcontseq_before_timestamptz(IntPtr seq, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_before_timestamptz(seq, t, strict));
 
         public static IntPtr tcontseq_restrict_minmax(IntPtr seq, bool min, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_minmax(seq, min, atfunc));
 
-        public static IntPtr tdiscseq_after_timestamptz(IntPtr seq, long t, bool strict)
+        public static IntPtr tdiscseq_after_timestamptz(IntPtr seq, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_after_timestamptz(seq, t, strict));
 
-        public static IntPtr tdiscseq_before_timestamptz(IntPtr seq, long t, bool strict)
+        public static IntPtr tdiscseq_before_timestamptz(IntPtr seq, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_before_timestamptz(seq, t, strict));
 
         public static IntPtr tdiscseq_restrict_minmax(IntPtr seq, bool min, bool atfunc)
@@ -6561,7 +7162,7 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_restrict_minmax(IntPtr temp, bool min, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_minmax(temp, min, atfunc));
 
-        public static IntPtr temporal_restrict_timestamptz(IntPtr temp, long t, bool atfunc)
+        public static IntPtr temporal_restrict_timestamptz(IntPtr temp, int t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_timestamptz(temp, t, atfunc));
 
         public static IntPtr temporal_restrict_tstzset(IntPtr temp, IntPtr s, bool atfunc)
@@ -6573,19 +7174,19 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_restrict_tstzspanset(IntPtr temp, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_tstzspanset(temp, ss, atfunc));
 
-        public static IntPtr temporal_restrict_value(IntPtr temp, ulong value, bool atfunc)
+        public static IntPtr temporal_restrict_value(IntPtr temp, IntPtr value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_value(temp, value, atfunc));
 
         public static IntPtr temporal_restrict_values(IntPtr temp, IntPtr set, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_restrict_values(temp, set, atfunc));
 
-        public static bool temporal_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr result)
+        public static bool temporal_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_value_at_timestamptz(temp, t, strict, result));
 
-        public static IntPtr tinstant_after_timestamptz(IntPtr inst, long t, bool strict)
+        public static IntPtr tinstant_after_timestamptz(IntPtr inst, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_after_timestamptz(inst, t, strict));
 
-        public static IntPtr tinstant_before_timestamptz(IntPtr inst, long t, bool strict)
+        public static IntPtr tinstant_before_timestamptz(IntPtr inst, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_before_timestamptz(inst, t, strict));
 
         public static IntPtr tinstant_restrict_tstzspan(IntPtr inst, IntPtr period, bool atfunc)
@@ -6594,13 +7195,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tinstant_restrict_tstzspanset(IntPtr inst, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_tstzspanset(inst, ss, atfunc));
 
-        public static IntPtr tinstant_restrict_timestamptz(IntPtr inst, long t, bool atfunc)
+        public static IntPtr tinstant_restrict_timestamptz(IntPtr inst, int t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_timestamptz(inst, t, atfunc));
 
         public static IntPtr tinstant_restrict_tstzset(IntPtr inst, IntPtr s, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_tstzset(inst, s, atfunc));
 
-        public static IntPtr tinstant_restrict_value(IntPtr inst, ulong value, bool atfunc)
+        public static IntPtr tinstant_restrict_value(IntPtr inst, IntPtr value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_restrict_value(inst, value, atfunc));
 
         public static IntPtr tinstant_restrict_values(IntPtr inst, IntPtr set, bool atfunc)
@@ -6624,7 +7225,7 @@ namespace MEOS.NET.Internal
         public static IntPtr tnumberseqset_restrict_spanset(IntPtr ss, IntPtr spanset, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_restrict_spanset(ss, spanset, atfunc));
 
-        public static IntPtr tsequence_at_timestamptz(IntPtr seq, long t)
+        public static IntPtr tsequence_at_timestamptz(IntPtr seq, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_at_timestamptz(seq, t));
 
         public static IntPtr tsequence_restrict_tstzspan(IntPtr seq, IntPtr s, bool atfunc)
@@ -6633,10 +7234,10 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequence_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_restrict_tstzspanset(seq, ss, atfunc));
 
-        public static IntPtr tsequenceset_after_timestamptz(IntPtr ss, long t, bool strict)
+        public static IntPtr tsequenceset_after_timestamptz(IntPtr ss, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_after_timestamptz(ss, t, strict));
 
-        public static IntPtr tsequenceset_before_timestamptz(IntPtr ss, long t, bool strict)
+        public static IntPtr tsequenceset_before_timestamptz(IntPtr ss, int t, bool strict)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_before_timestamptz(ss, t, strict));
 
         public static IntPtr tsequenceset_restrict_minmax(IntPtr ss, bool min, bool atfunc)
@@ -6648,13 +7249,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tsequenceset_restrict_tstzspanset(IntPtr ss, IntPtr ps, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_tstzspanset(ss, ps, atfunc));
 
-        public static IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, long t, bool atfunc)
+        public static IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, int t, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_timestamptz(ss, t, atfunc));
 
         public static IntPtr tsequenceset_restrict_tstzset(IntPtr ss, IntPtr s, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_tstzset(ss, s, atfunc));
 
-        public static IntPtr tsequenceset_restrict_value(IntPtr ss, ulong value, bool atfunc)
+        public static IntPtr tsequenceset_restrict_value(IntPtr ss, IntPtr value, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_restrict_value(ss, value, atfunc));
 
         public static IntPtr tsequenceset_restrict_values(IntPtr ss, IntPtr s, bool atfunc)
@@ -6678,76 +7279,76 @@ namespace MEOS.NET.Internal
         public static bool tsequenceset_eq(IntPtr ss1, IntPtr ss2)
             => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_eq(ss1, ss2));
 
-        public static int always_eq_base_temporal(ulong value, IntPtr temp)
+        public static int always_eq_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_base_temporal(value, temp));
 
-        public static int always_eq_temporal_base(IntPtr temp, ulong value)
+        public static int always_eq_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_temporal_base(temp, value));
 
-        public static int always_ne_base_temporal(ulong value, IntPtr temp)
+        public static int always_ne_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_base_temporal(value, temp));
 
-        public static int always_ne_temporal_base(IntPtr temp, ulong value)
+        public static int always_ne_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_temporal_base(temp, value));
 
-        public static int always_ge_base_temporal(ulong value, IntPtr temp)
+        public static int always_ge_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ge_base_temporal(value, temp));
 
-        public static int always_ge_temporal_base(IntPtr temp, ulong value)
+        public static int always_ge_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_ge_temporal_base(temp, value));
 
-        public static int always_gt_base_temporal(ulong value, IntPtr temp)
+        public static int always_gt_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_gt_base_temporal(value, temp));
 
-        public static int always_gt_temporal_base(IntPtr temp, ulong value)
+        public static int always_gt_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_gt_temporal_base(temp, value));
 
-        public static int always_le_base_temporal(ulong value, IntPtr temp)
+        public static int always_le_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_le_base_temporal(value, temp));
 
-        public static int always_le_temporal_base(IntPtr temp, ulong value)
+        public static int always_le_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_le_temporal_base(temp, value));
 
-        public static int always_lt_base_temporal(ulong value, IntPtr temp)
+        public static int always_lt_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_lt_base_temporal(value, temp));
 
-        public static int always_lt_temporal_base(IntPtr temp, ulong value)
+        public static int always_lt_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.always_lt_temporal_base(temp, value));
 
-        public static int ever_eq_base_temporal(ulong value, IntPtr temp)
+        public static int ever_eq_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_base_temporal(value, temp));
 
-        public static int ever_eq_temporal_base(IntPtr temp, ulong value)
+        public static int ever_eq_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_temporal_base(temp, value));
 
-        public static int ever_ne_base_temporal(ulong value, IntPtr temp)
+        public static int ever_ne_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_base_temporal(value, temp));
 
-        public static int ever_ne_temporal_base(IntPtr temp, ulong value)
+        public static int ever_ne_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_temporal_base(temp, value));
 
-        public static int ever_ge_base_temporal(ulong value, IntPtr temp)
+        public static int ever_ge_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ge_base_temporal(value, temp));
 
-        public static int ever_ge_temporal_base(IntPtr temp, ulong value)
+        public static int ever_ge_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_ge_temporal_base(temp, value));
 
-        public static int ever_gt_base_temporal(ulong value, IntPtr temp)
+        public static int ever_gt_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_gt_base_temporal(value, temp));
 
-        public static int ever_gt_temporal_base(IntPtr temp, ulong value)
+        public static int ever_gt_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_gt_temporal_base(temp, value));
 
-        public static int ever_le_base_temporal(ulong value, IntPtr temp)
+        public static int ever_le_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_le_base_temporal(value, temp));
 
-        public static int ever_le_temporal_base(IntPtr temp, ulong value)
+        public static int ever_le_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_le_temporal_base(temp, value));
 
-        public static int ever_lt_base_temporal(ulong value, IntPtr temp)
+        public static int ever_lt_base_temporal(IntPtr value, IntPtr temp)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_lt_base_temporal(value, temp));
 
-        public static int ever_lt_temporal_base(IntPtr temp, ulong value)
+        public static int ever_lt_temporal_base(IntPtr temp, IntPtr value)
             => SafeExecution<int>(() => MEOSExternalFunctions.ever_lt_temporal_base(temp, value));
 
         public static IntPtr tnumberinst_abs(IntPtr inst)
@@ -6771,13 +7372,13 @@ namespace MEOS.NET.Internal
         public static IntPtr tnumberseqset_delta_value(IntPtr ss)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseqset_delta_value(ss));
 
-        public static IntPtr tdistance_tnumber_number(IntPtr temp, ulong value)
+        public static IntPtr tdistance_tnumber_number(IntPtr temp, IntPtr value)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tnumber_number(temp, value));
 
         public static double nad_tbox_tbox(IntPtr box1, IntPtr box2)
             => SafeExecution<double>(() => MEOSExternalFunctions.nad_tbox_tbox(box1, box2));
 
-        public static double nad_tnumber_number(IntPtr temp, ulong value)
+        public static double nad_tnumber_number(IntPtr temp, IntPtr value)
             => SafeExecution<double>(() => MEOSExternalFunctions.nad_tnumber_number(temp, value));
 
         public static double nad_tnumber_tbox(IntPtr temp, IntPtr box)
@@ -6837,32 +7438,950 @@ namespace MEOS.NET.Internal
         public static IntPtr temporal_app_tseq_transfn(IntPtr state, IntPtr seq)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_app_tseq_transfn(state, seq));
 
-        public static IntPtr span_bins(IntPtr s, ulong size, ulong origin, IntPtr count)
+        public static IntPtr span_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_bins(s, size, origin, count));
 
-        public static IntPtr spanset_bins(IntPtr ss, ulong size, ulong origin, IntPtr count)
+        public static IntPtr spanset_bins(IntPtr ss, IntPtr size, IntPtr origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_bins(ss, size, origin, count));
 
-        public static IntPtr tnumber_value_bins(IntPtr temp, ulong size, ulong origin, IntPtr count)
+        public static IntPtr tnumber_value_bins(IntPtr temp, IntPtr size, IntPtr origin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_bins(temp, size, origin, count));
 
-        public static IntPtr tnumber_value_time_boxes(IntPtr temp, ulong vsize, IntPtr duration, ulong vorigin, long torigin, IntPtr count)
+        public static IntPtr tnumber_value_time_boxes(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_boxes(temp, vsize, duration, vorigin, torigin, count));
 
-        public static IntPtr tnumber_value_split(IntPtr temp, ulong vsize, ulong vorigin, IntPtr bins, IntPtr count)
+        public static IntPtr tnumber_value_split(IntPtr temp, IntPtr vsize, IntPtr vorigin, IntPtr bins, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_split(temp, vsize, vorigin, bins, count));
 
-        public static IntPtr tbox_get_value_time_tile(ulong value, long t, ulong vsize, IntPtr duration, ulong vorigin, long torigin, int basetype, int spantype)
+        public static IntPtr tbox_get_value_time_tile(IntPtr value, int t, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, int basetype, int spantype)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_get_value_time_tile(value, t, vsize, duration, vorigin, torigin, basetype, spantype));
 
-        public static IntPtr tnumber_value_time_split(IntPtr temp, ulong size, IntPtr duration, ulong vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count)
+        public static IntPtr tnumber_value_time_split(IntPtr temp, IntPtr size, IntPtr duration, IntPtr vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_split(temp, size, duration, vorigin, torigin, value_bins, time_bins, count));
+
+        public static string double2_out(IntPtr d, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.double2_out(d, maxdd));
+
+        public static void double2_set(double a, double b, IntPtr result)
+            => SafeExecution(() => MEOSExternalFunctions.double2_set(a, b, result));
+
+        public static IntPtr double2_add(IntPtr d1, IntPtr d2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double2_add(d1, d2));
+
+        public static bool double2_eq(IntPtr d1, IntPtr d2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double2_eq(d1, d2));
+
+        public static string double3_out(IntPtr d, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.double3_out(d, maxdd));
+
+        public static void double3_set(double a, double b, double c, IntPtr result)
+            => SafeExecution(() => MEOSExternalFunctions.double3_set(a, b, c, result));
+
+        public static IntPtr double3_add(IntPtr d1, IntPtr d2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double3_add(d1, d2));
+
+        public static bool double3_eq(IntPtr d1, IntPtr d2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double3_eq(d1, d2));
+
+        public static string double4_out(IntPtr d, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.double4_out(d, maxdd));
+
+        public static void double4_set(double a, double b, double c, double d, IntPtr result)
+            => SafeExecution(() => MEOSExternalFunctions.double4_set(a, b, c, d, result));
+
+        public static IntPtr double4_add(IntPtr d1, IntPtr d2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double4_add(d1, d2));
+
+        public static bool double4_eq(IntPtr d1, IntPtr d2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double4_eq(d1, d2));
+
+        public static bool double2_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double2_collinear(x1, x2, x3, ratio));
+
+        public static bool double3_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double3_collinear(x1, x2, x3, ratio));
+
+        public static bool double4_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double4_collinear(x1, x2, x3, ratio));
+
+        public static IntPtr double2segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double2segm_interpolate(start, end, ratio));
+
+        public static IntPtr double3segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double3segm_interpolate(start, end, ratio));
+
+        public static IntPtr double4segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.double4segm_interpolate(start, end, ratio));
+
+        public static int pg_atoi(string s, int size, int c)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_atoi(s, size, c));
+
+        public static bool ensure_has_X(int type, short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_X(type, flags));
+
+        public static bool ensure_has_Z(int type, short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_Z(type, flags));
+
+        public static bool ensure_has_T(int type, short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_T(type, flags));
+
+        public static bool ensure_has_not_Z(int type, short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_Z(type, flags));
+
+        public static bool ensure_not_null(IntPtr ptr)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_null(ptr));
+
+        public static bool ensure_one_not_null(IntPtr ptr1, IntPtr ptr2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_one_not_null(ptr1, ptr2));
+
+        public static bool ensure_one_true(bool hasshift, bool haswidth)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_one_true(hasshift, haswidth));
+
+        public static bool ensure_valid_interp(int temptype, int interp)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_interp(temptype, interp));
+
+        public static bool ensure_continuous(IntPtr temp)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_continuous(temp));
+
+        public static bool ensure_same_interp(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_interp(temp1, temp2));
+
+        public static bool ensure_same_continuous_interp(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_continuous_interp(flags1, flags2));
+
+        public static bool ensure_linear_interp(short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_linear_interp(flags));
+
+        public static bool ensure_nonlinear_interp(short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_nonlinear_interp(flags));
+
+        public static bool ensure_common_dimension(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_common_dimension(flags1, flags2));
+
+        public static bool ensure_temporal_isof_type(IntPtr temp, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_type(temp, type));
+
+        public static bool ensure_temporal_isof_basetype(IntPtr temp, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_basetype(temp, basetype));
+
+        public static bool ensure_temporal_isof_subtype(IntPtr temp, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_temporal_isof_subtype(temp, type));
+
+        public static bool ensure_same_temporal_type(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_temporal_type(temp1, temp2));
+
+        public static bool ensure_valid_tnumber_numspan(IntPtr temp, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_numspan(temp, s));
+
+        public static bool ensure_valid_tnumber_numspanset(IntPtr temp, IntPtr ss)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_numspanset(temp, ss));
+
+        public static bool ensure_valid_tnumber_tbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_tbox(temp, box));
+
+        public static bool ensure_valid_temporal_set(IntPtr temp, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_temporal_set(temp, s));
+
+        public static bool ensure_valid_temporal_temporal(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_temporal_temporal(temp1, temp2));
+
+        public static bool ensure_valid_tnumber_tnumber(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnumber_tnumber(temp1, temp2));
+
+        public static bool ensure_not_negative(int i)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_negative(i));
+
+        public static bool ensure_positive(int i)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive(i));
+
+        public static bool not_negative_datum(IntPtr size, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.not_negative_datum(size, basetype));
+
+        public static bool ensure_not_negative_datum(IntPtr size, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_negative_datum(size, basetype));
+
+        public static bool positive_datum(IntPtr size, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.positive_datum(size, basetype));
+
+        public static bool ensure_positive_datum(IntPtr size, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive_datum(size, basetype));
+
+        public static bool ensure_valid_day_duration(IntPtr duration)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_day_duration(duration));
+
+        public static bool positive_duration(IntPtr duration)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.positive_duration(duration));
+
+        public static bool ensure_positive_duration(IntPtr duration)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_positive_duration(duration));
+
+        public static IntPtr temporal_bbox_ptr(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_bbox_ptr(temp));
+
+        public static bool intersection_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr mode, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_temporal_temporal(temp1, temp2, mode, inter1, inter2));
+
+        public static string mobilitydb_version()
+            => SafeExecution<string>(() => MEOSExternalFunctions.mobilitydb_version());
+
+        public static string mobilitydb_full_version()
+            => SafeExecution<string>(() => MEOSExternalFunctions.mobilitydb_full_version());
+
+        public static IntPtr round_fn(int basetype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.round_fn(basetype));
+
+        public static bool temporal_bbox_restrict_value(IntPtr temp, IntPtr value)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.temporal_bbox_restrict_value(temp, value));
+
+        public static bool ensure_valid_tcbuffer_cbuffer(IntPtr temp, IntPtr cb)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_cbuffer(temp, cb));
+
+        public static bool ensure_valid_tcbuffer_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_geo(temp, gs));
+
+        public static bool ensure_valid_tcbuffer_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_stbox(temp, box));
+
+        public static bool ensure_valid_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tcbuffer_tcbuffer(temp1, temp2));
+
+        public static int tcbuffersegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_intersection_value(start, end, value, lower, upper, t1, t2));
+
+        public static int tcbuffersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static int tcbuffersegm_dwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_dwithin_turnpt(start1, end1, start2, end2, dist, lower, upper, t1, t2));
+
+        public static int tcbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcbuffersegm_distance_turnpt(start1, end1, start2, end2, dist, lower, upper, t1, t2));
+
+        public static bool cbuffer_set_stbox(IntPtr cb, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_set_stbox(cb, box));
+
+        public static void cbufferarr_set_stbox(IntPtr values, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.cbufferarr_set_stbox(values, count, box));
+
+        public static bool cbuffer_timestamptz_set_stbox(IntPtr cb, int t, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_timestamptz_set_stbox(cb, t, box));
+
+        public static bool cbuffer_tstzspan_set_stbox(IntPtr cb, IntPtr s, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.cbuffer_tstzspan_set_stbox(cb, s, box));
+
+        public static void tcbufferinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tcbufferinst_set_stbox(inst, box));
+
+        public static void tcbufferinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tcbufferinstarr_set_stbox(instants, count, box));
+
+        public static void tcbufferseq_expand_stbox(IntPtr seq, IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.tcbufferseq_expand_stbox(seq, inst));
+
+        public static IntPtr tcbufferinst_trav_area(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferinst_trav_area(inst));
+
+        public static IntPtr tcbufferseq_trav_area(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferseq_trav_area(seq));
+
+        public static IntPtr tcbufferseqset_trav_area(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbufferseqset_trav_area(ss));
+
+        public static IntPtr tcbuffersegm_trav_area(IntPtr inst1, IntPtr inst2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffersegm_trav_area(inst1, inst2));
+
+        public static IntPtr tcbuffer_restrict_cbuffer(IntPtr temp, IntPtr cb, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_cbuffer(temp, cb, atfunc));
+
+        public static IntPtr tcbuffer_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_stbox(temp, box, border_inc, atfunc));
+
+        public static IntPtr tcbuffer_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcbuffer_restrict_geom(temp, gs, atfunc));
+
+        public static int ea_contains_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_tcbuffer(gs, temp, ever));
+
+        public static int ea_contains_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tcbuffer_geo(temp, gs, ever));
+
+        public static int ea_contains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tcbuffer_cbuffer(temp, cb, ever));
+
+        public static int ea_contains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_cbuffer_tcbuffer(cb, temp, ever));
+
+        public static int ea_covers_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_tcbuffer(gs, temp, ever));
+
+        public static int ea_covers_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_geo(temp, gs, ever));
+
+        public static int ea_covers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_cbuffer(temp, cb, ever));
+
+        public static int ea_covers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_cbuffer_tcbuffer(cb, temp, ever));
+
+        public static int ea_covers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tcbuffer_tcbuffer(temp1, temp2, ever));
+
+        public static int ea_disjoint_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_geo(temp, gs, ever));
+
+        public static int ea_disjoint_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_geo_tcbuffer(gs, temp, ever));
+
+        public static int ea_disjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_cbuffer(temp, cb, ever));
+
+        public static int ea_disjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_cbuffer_tcbuffer(cb, temp, ever));
+
+        public static int ea_disjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tcbuffer_tcbuffer(temp1, temp2, ever));
+
+        public static int ea_intersects_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_geo(temp, gs, ever));
+
+        public static int ea_intersects_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_geo_tcbuffer(gs, temp, ever));
+
+        public static int ea_intersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_cbuffer(temp, cb, ever));
+
+        public static int ea_intersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_cbuffer_tcbuffer(cb, temp, ever));
+
+        public static int ea_intersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tcbuffer_tcbuffer(temp1, temp2, ever));
+
+        public static int ea_touches_tcbuffer_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_geo(temp, gs, ever));
+
+        public static int ea_touches_geo_tcbuffer(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_geo_tcbuffer(gs, temp, ever));
+
+        public static int ea_touches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_cbuffer(temp, cb, ever));
+
+        public static int ea_touches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_cbuffer_tcbuffer(cb, temp, ever));
+
+        public static int ea_touches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tcbuffer_tcbuffer(temp1, temp2, ever));
+
+        public static IntPtr tinterrel_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, bool tinter)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tcbuffer_cbuffer(temp, cb, tinter));
+
+        public static IntPtr tinterrel_tcbuffer_geo(IntPtr temp, IntPtr gs, bool tinter)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tcbuffer_geo(temp, gs, tinter));
+
+        public static int lwproj_lookup(int srid_from, int srid_to, IntPtr pj)
+            => SafeExecution<int>(() => MEOSExternalFunctions.lwproj_lookup(srid_from, srid_to, pj));
+
+        public static int spheroid_init_from_srid(int srid, IntPtr s)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spheroid_init_from_srid(srid, s));
+
+        public static void srid_check_latlong(int srid)
+            => SafeExecution(() => MEOSExternalFunctions.srid_check_latlong(srid));
+
+        public static int srid_is_latlong(int srid)
+            => SafeExecution<int>(() => MEOSExternalFunctions.srid_is_latlong(srid));
+
+        public static IntPtr geom_serialize(IntPtr lwgeom)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geom_serialize(lwgeom));
+
+        public static IntPtr geog_serialize(IntPtr lwgeom)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geog_serialize(lwgeom));
+
+        public static IntPtr postgis_valid_typmod(IntPtr gs, int typmod)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.postgis_valid_typmod(gs, typmod));
+
+        public static string geo_as_wkt(IntPtr gs, int precision, bool extended)
+            => SafeExecution<string>(() => MEOSExternalFunctions.geo_as_wkt(gs, precision, extended));
+
+        public static IntPtr box2d_to_lwgeom(IntPtr box, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.box2d_to_lwgeom(box, srid));
+
+        public static IntPtr box3d_to_lwgeom(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.box3d_to_lwgeom(box));
+
+        public static IntPtr POSTGIS2GEOS(IntPtr pglwgeom)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.POSTGIS2GEOS(pglwgeom));
+
+        public static IntPtr GEOS2POSTGIS(IntPtr geom, byte want3d)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.GEOS2POSTGIS(geom, want3d));
+
+        public static bool geom_spatialrel(IntPtr gs1, IntPtr gs2, IntPtr rel)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geom_spatialrel(gs1, gs2, rel));
+
+        public static IntPtr lwgeom_line_interpolate_point(IntPtr geom, double fraction, int srid, byte repeat)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwgeom_line_interpolate_point(geom, fraction, srid, repeat));
+
+        public static void point_get_coords(IntPtr point, bool hasz, IntPtr x, IntPtr y, IntPtr z)
+            => SafeExecution(() => MEOSExternalFunctions.point_get_coords(point, hasz, x, y, z));
+
+        public static void tstzset_stbox_slice(IntPtr tsdatum, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tstzset_stbox_slice(tsdatum, box));
+
+        public static void tstzspanset_stbox_slice(IntPtr psdatum, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tstzspanset_stbox_slice(psdatum, box));
+
+        public static bool stbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_index_leaf_consistent(key, query, strategy));
+
+        public static bool stbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_gist_inner_consistent(key, query, strategy));
+
+        public static bool stbox_index_recheck(int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_index_recheck(strategy));
+
+        public static void mobilitydb_init()
+            => SafeExecution(() => MEOSExternalFunctions.mobilitydb_init());
+
+        public static IntPtr geo_stbox(IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_stbox(gs));
+
+        public static IntPtr stbox_geo(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_geo(box));
+
+        public static IntPtr tcomp_geo_tgeo(IntPtr gs, IntPtr temp, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_geo_tgeo(gs, temp, func));
+
+        public static IntPtr tcomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_tgeo_geo(temp, gs, func));
+
+        public static bool ensure_geoaggstate(IntPtr state, int srid, bool hasz)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoaggstate(state, srid, hasz));
+
+        public static bool ensure_geoaggstate_state(IntPtr state1, IntPtr state2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_geoaggstate_state(state1, state2));
+
+        public static IntPtr tpoint_transform_tcentroid(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_transform_tcentroid(temp, count));
+
+        public static IntPtr tpointinst_tcentroid_finalfn(IntPtr instants, int count, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointinst_tcentroid_finalfn(instants, count, srid));
+
+        public static IntPtr tpointseq_tcentroid_finalfn(IntPtr sequences, int count, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_tcentroid_finalfn(sequences, count, srid));
+
+        public static bool point3d_min_dist(IntPtr p1, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr fraction)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.point3d_min_dist(p1, p2, p3, p4, fraction));
+
+        public static int tgeompointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tgeompointsegm_distance_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
+
+        public static int tgeogpointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tgeogpointsegm_distance_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
+
+        public static double tnumberinst_distance(IntPtr inst1, IntPtr inst2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberinst_distance(inst1, inst2));
+
+        public static double tinstant_distance(IntPtr inst1, IntPtr inst2, IntPtr func)
+            => SafeExecution<double>(() => MEOSExternalFunctions.tinstant_distance(inst1, inst2, func));
+
+        public static IntPtr tpointseq_at_geom(IntPtr seq, IntPtr gs, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_at_geom(seq, gs, count));
+
+        public static IntPtr tpointseq_interperiods(IntPtr seq, IntPtr gs, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpointseq_interperiods(seq, gs, count));
+
+        public static void datum_point4d(IntPtr value, IntPtr p)
+            => SafeExecution(() => MEOSExternalFunctions.datum_point4d(value, p));
+
+        public static int geopoint_cmp(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.geopoint_cmp(gs1, gs2));
+
+        public static bool geopoint_eq(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_eq(gs1, gs2));
+
+        public static bool geopoint_same(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_same(gs1, gs2));
+
+        public static bool datum_point_eq(IntPtr point1, IntPtr point2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_point_eq(point1, point2));
+
+        public static bool datum_point_same(IntPtr point1, IntPtr point2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_point_same(point1, point2));
+
+        public static int datum2_point_eq(IntPtr point1, IntPtr point2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_eq(point1, point2));
+
+        public static int datum2_point_ne(IntPtr point1, IntPtr point2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_ne(point1, point2));
+
+        public static int datum2_point_same(IntPtr point1, IntPtr point2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_same(point1, point2));
+
+        public static int datum2_point_nsame(IntPtr point1, IntPtr point2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_point_nsame(point1, point2));
+
+        public static int datum2_geom_centroid(IntPtr geo)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_geom_centroid(geo));
+
+        public static int datum2_geog_centroid(IntPtr geo)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_geog_centroid(geo));
+
+        public static IntPtr geo_extract_elements(IntPtr gs, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_extract_elements(gs, count));
+
+        public static IntPtr geo_serialize(IntPtr geom)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_serialize(geom));
+
+        public static IntPtr geo_distance_fn(short flags)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_distance_fn(flags));
+
+        public static IntPtr pt_distance_fn(short flags)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pt_distance_fn(flags));
+
+        public static int datum_geom_distance2d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_distance2d(geom1, geom2));
+
+        public static int datum_geom_distance3d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_distance3d(geom1, geom2));
+
+        public static int datum_geog_distance(IntPtr geog1, IntPtr geog2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_distance(geog1, geog2));
+
+        public static int datum_pt_distance2d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pt_distance2d(geom1, geom2));
+
+        public static int datum_pt_distance3d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pt_distance3d(geom1, geom2));
+
+        public static short spatial_flags(IntPtr d, int basetype)
+            => SafeExecution<short>(() => MEOSExternalFunctions.spatial_flags(d, basetype));
+
+        public static bool ensure_srid_is_latlong(int srid)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_srid_is_latlong(srid));
+
+        public static bool ensure_spatial_validity(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spatial_validity(temp1, temp2));
+
+        public static bool ensure_not_geodetic(short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_geodetic(flags));
+
+        public static bool ensure_same_geodetic(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic(flags1, flags2));
+
+        public static bool ensure_same_geodetic_geo(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_geo(gs1, gs2));
+
+        public static bool ensure_same_geodetic_tspatial_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_tspatial_geo(temp, gs));
+
+        public static bool ensure_same_geodetic_tspatial_base(IntPtr temp, IntPtr @base)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_tspatial_base(temp, @base));
+
+        public static bool ensure_srid_known(int srid)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_srid_known(srid));
+
+        public static bool ensure_same_srid(int srid1, int srid2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_srid(srid1, srid2));
+
+        public static bool ensure_same_dimensionality(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality(flags1, flags2));
+
+        public static bool same_spatial_dimensionality(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_spatial_dimensionality(flags1, flags2));
+
+        public static bool ensure_same_spatial_dimensionality(short flags1, short flags2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spatial_dimensionality(flags1, flags2));
+
+        public static bool ensure_same_dimensionality_geo(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_geo(gs1, gs2));
+
+        public static bool same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_dimensionality_tspatial_geo(temp, gs));
+
+        public static bool ensure_same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_tspatial_geo(temp, gs));
+
+        public static bool ensure_same_spatial_dimensionality_stbox_geo(IntPtr box, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spatial_dimensionality_stbox_geo(box, gs));
+
+        public static bool ensure_same_geodetic_stbox_geo(IntPtr box, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geodetic_stbox_geo(box, gs));
+
+        public static bool ensure_has_Z_geo(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_Z_geo(gs));
+
+        public static bool ensure_has_not_Z_geo(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_Z_geo(gs));
+
+        public static bool ensure_has_M_geo(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_M_geo(gs));
+
+        public static bool ensure_has_not_M_geo(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_not_M_geo(gs));
+
+        public static bool ensure_not_geodetic_geo(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_geodetic_geo(gs));
+
+        public static bool ensure_point_type(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_point_type(gs));
+
+        public static bool ensure_mline_type(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_mline_type(gs));
+
+        public static bool circle_type(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.circle_type(gs));
+
+        public static bool ensure_circle_type(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_circle_type(gs));
+
+        public static bool ensure_not_empty(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_not_empty(gs));
+
+        public static bool ensure_valid_stbox_geo(IntPtr box, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_stbox_geo(box, gs));
+
+        public static bool ensure_valid_tspatial_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_geo(temp, gs));
+
+        public static bool ensure_valid_tspatial_base(IntPtr temp, IntPtr @base)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_base(temp, @base));
+
+        public static bool ensure_valid_tspatial_tspatial(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tspatial_tspatial(temp1, temp2));
+
+        public static bool ensure_valid_spatial_stbox_stbox(IntPtr box1, IntPtr box2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spatial_stbox_stbox(box1, box2));
+
+        public static bool ensure_valid_tgeo_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_stbox(temp, box));
+
+        public static bool ensure_valid_geo_geo(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_geo_geo(gs1, gs2));
+
+        public static bool ensure_valid_tgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_geo(temp, gs));
+
+        public static bool ensure_valid_tgeo_tgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tgeo_tgeo(temp1, temp2));
+
+        public static bool ensure_valid_tpoint_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpoint_geo(temp, gs));
+
+        public static bool ensure_valid_tpoint_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpoint_tpoint(temp1, temp2));
+
+        public static bool mline_type(IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.mline_type(gs));
+
+        public static IntPtr tpoint_get_coord(IntPtr temp, int coord)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_get_coord(temp, coord));
+
+        public static int eacomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_tgeo_geo(temp, gs, func, ever));
+
+        public static IntPtr closest_point2d_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point2d_on_segment_ratio(p, A, B, closest));
+
+        public static IntPtr closest_point3dz_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point3dz_on_segment_ratio(p, A, B, closest));
+
+        public static IntPtr closest_point_on_segment_sphere(IntPtr p, IntPtr A, IntPtr B, IntPtr closest, IntPtr dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.closest_point_on_segment_sphere(p, A, B, closest, dist));
+
+        public static void interpolate_point4d_spheroid(IntPtr p1, IntPtr p2, IntPtr p, IntPtr s, double f)
+            => SafeExecution(() => MEOSExternalFunctions.interpolate_point4d_spheroid(p1, p2, p, s, f));
+
+        public static IntPtr geopoint_make(double x, double y, double z, bool hasz, bool geodetic, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geopoint_make(x, y, z, hasz, geodetic, srid));
+
+        public static IntPtr lwcircle_make(double x, double y, double radius, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwcircle_make(x, y, radius, srid));
+
+        public static IntPtr geocircle_make(double x, double y, double radius, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geocircle_make(x, y, radius, srid));
+
+        public static int pointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pointsegm_interpolate(start, end, ratio));
+
+        public static IntPtr pointsegm_locate(IntPtr start, IntPtr end, IntPtr point, IntPtr dist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pointsegm_locate(start, end, point, dist));
+
+        public static int tgeompointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tgeompointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static int tgeogpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tgeogpointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static bool geopoint_collinear(IntPtr value1, IntPtr value2, IntPtr value3, double ratio, bool hasz, bool geodetic)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geopoint_collinear(value1, value2, value3, ratio, hasz, geodetic));
+
+        public static IntPtr lwpointarr_remove_duplicates(IntPtr points, int count, IntPtr newcount)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwpointarr_remove_duplicates(points, count, newcount));
+
+        public static IntPtr lwpointarr_make_trajectory(IntPtr points, int count, int interp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwpointarr_make_trajectory(points, count, interp));
+
+        public static IntPtr lwline_make(IntPtr value1, IntPtr value2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwline_make(value1, value2));
+
+        public static IntPtr lwcoll_from_points_lines(IntPtr points, IntPtr lines, int npoints, int nlines)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.lwcoll_from_points_lines(points, lines, npoints, nlines));
+
+        public static int tpointseq_stops_iter(IntPtr seq, double maxdist, int mintunits, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tpointseq_stops_iter(seq, maxdist, mintunits, result));
+
+        public static int datum_geom_contains(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_contains(geom1, geom2));
+
+        public static int datum_geom_covers(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_covers(geom1, geom2));
+
+        public static int datum_geom_disjoint2d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_disjoint2d(geom1, geom2));
+
+        public static int datum_geom_disjoint3d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_disjoint3d(geom1, geom2));
+
+        public static int datum_geog_disjoint(IntPtr geog1, IntPtr geog2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_disjoint(geog1, geog2));
+
+        public static int datum_geom_intersects2d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_intersects2d(geom1, geom2));
+
+        public static int datum_geom_intersects3d(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_intersects3d(geom1, geom2));
+
+        public static int datum_geog_intersects(IntPtr geog1, IntPtr geog2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_intersects(geog1, geog2));
+
+        public static int datum_geom_touches(IntPtr geom1, IntPtr geom2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_touches(geom1, geom2));
+
+        public static int datum_geom_dwithin2d(IntPtr geom1, IntPtr geom2, IntPtr dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_dwithin2d(geom1, geom2, dist));
+
+        public static int datum_geom_dwithin3d(IntPtr geom1, IntPtr geom2, IntPtr dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_dwithin3d(geom1, geom2, dist));
+
+        public static int datum_geog_dwithin(IntPtr geog1, IntPtr geog2, IntPtr dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geog_dwithin(geog1, geog2, dist));
+
+        public static int datum_geom_relate_pattern(IntPtr geog1, IntPtr geog2, IntPtr p)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geom_relate_pattern(geog1, geog2, p));
+
+        public static IntPtr geo_disjoint_fn(short flags1, short flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_disjoint_fn(flags1, flags2));
+
+        public static IntPtr geo_disjoint_fn_geo(short flags1, IntPtr flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_disjoint_fn_geo(flags1, flags2));
+
+        public static IntPtr geo_intersects_fn(short flags1, short flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_intersects_fn(flags1, flags2));
+
+        public static IntPtr geo_intersects_fn_geo(short flags1, IntPtr flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_intersects_fn_geo(flags1, flags2));
+
+        public static IntPtr geo_dwithin_fn(short flags1, short flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_dwithin_fn(flags1, flags2));
+
+        public static IntPtr geo_dwithin_fn_geo(short flags1, IntPtr flags2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_dwithin_fn_geo(flags1, flags2));
+
+        public static int tpointsegm_tdwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tpointsegm_tdwithin_turnpt(start1, end1, start2, end2, value, lower, upper, t1, t2));
+
+        public static int spatialrel_geo_geo(IntPtr gs1, IntPtr gs2, IntPtr param, IntPtr func, int numparam, bool invert)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spatialrel_geo_geo(gs1, gs2, param, func, numparam, invert));
+
+        public static int spatialrel_tgeo_tgeo(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam)
+            => SafeExecution<int>(() => MEOSExternalFunctions.spatialrel_tgeo_tgeo(temp1, temp2, param, func, numparam));
+
+        public static int ea_contains_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_tgeo(gs, temp, ever));
+
+        public static int ea_contains_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tgeo_geo(temp, gs, ever));
+
+        public static int ea_contains_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_tgeo_tgeo(temp, temp2, ever));
+
+        public static int ea_covers_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_tgeo(gs, temp, ever));
+
+        public static int ea_covers_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tgeo_geo(temp, gs, ever));
+
+        public static int ea_covers_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_tgeo_tgeo(temp, temp2, ever));
+
+        public static int ea_disjoint_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_geo_tgeo(gs, temp, ever));
+
+        public static int ea_disjoint_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tgeo_geo(temp, gs, ever));
+
+        public static int ea_disjoint_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_tgeo_tgeo(temp, temp2, ever));
+
+        public static int ea_intersects_geo_tgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_geo_tgeo(gs, temp, ever));
+
+        public static int ea_intersects_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tgeo_geo(temp, gs, ever));
+
+        public static int ea_intersects_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_intersects_tgeo_tgeo(temp, temp2, ever));
+
+        public static int ea_touches_tpoint_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tpoint_geo(temp, gs, ever));
+
+        public static int ea_touches_tgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tgeo_geo(temp, gs, ever));
+
+        public static int ea_touches_tgeo_tgeo(IntPtr temp, IntPtr temp2, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_touches_tgeo_tgeo(temp, temp2, ever));
+
+        public static int ea_dwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_dwithin_tgeo_geo(temp, gs, dist, ever));
+
+        public static int ea_dwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_dwithin_tgeo_tgeo(temp1, temp2, dist, ever));
+
+        public static int ea_spatialrel_tspatial_geo(IntPtr temp, IntPtr gs, IntPtr func, bool ever, bool invert)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_spatialrel_tspatial_geo(temp, gs, func, ever, invert));
+
+        public static int ea_spatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_spatialrel_tspatial_tspatial(temp1, temp2, func, ever));
+
+        public static IntPtr tspatialrel_tspatial_base(IntPtr temp, IntPtr @base, IntPtr param, IntPtr func, int numparam, bool invert)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialrel_tspatial_base(temp, @base, param, func, numparam, invert));
+
+        public static IntPtr tspatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam, bool invert)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialrel_tspatial_tspatial(temp1, temp2, param, func, numparam, invert));
+
+        public static IntPtr tinterrel_tgeo_geo(IntPtr temp, IntPtr gs, bool tinter)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tgeo_geo(temp, gs, tinter));
+
+        public static IntPtr tinterrel_tspatial_base(IntPtr temp, IntPtr @base, bool tinter, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tspatial_base(temp, @base, tinter, func));
+
+        public static IntPtr tinterrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, bool tinter)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinterrel_tspatial_tspatial(temp1, temp2, tinter));
+
+        public static IntPtr tdwithin_tspatial_tspatial(IntPtr sync1, IntPtr sync2, IntPtr dist, IntPtr func, IntPtr tpfn)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tspatial_tspatial(sync1, sync2, dist, func, tpfn));
+
+        public static int tdwithin_add_solutions(int solutions, int lower, int upper, bool lower_inc, bool upper_inc, bool upper_inc1, int t1, int t2, IntPtr instants, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tdwithin_add_solutions(solutions, lower, upper, lower_inc, upper_inc, upper_inc1, t1, t2, instants, result));
+
+        public static IntPtr tdwithin_tspatial_spatial(IntPtr temp, IntPtr @base, IntPtr dist, IntPtr func, IntPtr tpfn)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdwithin_tspatial_spatial(temp, @base, dist, func, tpfn));
+
+        public static IntPtr bitmatrix_make(IntPtr count, int ndims)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bitmatrix_make(count, ndims));
+
+        public static int tpoint_set_tiles(IntPtr temp, IntPtr state, IntPtr bm)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tpoint_set_tiles(temp, state, bm));
+
+        public static IntPtr tpoint_at_tile(IntPtr temp, IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_at_tile(temp, box));
+
+        public static void stbox_tile_state_set(double x, double y, double z, int t, double xsize, double ysize, double zsize, int tunits, bool hasx, bool hasz, bool hast, int srid, IntPtr result)
+            => SafeExecution(() => MEOSExternalFunctions.stbox_tile_state_set(x, y, z, t, xsize, ysize, zsize, tunits, hasx, hasz, hast, srid, result));
+
+        public static IntPtr stbox_tile_state_make(IntPtr temp, IntPtr box, double xsize, double ysize, double zsize, IntPtr duration, int sorigin, int torigin, bool border_inc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_tile_state_make(temp, box, xsize, ysize, zsize, duration, sorigin, torigin, border_inc));
+
+        public static void stbox_tile_state_next(IntPtr state)
+            => SafeExecution(() => MEOSExternalFunctions.stbox_tile_state_next(state));
+
+        public static bool stbox_tile_state_get(IntPtr state, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.stbox_tile_state_get(state, box));
+
+        public static IntPtr tgeo_space_time_tile_init(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool bitmatrix, bool border_inc, IntPtr ntiles)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_space_time_tile_init(temp, xsize, ysize, zsize, duration, sorigin, torigin, bitmatrix, border_inc, ntiles));
+
+        public static IntPtr stbox_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, bool hasx, bool hast)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_space_time_tile(point, t, xsize, ysize, zsize, duration, sorigin, torigin, hasx, hast));
+
+        public static IntPtr create_trip(IntPtr lines, IntPtr maxSpeeds, IntPtr categories, uint noEdges, int startTime, bool disturbData, int verbosity)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.create_trip(lines, maxSpeeds, categories, noEdges, startTime, disturbData, verbosity));
+
+        public static IntPtr spatialarr_wkt_out(IntPtr spatialarr, int basetype, int count, int maxdd, bool extended)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spatialarr_wkt_out(spatialarr, basetype, count, maxdd, extended));
+
+        public static string spatialbase_as_text(IntPtr value, int type, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.spatialbase_as_text(value, type, maxdd));
+
+        public static string spatialbase_as_ewkt(IntPtr value, int type, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.spatialbase_as_ewkt(value, type, maxdd));
+
+        public static bool point_transf_pj(IntPtr gs, int srid_to, IntPtr pj)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.point_transf_pj(gs, srid_to, pj));
+
+        public static void tgeoinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tgeoinst_set_stbox(inst, box));
+
+        public static void tgeoinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tgeoinstarr_set_stbox(instants, count, box));
+
+        public static void tgeoseq_expand_stbox(IntPtr seq, IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.tgeoseq_expand_stbox(seq, inst));
+
+        public static void tspatialinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tspatialinst_set_stbox(inst, box));
+
+        public static void tspatialinstarr_set_stbox(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tspatialinstarr_set_stbox(instants, count, lower_inc, upper_inc, interp, box));
+
+        public static void tspatialseqarr_set_stbox(IntPtr sequences, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tspatialseqarr_set_stbox(sequences, count, box));
+
+        public static void tspatialseq_expand_stbox(IntPtr seq, IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.tspatialseq_expand_stbox(seq, inst));
+
+        public static void spatialarr_set_bbox(IntPtr values, int basetype, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.spatialarr_set_bbox(values, basetype, count, box));
+
+        public static bool boxop_tspatial_stbox(IntPtr temp, IntPtr box, IntPtr func, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tspatial_stbox(temp, box, func, invert));
+
+        public static bool boxop_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tspatial_tspatial(temp1, temp2, func));
+
+        public static bool srid_parse(IntPtr str, IntPtr srid)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.srid_parse(str, srid));
+
+        public static bool spatial_parse_elem(IntPtr str, int temptype, byte delim, IntPtr temp_srid, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_parse_elem(str, temptype, delim, temp_srid, result));
+
+        public static bool geo_parse(IntPtr str, int basetype, byte delim, IntPtr srid, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.geo_parse(str, basetype, delim, srid, result));
+
+        public static IntPtr stbox_parse(IntPtr str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_parse(str));
+
+        public static IntPtr tpoint_parse(IntPtr str, int temptype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_parse(str, temptype));
+
+        public static IntPtr tspatialinst_parse(IntPtr str, int temptype, bool end, IntPtr temp_srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialinst_parse(str, temptype, end, temp_srid));
+
+        public static IntPtr tspatialseq_disc_parse(IntPtr str, int temptype, IntPtr temp_srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseq_disc_parse(str, temptype, temp_srid));
+
+        public static IntPtr tspatialseq_cont_parse(IntPtr str, int temptype, int interp, bool end, IntPtr temp_srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseq_cont_parse(str, temptype, interp, end, temp_srid));
+
+        public static IntPtr tspatialseqset_parse(IntPtr str, int temptype, int interp, IntPtr temp_srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatialseqset_parse(str, temptype, interp, temp_srid));
+
+        public static IntPtr tspatial_parse(IntPtr str, int temptype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tspatial_parse(str, temptype));
 
         public static IntPtr proj_get_context()
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.proj_get_context());
 
-        public static ulong datum_geo_round(ulong value, ulong size)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.datum_geo_round(value, size));
+        public static int datum_geo_round(IntPtr value, IntPtr size)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_geo_round(value, size));
 
         public static IntPtr point_round(IntPtr gs, int maxdd)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.point_round(gs, maxdd));
@@ -6879,7 +8398,7 @@ namespace MEOS.NET.Internal
         public static void geoarr_set_stbox(IntPtr values, int count, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.geoarr_set_stbox(values, count, box));
 
-        public static bool spatial_set_stbox(ulong d, int basetype, IntPtr box)
+        public static bool spatial_set_stbox(IntPtr d, int basetype, IntPtr box)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_set_stbox(d, basetype, box));
 
         public static void spatialset_set_stbox(IntPtr set, IntPtr box)
@@ -6905,9 +8424,6 @@ namespace MEOS.NET.Internal
 
         public static bool inter_stbox_stbox(IntPtr box1, IntPtr box2, IntPtr result)
             => SafeExecution<bool>(() => MEOSExternalFunctions.inter_stbox_stbox(box1, box2, result));
-
-        public static IntPtr stbox_geo(IntPtr box)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.stbox_geo(box));
 
         public static IntPtr tgeogpointinst_from_mfjson(IntPtr mfjson, int srid)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeogpointinst_from_mfjson(mfjson, srid));
@@ -6984,43 +8500,43 @@ namespace MEOS.NET.Internal
         public static void tspatial_set_stbox(IntPtr temp, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tspatial_set_stbox(temp, box));
 
-        public static void tgeoinst_set_stbox(IntPtr inst, IntPtr box)
-            => SafeExecution(() => MEOSExternalFunctions.tgeoinst_set_stbox(inst, box));
-
         public static void tspatialseq_set_stbox(IntPtr seq, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tspatialseq_set_stbox(seq, box));
 
         public static void tspatialseqset_set_stbox(IntPtr ss, IntPtr box)
             => SafeExecution(() => MEOSExternalFunctions.tspatialseqset_set_stbox(ss, box));
 
-        public static IntPtr tgeo_restrict_geom(IntPtr temp, IntPtr gs, IntPtr zspan, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_restrict_geom(temp, gs, zspan, atfunc));
+        public static IntPtr tgeo_restrict_elevation(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_restrict_elevation(temp, s, atfunc));
+
+        public static IntPtr tgeo_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_restrict_geom(temp, gs, atfunc));
 
         public static IntPtr tgeo_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeo_restrict_stbox(temp, box, border_inc, atfunc));
 
-        public static IntPtr tgeoinst_restrict_geom(IntPtr inst, IntPtr gs, IntPtr zspan, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoinst_restrict_geom(inst, gs, zspan, atfunc));
+        public static IntPtr tgeoinst_restrict_geom(IntPtr inst, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoinst_restrict_geom(inst, gs, atfunc));
 
         public static IntPtr tgeoinst_restrict_stbox(IntPtr inst, IntPtr box, bool border_inc, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoinst_restrict_stbox(inst, box, border_inc, atfunc));
 
-        public static IntPtr tgeoseq_restrict_geom(IntPtr seq, IntPtr gs, IntPtr zspan, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseq_restrict_geom(seq, gs, zspan, atfunc));
+        public static IntPtr tgeoseq_restrict_geom(IntPtr seq, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseq_restrict_geom(seq, gs, atfunc));
 
         public static IntPtr tgeoseq_restrict_stbox(IntPtr seq, IntPtr box, bool border_inc, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseq_restrict_stbox(seq, box, border_inc, atfunc));
 
-        public static IntPtr tgeoseqset_restrict_geom(IntPtr ss, IntPtr gs, IntPtr zspan, bool atfunc)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_restrict_geom(ss, gs, zspan, atfunc));
+        public static IntPtr tgeoseqset_restrict_geom(IntPtr ss, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_restrict_geom(ss, gs, atfunc));
 
         public static IntPtr tgeoseqset_restrict_stbox(IntPtr ss, IntPtr box, bool border_inc, bool atfunc)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_restrict_stbox(ss, box, border_inc, atfunc));
 
-        public static int spatial_srid(ulong d, int basetype)
+        public static int spatial_srid(IntPtr d, int basetype)
             => SafeExecution<int>(() => MEOSExternalFunctions.spatial_srid(d, basetype));
 
-        public static bool spatial_set_srid(ulong d, int basetype, int srid)
+        public static bool spatial_set_srid(IntPtr d, int basetype, int srid)
             => SafeExecution<bool>(() => MEOSExternalFunctions.spatial_set_srid(d, basetype, srid));
 
         public static int tspatialinst_srid(IntPtr inst)
@@ -7064,9 +8580,6 @@ namespace MEOS.NET.Internal
 
         public static IntPtr tgeoseqset_split_n_stboxes(IntPtr ss, int max_count, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeoseqset_split_n_stboxes(ss, max_count, count));
-
-        public static IntPtr tpoint_get_coord(IntPtr temp, int coord)
-            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpoint_get_coord(temp, coord));
 
         public static IntPtr tgeominst_tgeoginst(IntPtr inst, bool oper)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeominst_tgeoginst(inst, oper));
@@ -7134,10 +8647,10 @@ namespace MEOS.NET.Internal
         public static string nsegment_out(IntPtr ns, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.nsegment_out(ns, maxdd));
 
-        public static IntPtr npoint_make(long rid, double pos)
+        public static IntPtr npoint_make(int rid, double pos)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_make(rid, pos));
 
-        public static IntPtr nsegment_make(long rid, double pos1, double pos2)
+        public static IntPtr nsegment_make(int rid, double pos1, double pos2)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_make(rid, pos1, pos2));
 
         public static IntPtr geompoint_to_npoint(IntPtr gs)
@@ -7161,34 +8674,34 @@ namespace MEOS.NET.Internal
         public static IntPtr nsegment_to_stbox(IntPtr np)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_to_stbox(np));
 
-        public static uint npoint_hash(IntPtr np)
-            => SafeExecution<uint>(() => MEOSExternalFunctions.npoint_hash(np));
+        public static int npoint_hash(IntPtr np)
+            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_hash(np));
 
-        public static ulong npoint_hash_extended(IntPtr np, ulong seed)
-            => SafeExecution<ulong>(() => MEOSExternalFunctions.npoint_hash_extended(np, seed));
+        public static int npoint_hash_extended(IntPtr np, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_hash_extended(np, seed));
 
         public static double npoint_position(IntPtr np)
             => SafeExecution<double>(() => MEOSExternalFunctions.npoint_position(np));
 
-        public static long npoint_route(IntPtr np)
-            => SafeExecution<long>(() => MEOSExternalFunctions.npoint_route(np));
+        public static int npoint_route(IntPtr np)
+            => SafeExecution<int>(() => MEOSExternalFunctions.npoint_route(np));
 
         public static double nsegment_end_position(IntPtr ns)
             => SafeExecution<double>(() => MEOSExternalFunctions.nsegment_end_position(ns));
 
-        public static long nsegment_route(IntPtr ns)
-            => SafeExecution<long>(() => MEOSExternalFunctions.nsegment_route(ns));
+        public static int nsegment_route(IntPtr ns)
+            => SafeExecution<int>(() => MEOSExternalFunctions.nsegment_route(ns));
 
         public static double nsegment_start_position(IntPtr ns)
             => SafeExecution<double>(() => MEOSExternalFunctions.nsegment_start_position(ns));
 
-        public static bool route_exists(long rid)
+        public static bool route_exists(int rid)
             => SafeExecution<bool>(() => MEOSExternalFunctions.route_exists(rid));
 
-        public static IntPtr route_geom(long rid)
+        public static IntPtr route_geom(int rid)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.route_geom(rid));
 
-        public static double route_length(long rid)
+        public static double route_length(int rid)
             => SafeExecution<double>(() => MEOSExternalFunctions.route_length(rid));
 
         public static IntPtr npoint_round(IntPtr np, int maxdd)
@@ -7206,7 +8719,7 @@ namespace MEOS.NET.Internal
         public static int nsegment_srid(IntPtr ns)
             => SafeExecution<int>(() => MEOSExternalFunctions.nsegment_srid(ns));
 
-        public static IntPtr npoint_timestamptz_to_stbox(IntPtr np, long t)
+        public static IntPtr npoint_timestamptz_to_stbox(IntPtr np, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_timestamptz_to_stbox(np, t));
 
         public static IntPtr npoint_tstzspan_to_stbox(IntPtr np, IntPtr s)
@@ -7324,7 +8837,7 @@ namespace MEOS.NET.Internal
         public static string tnpoint_out(IntPtr temp, int maxdd)
             => SafeExecution<string>(() => MEOSExternalFunctions.tnpoint_out(temp, maxdd));
 
-        public static IntPtr tnpointinst_make(IntPtr np, long t)
+        public static IntPtr tnpointinst_make(IntPtr np, int t)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_make(np, t));
 
         public static IntPtr tgeompoint_to_tnpoint(IntPtr temp)
@@ -7342,8 +8855,8 @@ namespace MEOS.NET.Internal
         public static IntPtr tnpoint_positions(IntPtr temp, IntPtr count)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_positions(temp, count));
 
-        public static long tnpoint_route(IntPtr temp)
-            => SafeExecution<long>(() => MEOSExternalFunctions.tnpoint_route(temp));
+        public static int tnpoint_route(IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnpoint_route(temp));
 
         public static IntPtr tnpoint_routes(IntPtr temp)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_routes(temp));
@@ -7464,6 +8977,1929 @@ namespace MEOS.NET.Internal
 
         public static IntPtr tne_tnpoint_npoint(IntPtr temp, IntPtr np)
             => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_tnpoint_npoint(temp, np));
+
+        public static string pose_as_ewkt(IntPtr pose, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.pose_as_ewkt(pose, maxdd));
+
+        public static string pose_as_hexwkb(IntPtr pose, IntPtr variant, IntPtr size)
+            => SafeExecution<string>(() => MEOSExternalFunctions.pose_as_hexwkb(pose, variant, size));
+
+        public static string pose_as_text(IntPtr pose, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.pose_as_text(pose, maxdd));
+
+        public static IntPtr pose_as_wkb(IntPtr pose, IntPtr variant, IntPtr size_out)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_as_wkb(pose, variant, size_out));
+
+        public static IntPtr pose_from_wkb(IntPtr wkb, ulong size)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_from_wkb(wkb, size));
+
+        public static IntPtr pose_from_hexwkb(string hexwkb)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_from_hexwkb(hexwkb));
+
+        public static IntPtr pose_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_in(str));
+
+        public static string pose_out(IntPtr pose, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.pose_out(pose, maxdd));
+
+        public static IntPtr pose_copy(IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_copy(pose));
+
+        public static IntPtr pose_make_2d(double x, double y, double theta, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_make_2d(x, y, theta, srid));
+
+        public static IntPtr pose_make_3d(double x, double y, double z, double W, double X, double Y, double Z, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_make_3d(x, y, z, W, X, Y, Z, srid));
+
+        public static IntPtr pose_make_point2d(IntPtr gs, double theta)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_make_point2d(gs, theta));
+
+        public static IntPtr pose_make_point3d(IntPtr gs, double W, double X, double Y, double Z)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_make_point3d(gs, W, X, Y, Z));
+
+        public static IntPtr pose_to_point(IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_to_point(pose));
+
+        public static IntPtr pose_to_stbox(IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_to_stbox(pose));
+
+        public static int pose_hash(IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pose_hash(pose));
+
+        public static int pose_hash_extended(IntPtr pose, int seed)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pose_hash_extended(pose, seed));
+
+        public static IntPtr pose_orientation(IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_orientation(pose));
+
+        public static double pose_rotation(IntPtr pose)
+            => SafeExecution<double>(() => MEOSExternalFunctions.pose_rotation(pose));
+
+        public static IntPtr pose_round(IntPtr pose, int maxdd)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_round(pose, maxdd));
+
+        public static IntPtr posearr_round(IntPtr posearr, int count, int maxdd)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.posearr_round(posearr, count, maxdd));
+
+        public static void pose_set_srid(IntPtr pose, int srid)
+            => SafeExecution(() => MEOSExternalFunctions.pose_set_srid(pose, srid));
+
+        public static int pose_srid(IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pose_srid(pose));
+
+        public static IntPtr pose_transform(IntPtr pose, int srid)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_transform(pose, srid));
+
+        public static IntPtr pose_transform_pipeline(IntPtr pose, string pipelinestr, int srid, bool is_forward)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_transform_pipeline(pose, pipelinestr, srid, is_forward));
+
+        public static IntPtr pose_tstzspan_to_stbox(IntPtr pose, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_tstzspan_to_stbox(pose, s));
+
+        public static IntPtr pose_timestamptz_to_stbox(IntPtr pose, int t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_timestamptz_to_stbox(pose, t));
+
+        public static double distance_pose_geo(IntPtr pose, IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_pose_geo(pose, gs));
+
+        public static double distance_pose_pose(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_pose_pose(pose1, pose2));
+
+        public static double distance_pose_stbox(IntPtr pose, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.distance_pose_stbox(pose, box));
+
+        public static int pose_cmp(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pose_cmp(pose1, pose2));
+
+        public static bool pose_eq(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_eq(pose1, pose2));
+
+        public static bool pose_ge(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_ge(pose1, pose2));
+
+        public static bool pose_gt(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_gt(pose1, pose2));
+
+        public static bool pose_le(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_le(pose1, pose2));
+
+        public static bool pose_lt(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_lt(pose1, pose2));
+
+        public static bool pose_ne(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_ne(pose1, pose2));
+
+        public static bool pose_nsame(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_nsame(pose1, pose2));
+
+        public static bool pose_same(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_same(pose1, pose2));
+
+        public static IntPtr poseset_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_in(str));
+
+        public static string poseset_out(IntPtr s, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.poseset_out(s, maxdd));
+
+        public static IntPtr poseset_make(IntPtr values, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_make(values, count));
+
+        public static IntPtr pose_to_set(IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_to_set(pose));
+
+        public static IntPtr poseset_end_value(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_end_value(s));
+
+        public static IntPtr poseset_start_value(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_start_value(s));
+
+        public static bool poseset_value_n(IntPtr s, int n, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.poseset_value_n(s, n, result));
+
+        public static IntPtr poseset_values(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.poseset_values(s));
+
+        public static bool contained_pose_set(IntPtr pose, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_pose_set(pose, s));
+
+        public static bool contains_set_pose(IntPtr s, IntPtr pose)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_set_pose(s, pose));
+
+        public static IntPtr intersection_pose_set(IntPtr pose, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_pose_set(pose, s));
+
+        public static IntPtr intersection_set_pose(IntPtr s, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.intersection_set_pose(s, pose));
+
+        public static IntPtr minus_pose_set(IntPtr pose, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_pose_set(pose, s));
+
+        public static IntPtr minus_set_pose(IntPtr s, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.minus_set_pose(s, pose));
+
+        public static IntPtr pose_union_transfn(IntPtr state, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_union_transfn(state, pose));
+
+        public static IntPtr union_pose_set(IntPtr pose, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_pose_set(pose, s));
+
+        public static IntPtr union_set_pose(IntPtr s, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.union_set_pose(s, pose));
+
+        public static IntPtr tpose_in(string str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_in(str));
+
+        public static IntPtr tpose_make(IntPtr tpoint, IntPtr tradius)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_make(tpoint, tradius));
+
+        public static IntPtr tpose_to_tpoint(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_to_tpoint(temp));
+
+        public static IntPtr tpose_end_value(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_end_value(temp));
+
+        public static IntPtr tpose_points(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_points(temp));
+
+        public static IntPtr tpose_rotation(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_rotation(temp));
+
+        public static IntPtr tpose_start_value(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_start_value(temp));
+
+        public static IntPtr tpose_trajectory(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_trajectory(temp));
+
+        public static bool tpose_value_at_timestamptz(IntPtr temp, int t, bool strict, IntPtr value)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tpose_value_at_timestamptz(temp, t, strict, value));
+
+        public static bool tpose_value_n(IntPtr temp, int n, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tpose_value_n(temp, n, result));
+
+        public static IntPtr tpose_values(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_values(temp, count));
+
+        public static IntPtr tpose_at_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_at_geom(temp, gs));
+
+        public static IntPtr tpose_at_stbox(IntPtr temp, IntPtr box, bool border_inc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_at_stbox(temp, box, border_inc));
+
+        public static IntPtr tpose_at_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_at_pose(temp, pose));
+
+        public static IntPtr tpose_minus_geom(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_minus_geom(temp, gs));
+
+        public static IntPtr tpose_minus_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_minus_pose(temp, pose));
+
+        public static IntPtr tpose_minus_stbox(IntPtr temp, IntPtr box, bool border_inc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_minus_stbox(temp, box, border_inc));
+
+        public static IntPtr tdistance_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tpose_pose(temp, pose));
+
+        public static IntPtr tdistance_tpose_point(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tpose_point(temp, gs));
+
+        public static IntPtr tdistance_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_tpose_tpose(temp1, temp2));
+
+        public static double nad_tpose_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tpose_geo(temp, gs));
+
+        public static double nad_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tpose_pose(temp, pose));
+
+        public static double nad_tpose_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tpose_stbox(temp, box));
+
+        public static double nad_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_tpose_tpose(temp1, temp2));
+
+        public static IntPtr nai_tpose_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tpose_geo(temp, gs));
+
+        public static IntPtr nai_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tpose_pose(temp, pose));
+
+        public static IntPtr nai_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_tpose_tpose(temp1, temp2));
+
+        public static IntPtr shortestline_tpose_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tpose_geo(temp, gs));
+
+        public static IntPtr shortestline_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tpose_pose(temp, pose));
+
+        public static IntPtr shortestline_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_tpose_tpose(temp1, temp2));
+
+        public static int always_eq_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_pose_tpose(pose, temp));
+
+        public static int always_eq_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_tpose_pose(temp, pose));
+
+        public static int always_eq_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_tpose_tpose(temp1, temp2));
+
+        public static int always_ne_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_pose_tpose(pose, temp));
+
+        public static int always_ne_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_tpose_pose(temp, pose));
+
+        public static int always_ne_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_tpose_tpose(temp1, temp2));
+
+        public static int ever_eq_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_pose_tpose(pose, temp));
+
+        public static int ever_eq_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_tpose_pose(temp, pose));
+
+        public static int ever_eq_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_tpose_tpose(temp1, temp2));
+
+        public static int ever_ne_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_pose_tpose(pose, temp));
+
+        public static int ever_ne_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_tpose_pose(temp, pose));
+
+        public static int ever_ne_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_tpose_tpose(temp1, temp2));
+
+        public static IntPtr teq_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_pose_tpose(pose, temp));
+
+        public static IntPtr teq_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_tpose_pose(temp, pose));
+
+        public static IntPtr tne_pose_tpose(IntPtr pose, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_pose_tpose(pose, temp));
+
+        public static IntPtr tne_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_tpose_pose(temp, pose));
+
+        public static string trgeo_out(IntPtr temp)
+            => SafeExecution<string>(() => MEOSExternalFunctions.trgeo_out(temp));
+
+        public static IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, int t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_make(geom, pose, t));
+
+        public static IntPtr geo_tpose_to_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tpose_to_trgeo(gs, temp));
+
+        public static IntPtr trgeo_to_tpose(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tpose(temp));
+
+        public static IntPtr trgeo_to_tpoint(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tpoint(temp));
+
+        public static IntPtr trgeo_end_instant(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_end_instant(temp));
+
+        public static IntPtr trgeo_end_sequence(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_end_sequence(temp));
+
+        public static IntPtr trgeo_end_value(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_end_value(temp));
+
+        public static IntPtr trgeo_geom(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_geom(temp));
+
+        public static IntPtr trgeo_instant_n(IntPtr temp, int n)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_instant_n(temp, n));
+
+        public static IntPtr trgeo_instants(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_instants(temp, count));
+
+        public static IntPtr trgeo_points(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_points(temp));
+
+        public static IntPtr trgeo_rotation(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_rotation(temp));
+
+        public static IntPtr trgeo_segments(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_segments(temp, count));
+
+        public static IntPtr trgeo_sequence_n(IntPtr temp, int i)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_sequence_n(temp, i));
+
+        public static IntPtr trgeo_sequences(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_sequences(temp, count));
+
+        public static IntPtr trgeo_start_instant(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_start_instant(temp));
+
+        public static IntPtr trgeo_start_sequence(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_start_sequence(temp));
+
+        public static IntPtr trgeo_start_value(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_start_value(temp));
+
+        public static bool trgeo_value_n(IntPtr temp, int n, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.trgeo_value_n(temp, n, result));
+
+        public static IntPtr trgeo_traversed_area(IntPtr temp, bool unary_union)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_traversed_area(temp, unary_union));
+
+        public static IntPtr trgeo_append_tinstant(IntPtr temp, IntPtr inst, int interp, double maxdist, IntPtr maxt, bool expand)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_append_tinstant(temp, inst, interp, maxdist, maxt, expand));
+
+        public static IntPtr trgeo_append_tsequence(IntPtr temp, IntPtr seq, bool expand)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_append_tsequence(temp, seq, expand));
+
+        public static IntPtr trgeo_delete_timestamptz(IntPtr temp, int t, bool connect)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_delete_timestamptz(temp, t, connect));
+
+        public static IntPtr trgeo_delete_tstzset(IntPtr temp, IntPtr s, bool connect)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_delete_tstzset(temp, s, connect));
+
+        public static IntPtr trgeo_delete_tstzspan(IntPtr temp, IntPtr s, bool connect)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_delete_tstzspan(temp, s, connect));
+
+        public static IntPtr trgeo_delete_tstzspanset(IntPtr temp, IntPtr ss, bool connect)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_delete_tstzspanset(temp, ss, connect));
+
+        public static IntPtr trgeo_round(IntPtr temp, int maxdd)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_round(temp, maxdd));
+
+        public static IntPtr trgeo_set_interp(IntPtr temp, int interp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_set_interp(temp, interp));
+
+        public static IntPtr trgeo_to_tinstant(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tinstant(temp));
+
+        public static IntPtr trgeo_after_timestamptz(IntPtr temp, int t, bool strict)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_after_timestamptz(temp, t, strict));
+
+        public static IntPtr trgeo_before_timestamptz(IntPtr temp, int t, bool strict)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_before_timestamptz(temp, t, strict));
+
+        public static IntPtr trgeo_restrict_value(IntPtr temp, IntPtr value, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_value(temp, value, atfunc));
+
+        public static IntPtr trgeo_restrict_values(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_values(temp, s, atfunc));
+
+        public static IntPtr trgeo_restrict_timestamptz(IntPtr temp, int t, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_timestamptz(temp, t, atfunc));
+
+        public static IntPtr trgeo_restrict_tstzset(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_tstzset(temp, s, atfunc));
+
+        public static IntPtr trgeo_restrict_tstzspan(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_tstzspan(temp, s, atfunc));
+
+        public static IntPtr trgeo_restrict_tstzspanset(IntPtr temp, IntPtr ss, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_restrict_tstzspanset(temp, ss, atfunc));
+
+        public static IntPtr tdistance_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_trgeo_geo(temp, gs));
+
+        public static IntPtr tdistance_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_trgeo_tpoint(temp1, temp2));
+
+        public static IntPtr tdistance_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdistance_trgeo_trgeo(temp1, temp2));
+
+        public static double nad_stbox_trgeo(IntPtr box, IntPtr temp)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_stbox_trgeo(box, temp));
+
+        public static double nad_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_trgeo_geo(temp, gs));
+
+        public static double nad_trgeo_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_trgeo_stbox(temp, box));
+
+        public static double nad_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_trgeo_tpoint(temp1, temp2));
+
+        public static double nad_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<double>(() => MEOSExternalFunctions.nad_trgeo_trgeo(temp1, temp2));
+
+        public static IntPtr nai_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_trgeo_geo(temp, gs));
+
+        public static IntPtr nai_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_trgeo_tpoint(temp1, temp2));
+
+        public static IntPtr nai_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nai_trgeo_trgeo(temp1, temp2));
+
+        public static IntPtr shortestline_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_trgeo_geo(temp, gs));
+
+        public static IntPtr shortestline_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_trgeo_tpoint(temp1, temp2));
+
+        public static IntPtr shortestline_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.shortestline_trgeo_trgeo(temp1, temp2));
+
+        public static int always_eq_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_geo_trgeo(gs, temp));
+
+        public static int always_eq_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_trgeo_geo(temp, gs));
+
+        public static int always_eq_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_eq_trgeo_trgeo(temp1, temp2));
+
+        public static int always_ne_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_geo_trgeo(gs, temp));
+
+        public static int always_ne_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_trgeo_geo(temp, gs));
+
+        public static int always_ne_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.always_ne_trgeo_trgeo(temp1, temp2));
+
+        public static int ever_eq_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_geo_trgeo(gs, temp));
+
+        public static int ever_eq_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_trgeo_geo(temp, gs));
+
+        public static int ever_eq_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_eq_trgeo_trgeo(temp1, temp2));
+
+        public static int ever_ne_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_geo_trgeo(gs, temp));
+
+        public static int ever_ne_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_trgeo_geo(temp, gs));
+
+        public static int ever_ne_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ever_ne_trgeo_trgeo(temp1, temp2));
+
+        public static IntPtr teq_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_geo_trgeo(gs, temp));
+
+        public static IntPtr teq_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.teq_trgeo_geo(temp, gs));
+
+        public static IntPtr tne_geo_trgeo(IntPtr gs, IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_geo_trgeo(gs, temp));
+
+        public static IntPtr tne_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tne_trgeo_geo(temp, gs));
+
+        public static bool ensure_valid_tnpoint_npoint(IntPtr temp, IntPtr np)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_npoint(temp, np));
+
+        public static bool ensure_valid_tnpoint_npointset(IntPtr temp, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_npointset(temp, s));
+
+        public static bool ensure_valid_tnpoint_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_geo(temp, gs));
+
+        public static bool ensure_valid_tnpoint_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_stbox(temp, box));
+
+        public static bool ensure_valid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tnpoint_tnpoint(temp1, temp2));
+
+        public static int tnpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnpointsegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static bool common_rid_tnpoint_npoint(IntPtr temp, IntPtr np)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_npoint(temp, np));
+
+        public static bool common_rid_tnpoint_npointset(IntPtr temp, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_npointset(temp, s));
+
+        public static bool common_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.common_rid_tnpoint_tnpoint(temp1, temp2));
+
+        public static bool npoint_collinear(IntPtr np1, IntPtr np2, IntPtr np3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_collinear(np1, np2, np3, ratio));
+
+        public static IntPtr npointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointsegm_interpolate(start, end, ratio));
+
+        public static IntPtr npointsegm_locate(IntPtr start, IntPtr end, IntPtr value)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointsegm_locate(start, end, value));
+
+        public static IntPtr npointarr_geom(IntPtr points, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npointarr_geom(points, count));
+
+        public static IntPtr nsegmentarr_geom(IntPtr segments, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegmentarr_geom(segments, count));
+
+        public static IntPtr nsegmentarr_normalize(IntPtr segments, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegmentarr_normalize(segments, count));
+
+        public static string npoint_wkt_out(IntPtr value, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.npoint_wkt_out(value, maxdd));
+
+        public static void npoint_set(int rid, double pos, IntPtr np)
+            => SafeExecution(() => MEOSExternalFunctions.npoint_set(rid, pos, np));
+
+        public static void nsegment_set(int rid, double pos1, double pos2, IntPtr ns)
+            => SafeExecution(() => MEOSExternalFunctions.nsegment_set(rid, pos1, pos2, ns));
+
+        public static int datum_npoint_round(IntPtr npoint, IntPtr size)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_npoint_round(npoint, size));
+
+        public static IntPtr tnpointinst_tgeompointinst(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_tgeompointinst(inst));
+
+        public static IntPtr tnpointseq_tgeompointseq_disc(IntPtr @is)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_tgeompointseq_disc(@is));
+
+        public static IntPtr tnpointseq_tgeompointseq_cont(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_tgeompointseq_cont(seq));
+
+        public static IntPtr tnpointseqset_tgeompointseqset(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_tgeompointseqset(ss));
+
+        public static IntPtr tgeompointinst_tnpointinst(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointinst_tnpointinst(inst));
+
+        public static IntPtr tgeompointseq_tnpointseq(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointseq_tnpointseq(seq));
+
+        public static IntPtr tgeompointseqset_tnpointseqset(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tgeompointseqset_tnpointseqset(ss));
+
+        public static IntPtr tnpointinst_positions(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_positions(inst));
+
+        public static IntPtr tnpointseq_positions(IntPtr seq, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_positions(seq, count));
+
+        public static IntPtr tnpointseqset_positions(IntPtr ss, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_positions(ss, count));
+
+        public static int tnpointinst_route(IntPtr inst)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnpointinst_route(inst));
+
+        public static IntPtr tnpointinst_routes(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointinst_routes(inst));
+
+        public static IntPtr tnpointseq_disc_routes(IntPtr @is)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_disc_routes(@is));
+
+        public static IntPtr tnpointseq_cont_routes(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_cont_routes(seq));
+
+        public static IntPtr tnpointseqset_routes(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseqset_routes(ss));
+
+        public static IntPtr tnpointseq_linear_positions(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpointseq_linear_positions(seq));
+
+        public static IntPtr tnpoint_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_stbox(temp, box, border_inc, atfunc));
+
+        public static IntPtr tnpoint_restrict_npoint(IntPtr temp, IntPtr np, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_npoint(temp, np, atfunc));
+
+        public static IntPtr tnpoint_restrict_npointset(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_npointset(temp, s, atfunc));
+
+        public static bool npoint_set_stbox(IntPtr np, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_set_stbox(np, box));
+
+        public static void npointarr_set_stbox(IntPtr values, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.npointarr_set_stbox(values, count, box));
+
+        public static bool nsegment_set_stbox(IntPtr ns, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.nsegment_set_stbox(ns, box));
+
+        public static bool npoint_timestamptz_set_stbox(IntPtr np, int t, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_timestamptz_set_stbox(np, t, box));
+
+        public static bool npoint_tstzspan_set_stbox(IntPtr np, IntPtr s, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.npoint_tstzspan_set_stbox(np, s, box));
+
+        public static void tnpointinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tnpointinst_set_stbox(inst, box));
+
+        public static void tnpointinstarr_set_stbox(IntPtr inst, int count, int interp, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tnpointinstarr_set_stbox(inst, count, interp, box));
+
+        public static void tnpointseq_expand_stbox(IntPtr seq, IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.tnpointseq_expand_stbox(seq, inst));
+
+        public static int datum_npoint_distance(IntPtr np1, IntPtr np2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_npoint_distance(np1, np2));
+
+        public static IntPtr npoint_parse(IntPtr str, bool end)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.npoint_parse(str, end));
+
+        public static IntPtr nsegment_parse(IntPtr str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.nsegment_parse(str));
+
+        public static bool contains_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_bigint(temp, rid, invert));
+
+        public static bool contained_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_bigint(temp, rid, invert));
+
+        public static bool same_rid_tnpoint_bigint(IntPtr temp, int rid, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_bigint(temp, rid, invert));
+
+        public static bool overlaps_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.overlaps_rid_tnpoint_bigintset(temp, s, invert));
+
+        public static bool contains_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_bigintset(temp, s, invert));
+
+        public static bool contained_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_bigintset(temp, s, invert));
+
+        public static bool same_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_bigintset(temp, s, invert));
+
+        public static bool contains_rid_tnpoint_npoint(IntPtr temp, IntPtr np, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_npoint(temp, np, invert));
+
+        public static bool contained_rid_npoint_tnpoint(IntPtr temp, IntPtr np, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_npoint_tnpoint(temp, np, invert));
+
+        public static bool same_rid_tnpoint_npoint(IntPtr temp, IntPtr np, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_npoint(temp, np, invert));
+
+        public static bool overlaps_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.overlaps_rid_tnpoint_tnpoint(temp1, temp2));
+
+        public static bool contains_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contains_rid_tnpoint_tnpoint(temp1, temp2));
+
+        public static bool contained_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.contained_rid_tnpoint_tnpoint(temp1, temp2));
+
+        public static bool same_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.same_rid_tnpoint_tnpoint(temp1, temp2));
+
+        public static bool ensure_same_rid_tnpointinst(IntPtr inst1, IntPtr inst2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_rid_tnpointinst(inst1, inst2));
+
+        public static IntPtr tnpoint_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnpoint_restrict_geom(temp, gs, atfunc));
+
+        public static bool ensure_valid_pose_geo(IntPtr pose, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_geo(pose, gs));
+
+        public static bool ensure_valid_pose_stbox(IntPtr pose, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_stbox(pose, box));
+
+        public static bool ensure_valid_pose_pose(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_pose_pose(pose1, pose2));
+
+        public static bool ensure_valid_poseset_pose(IntPtr s, IntPtr pose)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_poseset_pose(s, pose));
+
+        public static bool pose_collinear(IntPtr pose1, IntPtr pose2, IntPtr pose3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_collinear(pose1, pose2, pose3, ratio));
+
+        public static IntPtr posesegm_interpolate(IntPtr start, IntPtr end, double ratio)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.posesegm_interpolate(start, end, ratio));
+
+        public static IntPtr posesegm_locate(IntPtr start, IntPtr end, IntPtr value)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.posesegm_locate(start, end, value));
+
+        public static string pose_wkt_out(IntPtr pose, bool extended, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.pose_wkt_out(pose, extended, maxdd));
+
+        public static IntPtr pose_parse(IntPtr str, bool end)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pose_parse(str, end));
+
+        public static int datum_pose_point(IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_point(pose));
+
+        public static int datum_pose_rotation(IntPtr pose)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_rotation(pose));
+
+        public static int datum_pose_round(IntPtr pose, IntPtr size)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_pose_round(pose, size));
+
+        public static int pose_distance(IntPtr pose1, IntPtr pose2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pose_distance(pose1, pose2));
+
+        public static bool pose_set_stbox(IntPtr pose, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_set_stbox(pose, box));
+
+        public static void posearr_set_stbox(IntPtr values, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.posearr_set_stbox(values, count, box));
+
+        public static bool pose_timestamptz_set_stbox(IntPtr pose, int t, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_timestamptz_set_stbox(pose, t, box));
+
+        public static bool pose_tstzspan_set_stbox(IntPtr pose, IntPtr p, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.pose_tstzspan_set_stbox(pose, p, box));
+
+        public static bool ensure_valid_tpose_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_geo(temp, gs));
+
+        public static bool ensure_valid_tpose_pose(IntPtr temp, IntPtr pose)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_pose(temp, pose));
+
+        public static bool ensure_valid_tpose_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_stbox(temp, box));
+
+        public static bool ensure_valid_tpose_tpose(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tpose_tpose(temp1, temp2));
+
+        public static int tposesegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tposesegm_intersection_value(start, end, value, lower, upper, t1, t2));
+
+        public static int tposesegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tposesegm_intersection(start1, end1, start2, end2, lower, upper, t1, t2));
+
+        public static void tposeinst_set_stbox(IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tposeinst_set_stbox(inst, box));
+
+        public static void tposeinstarr_set_stbox(IntPtr instants, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tposeinstarr_set_stbox(instants, count, box));
+
+        public static void tposeseq_expand_stbox(IntPtr seq, IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.tposeseq_expand_stbox(seq, inst));
+
+        public static IntPtr tpose_restrict_geom(IntPtr temp, IntPtr gs, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_geom(temp, gs, atfunc));
+
+        public static IntPtr tpose_restrict_stbox(IntPtr temp, IntPtr box, bool border_inc, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_stbox(temp, box, border_inc, atfunc));
+
+        public static IntPtr tpose_restrict_elevation(IntPtr temp, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tpose_restrict_elevation(temp, s, atfunc));
+
+        public static int geo_get_srid(IntPtr g)
+            => SafeExecution<int>(() => MEOSExternalFunctions.geo_get_srid(g));
+
+        public static int date_in(string str)
+            => SafeExecution<int>(() => MEOSExternalFunctions.date_in(str));
+
+        public static string date_out(int d)
+            => SafeExecution<string>(() => MEOSExternalFunctions.date_out(d));
+
+        public static int interval_cmp(IntPtr interv1, IntPtr interv2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.interval_cmp(interv1, interv2));
+
+        public static IntPtr interval_in(string str, int typmod)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_in(str, typmod));
+
+        public static string interval_out(IntPtr interv)
+            => SafeExecution<string>(() => MEOSExternalFunctions.interval_out(interv));
+
+        public static long time_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.time_in(str, typmod));
+
+        public static string time_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.time_out(t));
+
+        public static long timestamp_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_in(str, typmod));
+
+        public static string timestamp_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.timestamp_out(t));
+
+        public static long timestamptz_in(string str, int typmod)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_in(str, typmod));
+
+        public static string timestamptz_out(long t)
+            => SafeExecution<string>(() => MEOSExternalFunctions.timestamptz_out(t));
+
+        public static bool ensure_has_geom(short flags)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_has_geom(flags));
+
+        public static bool ensure_valid_trgeo_geo(IntPtr temp, IntPtr gs)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_geo(temp, gs));
+
+        public static bool ensure_valid_trgeo_stbox(IntPtr temp, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_stbox(temp, box));
+
+        public static bool ensure_valid_trgeo_trgeo(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_trgeo(temp1, temp2));
+
+        public static bool ensure_valid_trgeo_tpoint(IntPtr temp1, IntPtr temp2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_trgeo_tpoint(temp1, temp2));
+
+        public static IntPtr trgeo_geom_p(IntPtr temp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_geom_p(temp));
+
+        public static string trgeo_wkt_out(IntPtr temp, int maxdd, bool extended)
+            => SafeExecution<string>(() => MEOSExternalFunctions.trgeo_wkt_out(temp, maxdd, extended));
+
+        public static IntPtr geo_tposeinst_to_trgeo(IntPtr gs, IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeinst_to_trgeo(gs, inst));
+
+        public static IntPtr geo_tposeseq_to_trgeo(IntPtr gs, IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeseq_to_trgeo(gs, seq));
+
+        public static IntPtr geo_tposeseqset_to_trgeo(IntPtr gs, IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.geo_tposeseqset_to_trgeo(gs, ss));
+
+        public static bool trgeo_value_at_timestamptz(IntPtr temp, long t, bool strict, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.trgeo_value_at_timestamptz(temp, t, strict, result));
+
+        public static IntPtr trgeoinst_geom_p(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_geom_p(inst));
+
+        public static ulong trgeoinst_pose_varsize(IntPtr inst)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.trgeoinst_pose_varsize(inst));
+
+        public static void trgeoinst_set_pose(IntPtr inst)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoinst_set_pose(inst));
+
+        public static IntPtr trgeoinst_tposeinst(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_tposeinst(inst));
+
+        public static IntPtr trgeoinst_make1(IntPtr geom, IntPtr pose, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_make1(geom, pose, t));
+
+        public static IntPtr trgeoseq_to_tinstant(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_to_tinstant(seq));
+
+        public static IntPtr trgeoseqset_to_tinstant(IntPtr ts)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_to_tinstant(ts));
+
+        public static IntPtr trgeoseq_geom_p(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_geom_p(seq));
+
+        public static ulong trgeoseq_pose_varsize(IntPtr seq)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.trgeoseq_pose_varsize(seq));
+
+        public static void trgeoseq_set_pose(IntPtr seq)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoseq_set_pose(seq));
+
+        public static IntPtr trgeoseq_tposeseq(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_tposeseq(seq));
+
+        public static bool trgeoseq_make_valid(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, bool linear)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.trgeoseq_make_valid(geom, instants, count, lower_inc, upper_inc, linear));
+
+        public static IntPtr trgeoseq_make1_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make1_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoseq_make1(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make1(geom, instants, count, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoseq_make_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoseq_make(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make(geom, instants, count, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoseq_make_free_exp(IntPtr geom, IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_free_exp(geom, instants, count, maxcount, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoseq_make_free(IntPtr geom, IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseq_make_free(geom, instants, count, lower_inc, upper_inc, interp, normalize));
+
+        public static IntPtr trgeoinst_to_tsequence(IntPtr inst, int interp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoinst_to_tsequence(inst, interp));
+
+        public static IntPtr trgeoseqset_geom_p(IntPtr ts)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_geom_p(ts));
+
+        public static IntPtr trgeoseqset_tposeseqset(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_tposeseqset(ss));
+
+        public static IntPtr trgeoseqset_make1_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make1_exp(geom, sequences, count, maxcount, normalize));
+
+        public static IntPtr trgeoseqset_make_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_exp(geom, sequences, count, maxcount, normalize));
+
+        public static IntPtr trgeoseqset_make(IntPtr geom, IntPtr sequences, int count, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make(geom, sequences, count, normalize));
+
+        public static IntPtr trgeoseqset_make_free(IntPtr geom, IntPtr sequences, int count, bool normalize)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_free(geom, sequences, count, normalize));
+
+        public static IntPtr trgeoseqset_make_gaps(IntPtr geom, IntPtr instants, int count, int interp, IntPtr maxt, double maxdist)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_make_gaps(geom, instants, count, interp, maxt, maxdist));
+
+        public static IntPtr trgeoseqset_to_tsequence(IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeoseqset_to_tsequence(ss));
+
+        public static IntPtr trgeo_to_tsequence(IntPtr temp, string interp_str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tsequence(temp, interp_str));
+
+        public static IntPtr trgeo_to_tsequenceset(IntPtr temp, string interp_str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_to_tsequenceset(temp, interp_str));
+
+        public static void trgeoinst_set_stbox(IntPtr geom, IntPtr inst, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoinst_set_stbox(geom, inst, box));
+
+        public static void trgeoinstarr_static_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_static_stbox(geom, instants, count, box));
+
+        public static void trgeoinstarr_rotating_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_rotating_stbox(geom, instants, count, box));
+
+        public static void trgeoinstarr_compute_bbox(IntPtr geom, IntPtr instants, int count, int interp, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.trgeoinstarr_compute_bbox(geom, instants, count, interp, box));
+
+        public static IntPtr trgeo_parse(IntPtr str, int temptype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.trgeo_parse(str, temptype));
+
+        public static int ea_contains_geo_trgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_contains_geo_trgeo(gs, temp, ever));
+
+        public static int ea_covers_geo_trgeo(IntPtr gs, IntPtr temp, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_geo_trgeo(gs, temp, ever));
+
+        public static int ea_covers_trgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_covers_trgeo_geo(temp, gs, ever));
+
+        public static int ea_disjoint_trgeo_geo(IntPtr temp, IntPtr gs, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.ea_disjoint_trgeo_geo(temp, gs, ever));
+
+        public static bool ensure_same_geom(IntPtr gs1, IntPtr gs2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_geom(gs1, gs2));
+
+        public static void lwgeom_apply_pose(IntPtr pose, IntPtr geom)
+            => SafeExecution(() => MEOSExternalFunctions.lwgeom_apply_pose(pose, geom));
+
+        public static double geom_radius(IntPtr gs)
+            => SafeExecution<double>(() => MEOSExternalFunctions.geom_radius(gs));
+
+        public static int v_clip_tpoly_point(IntPtr poly, IntPtr point, IntPtr pose, IntPtr poly_feature, IntPtr dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.v_clip_tpoly_point(poly, point, pose, poly_feature, dist));
+
+        public static int v_clip_tpoly_tpoly(IntPtr poly1, IntPtr poly2, IntPtr pose1, IntPtr pose2, IntPtr poly1_feature, IntPtr poly2_feature, IntPtr dist)
+            => SafeExecution<int>(() => MEOSExternalFunctions.v_clip_tpoly_tpoly(poly1, poly2, pose1, pose2, poly1_feature, poly2_feature, dist));
+
+        public static void apply_pose_point4d(IntPtr p, IntPtr pose)
+            => SafeExecution(() => MEOSExternalFunctions.apply_pose_point4d(p, pose));
+
+        public static IntPtr tfunc_tinstant(IntPtr inst, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant(inst, lfinfo));
+
+        public static IntPtr tfunc_tsequence(IntPtr seq, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequence(seq, lfinfo));
+
+        public static IntPtr tfunc_tsequenceset(IntPtr ss, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset(ss, lfinfo));
+
+        public static IntPtr tfunc_temporal(IntPtr temp, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal(temp, lfinfo));
+
+        public static IntPtr tfunc_tinstant_base(IntPtr inst, IntPtr value, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant_base(inst, value, lfinfo));
+
+        public static IntPtr tfunc_tsequence_base(IntPtr seq, IntPtr value, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequence_base(seq, value, lfinfo));
+
+        public static IntPtr tfunc_tsequenceset_base(IntPtr ss, IntPtr value, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset_base(ss, value, lfinfo));
+
+        public static IntPtr tfunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal_base(temp, value, lfinfo));
+
+        public static IntPtr tfunc_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tinstant_tinstant(inst1, inst2, lfinfo));
+
+        public static IntPtr tfunc_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tdiscseq_tdiscseq(seq1, seq2, lfinfo));
+
+        public static IntPtr tfunc_tcontseq_tcontseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tcontseq_tcontseq(seq1, seq2, lfinfo));
+
+        public static IntPtr tfunc_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_tsequenceset_tsequenceset(ss1, ss2, lfinfo));
+
+        public static IntPtr tfunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tfunc_temporal_temporal(temp1, temp2, lfinfo));
+
+        public static int eafunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eafunc_temporal_base(temp, value, lfinfo));
+
+        public static int eafunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eafunc_temporal_temporal(temp1, temp2, lfinfo));
+
+        public static int int4_in(string str)
+            => SafeExecution<int>(() => MEOSExternalFunctions.int4_in(str));
+
+        public static string int4_out(int val)
+            => SafeExecution<string>(() => MEOSExternalFunctions.int4_out(val));
+
+        public static long int8_in(string str)
+            => SafeExecution<long>(() => MEOSExternalFunctions.int8_in(str));
+
+        public static string int8_out(long val)
+            => SafeExecution<string>(() => MEOSExternalFunctions.int8_out(val));
+
+        public static int float8_in(string num, string type_name, string orig_string)
+            => SafeExecution<int>(() => MEOSExternalFunctions.float8_in(num, type_name, orig_string));
+
+        public static int pg_dsin(int arg1)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_dsin(arg1));
+
+        public static int pg_dcos(int arg1)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_dcos(arg1));
+
+        public static int pg_datan(int arg1)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_datan(arg1));
+
+        public static int pg_datan2(int arg1, int arg2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.pg_datan2(arg1, arg2));
+
+        public static IntPtr interval_negate(IntPtr interval)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.interval_negate(interval));
+
+        public static IntPtr pg_interval_justify_hours(IntPtr span)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.pg_interval_justify_hours(span));
+
+        public static uint hash_bytes_uint32(uint k)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.hash_bytes_uint32(k));
+
+        public static uint pg_hashint8(long val)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashint8(val));
+
+        public static uint pg_hashfloat8(int key)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashfloat8(key));
+
+        public static ulong hash_bytes_uint32_extended(uint k, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.hash_bytes_uint32_extended(k, seed));
+
+        public static ulong pg_hashint8extended(long val, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashint8extended(val, seed));
+
+        public static ulong pg_hashfloat8extended(int key, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashfloat8extended(key, seed));
+
+        public static uint pg_hashtext(IntPtr key)
+            => SafeExecution<uint>(() => MEOSExternalFunctions.pg_hashtext(key));
+
+        public static ulong pg_hashtextextended(IntPtr key, ulong seed)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.pg_hashtextextended(key, seed));
+
+        public static string set_out_fn(IntPtr s, int maxdd, IntPtr value_out)
+            => SafeExecution<string>(() => MEOSExternalFunctions.set_out_fn(s, maxdd, value_out));
+
+        public static bool ensure_set_isof_type(IntPtr s, int settype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_set_isof_type(s, settype));
+
+        public static bool ensure_valid_set_set(IntPtr s1, IntPtr s2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_set_set(s1, s2));
+
+        public static bool set_find_value(IntPtr s, IntPtr arg1, IntPtr loc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.set_find_value(s, arg1, loc));
+
+        public static IntPtr set_unnest_state_make(IntPtr set)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_unnest_state_make(set));
+
+        public static void set_unnest_state_next(IntPtr state)
+            => SafeExecution(() => MEOSExternalFunctions.set_unnest_state_next(state));
+
+        public static bool ensure_same_skiplist_subtype(IntPtr state, IntPtr subtype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_skiplist_subtype(state, subtype));
+
+        public static void skiplist_set_extra(IntPtr state, IntPtr data, ulong size)
+            => SafeExecution(() => MEOSExternalFunctions.skiplist_set_extra(state, data, size));
+
+        public static IntPtr skiplist_headval(IntPtr list)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.skiplist_headval(list));
+
+        public static bool ensure_span_isof_type(IntPtr s, int spantype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_isof_type(s, spantype));
+
+        public static bool ensure_span_isof_basetype(IntPtr s, int basetype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_span_isof_basetype(s, basetype));
+
+        public static bool ensure_same_span_type(IntPtr s1, IntPtr s2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_span_type(s1, s2));
+
+        public static bool ensure_valid_span_span(IntPtr s1, IntPtr s2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_span_span(s1, s2));
+
+        public static void span_deserialize(IntPtr s, IntPtr lower, IntPtr upper)
+            => SafeExecution(() => MEOSExternalFunctions.span_deserialize(s, lower, upper));
+
+        public static int span_bound_cmp(IntPtr b1, IntPtr b2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_bound_cmp(b1, b2));
+
+        public static int span_bound_qsort_cmp(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_bound_qsort_cmp(s1, s2));
+
+        public static int span_lower_cmp(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_lower_cmp(s1, s2));
+
+        public static int span_upper_cmp(IntPtr s1, IntPtr s2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_upper_cmp(s1, s2));
+
+        public static int span_decr_bound(IntPtr upper, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_decr_bound(upper, basetype));
+
+        public static int span_incr_bound(IntPtr upper, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_incr_bound(upper, basetype));
+
+        public static IntPtr spanarr_normalize(IntPtr spans, int count, bool sort, IntPtr newcount)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanarr_normalize(spans, count, sort, newcount));
+
+        public static void span_bounds_shift_scale_value(IntPtr shift, IntPtr width, int type, bool hasshift, bool haswidth, IntPtr lower, IntPtr upper)
+            => SafeExecution(() => MEOSExternalFunctions.span_bounds_shift_scale_value(shift, width, type, hasshift, haswidth, lower, upper));
+
+        public static void span_bounds_shift_scale_time(IntPtr shift, IntPtr duration, IntPtr lower, IntPtr upper)
+            => SafeExecution(() => MEOSExternalFunctions.span_bounds_shift_scale_time(shift, duration, lower, upper));
+
+        public static void floatspan_floor_ceil_iter(IntPtr s, int func)
+            => SafeExecution(() => MEOSExternalFunctions.floatspan_floor_ceil_iter(s, func));
+
+        public static void numspan_delta_scale_iter(IntPtr s, IntPtr origin, IntPtr delta, bool hasdelta, double scale)
+            => SafeExecution(() => MEOSExternalFunctions.numspan_delta_scale_iter(s, origin, delta, hasdelta, scale));
+
+        public static void tstzspan_delta_scale_iter(IntPtr s, long origin, long delta, double scale)
+            => SafeExecution(() => MEOSExternalFunctions.tstzspan_delta_scale_iter(s, origin, delta, scale));
+
+        public static void numspan_shift_scale_iter(IntPtr s, IntPtr shift, IntPtr width, bool hasshift, bool haswidth, IntPtr delta, IntPtr scale)
+            => SafeExecution(() => MEOSExternalFunctions.numspan_shift_scale_iter(s, shift, width, hasshift, haswidth, delta, scale));
+
+        public static void tstzspan_shift_scale1(IntPtr s, IntPtr shift, IntPtr duration, IntPtr delta, IntPtr scale)
+            => SafeExecution(() => MEOSExternalFunctions.tstzspan_shift_scale1(s, shift, duration, delta, scale));
+
+        public static int mi_span_value(IntPtr s, IntPtr value, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.mi_span_value(s, value, result));
+
+        public static double dist_double_value_value(IntPtr l, IntPtr r, int type)
+            => SafeExecution<double>(() => MEOSExternalFunctions.dist_double_value_value(l, r, type));
+
+        public static int common_entry_cmp(IntPtr i1, IntPtr i2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.common_entry_cmp(i1, i2));
+
+        public static bool span_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_index_leaf_consistent(key, query, strategy));
+
+        public static bool span_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_gist_inner_consistent(key, query, strategy));
+
+        public static bool span_index_recheck(int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_index_recheck(strategy));
+
+        public static bool ensure_spanset_isof_type(IntPtr ss, int spansettype)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_spanset_isof_type(ss, spansettype));
+
+        public static bool ensure_same_spanset_type(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spanset_type(ss1, ss2));
+
+        public static bool ensure_same_spanset_span_type(IntPtr ss, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_spanset_span_type(ss, s));
+
+        public static bool ensure_valid_spanset_span(IntPtr ss, IntPtr s)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spanset_span(ss, s));
+
+        public static bool ensure_valid_spanset_spanset(IntPtr ss1, IntPtr ss2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_spanset_spanset(ss1, ss2));
+
+        public static bool spanset_find_value(IntPtr ss, IntPtr v, IntPtr loc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.spanset_find_value(ss, v, loc));
+
+        public static int datum_and(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_and(l, r));
+
+        public static int datum_or(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_or(l, r));
+
+        public static IntPtr boolop_tbool_bool(IntPtr temp, IntPtr b, IntPtr func, bool invert)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.boolop_tbool_bool(temp, b, func, invert));
+
+        public static IntPtr boolop_tbool_tbool(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.boolop_tbool_tbool(temp1, temp2, func));
+
+        public static bool ensure_same_dimensionality_tbox(IntPtr box1, IntPtr box2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_same_dimensionality_tbox(box1, box2));
+
+        public static IntPtr set_tbox(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_tbox(s));
+
+        public static IntPtr span_tbox(IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.span_tbox(s));
+
+        public static IntPtr tbox_tstzspan(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_tstzspan(box));
+
+        public static IntPtr tbox_intspan(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_intspan(box));
+
+        public static IntPtr tbox_floatspan(IntPtr box)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_floatspan(box));
+
+        public static bool tbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_index_leaf_consistent(key, query, strategy));
+
+        public static bool tbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_gist_inner_consistent(key, query, strategy));
+
+        public static bool tbox_index_recheck(int strategy)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_index_recheck(strategy));
+
+        public static int datum_min_int32(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_int32(l, r));
+
+        public static int datum_max_int32(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_int32(l, r));
+
+        public static int datum_min_float8(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_float8(l, r));
+
+        public static int datum_max_float8(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_float8(l, r));
+
+        public static int datum_sum_int32(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_int32(l, r));
+
+        public static int datum_sum_float8(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_float8(l, r));
+
+        public static int datum_min_text(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_min_text(l, r));
+
+        public static int datum_max_text(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_max_text(l, r));
+
+        public static int datum_sum_double2(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double2(l, r));
+
+        public static int datum_sum_double3(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double3(l, r));
+
+        public static int datum_sum_double4(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sum_double4(l, r));
+
+        public static int temporal_skiplist_common(IntPtr list, IntPtr values, int count, IntPtr lower, IntPtr upper, IntPtr update)
+            => SafeExecution<int>(() => MEOSExternalFunctions.temporal_skiplist_common(list, values, count, lower, upper, update));
+
+        public static IntPtr temporal_skiplist_merge(IntPtr spliced, int spliced_count, IntPtr values, int count, IntPtr func, bool crossings, IntPtr newcount, IntPtr tofree, IntPtr nfree)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_skiplist_merge(spliced, spliced_count, values, count, func, crossings, newcount, tofree, nfree));
+
+        public static IntPtr tinstant_tagg(IntPtr instants1, int count1, IntPtr instants2, int count2, IntPtr func, IntPtr newcount, IntPtr tofree, IntPtr nfree)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tagg(instants1, count1, instants2, count2, func, newcount, tofree, nfree));
+
+        public static IntPtr tsequence_tagg(IntPtr sequences1, int count1, IntPtr sequences2, int count2, IntPtr func, bool crossings, IntPtr newcount)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_tagg(sequences1, count1, sequences2, count2, func, crossings, newcount));
+
+        public static IntPtr tcontseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func, bool interpoint)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_tagg_transfn(state, seq, func, interpoint));
+
+        public static IntPtr temporal_tagg_combinefn(IntPtr state1, IntPtr state2, IntPtr func, bool crossings)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_combinefn(state1, state2, func, crossings));
+
+        public static IntPtr tinstant_tagg_transfn(IntPtr state, IntPtr inst, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tagg_transfn(state, inst, func));
+
+        public static IntPtr tinstant_tavg_finalfn(IntPtr instants, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_tavg_finalfn(instants, count));
+
+        public static IntPtr tsequence_tavg_finalfn(IntPtr sequences, int count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_tavg_finalfn(sequences, count));
+
+        public static IntPtr tnumberinst_transform_tavg(IntPtr inst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberinst_transform_tavg(inst));
+
+        public static IntPtr temporal_transform_tcount(IntPtr temp, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_tcount(temp, count));
+
+        public static IntPtr temporal_transform_tagg(IntPtr temp, IntPtr count, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_tagg(temp, count, func));
+
+        public static IntPtr tsequenceset_tagg_transfn(IntPtr state, IntPtr ss, IntPtr func, bool crossings)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_tagg_transfn(state, ss, func, crossings));
+
+        public static IntPtr tdiscseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_tagg_transfn(state, seq, func));
+
+        public static IntPtr temporal_tagg_transfn(IntPtr state, IntPtr temp, IntPtr arg2, bool crossings)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_transfn(state, temp, arg2, crossings));
+
+        public static IntPtr temporal_tagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr func, bool crossings, IntPtr transform)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_tagg_transform_transfn(state, temp, func, crossings, transform));
+
+        public static double temporal_similarity(IntPtr temp1, IntPtr temp2, IntPtr simfunc)
+            => SafeExecution<double>(() => MEOSExternalFunctions.temporal_similarity(temp1, temp2, simfunc));
+
+        public static IntPtr temporal_similarity_path(IntPtr temp1, IntPtr temp2, IntPtr count, IntPtr simfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_similarity_path(temp1, temp2, count, simfunc));
+
+        public static ulong temporal_bbox_size(int tempype)
+            => SafeExecution<ulong>(() => MEOSExternalFunctions.temporal_bbox_size(tempype));
+
+        public static void tinstarr_set_bbox(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp, IntPtr bbox)
+            => SafeExecution(() => MEOSExternalFunctions.tinstarr_set_bbox(instants, count, lower_inc, upper_inc, interp, bbox));
+
+        public static void tsequence_compute_bbox(IntPtr seq)
+            => SafeExecution(() => MEOSExternalFunctions.tsequence_compute_bbox(seq));
+
+        public static void tseqarr_compute_bbox(IntPtr sequences, int count, IntPtr bbox)
+            => SafeExecution(() => MEOSExternalFunctions.tseqarr_compute_bbox(sequences, count, bbox));
+
+        public static void tsequenceset_compute_bbox(IntPtr ss)
+            => SafeExecution(() => MEOSExternalFunctions.tsequenceset_compute_bbox(ss));
+
+        public static bool boxop_temporal_tstzspan(IntPtr temp, IntPtr s, IntPtr func, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_temporal_tstzspan(temp, s, func, invert));
+
+        public static bool boxop_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_temporal_temporal(temp1, temp2, func));
+
+        public static bool boxop_tnumber_numspan(IntPtr temp, IntPtr span, IntPtr func, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_numspan(temp, span, func, invert));
+
+        public static bool boxop_tnumber_tbox(IntPtr temp, IntPtr box, IntPtr func, bool invert)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_tbox(temp, box, func, invert));
+
+        public static bool boxop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.boxop_tnumber_tnumber(temp1, temp2, func));
+
+        public static int eacomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_base_temporal(value, temp, func, ever));
+
+        public static int eacomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_temporal_base(temp, value, func, ever));
+
+        public static int eacomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func, bool ever)
+            => SafeExecution<int>(() => MEOSExternalFunctions.eacomp_temporal_temporal(temp1, temp2, func, ever));
+
+        public static IntPtr tcomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_base_temporal(value, temp, func));
+
+        public static IntPtr tcomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_temporal_base(temp, value, func));
+
+        public static IntPtr tcomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcomp_temporal_temporal(temp1, temp2, func));
+
+        public static IntPtr tdiscseq_at_timestamptz(IntPtr seq, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_at_timestamptz(seq, t));
+
+        public static IntPtr tdiscseq_restrict_value(IntPtr seq, IntPtr value, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_value(seq, value, atfunc));
+
+        public static IntPtr tdiscseq_restrict_values(IntPtr seq, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_values(seq, s, atfunc));
+
+        public static IntPtr tdiscseq_minus_timestamptz(IntPtr seq, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_minus_timestamptz(seq, t));
+
+        public static IntPtr tdiscseq_restrict_tstzset(IntPtr seq, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_tstzset(seq, s, atfunc));
+
+        public static IntPtr tdiscseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_restrict_tstzspanset(seq, ss, atfunc));
+
+        public static int tcontseq_restrict_value_iter(IntPtr seq, IntPtr value, bool atfunc, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_restrict_value_iter(seq, value, atfunc, result));
+
+        public static IntPtr tcontseq_delete_timestamptz(IntPtr seq, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_timestamptz(seq, t));
+
+        public static IntPtr tcontseq_delete_tstzset(IntPtr seq, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_tstzset(seq, s));
+
+        public static IntPtr tcontseq_delete_tstzspanset(IntPtr seq, IntPtr ss)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_delete_tstzspanset(seq, ss));
+
+        public static IntPtr tcontseq_at_tstzset(IntPtr seq, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_tstzset(seq, s));
+
+        public static IntPtr tcontseq_minus_timestamptz(IntPtr seq, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_timestamptz(seq, t));
+
+        public static IntPtr tcontseq_minus_tstzset(IntPtr seq, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_tstzset(seq, s));
+
+        public static IntPtr tcontseq_minus_tstzspan(IntPtr seq, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_minus_tstzspan(seq, s));
+
+        public static IntPtr tcontseq_restrict_value(IntPtr seq, IntPtr value, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_value(seq, value, atfunc));
+
+        public static IntPtr tcontseq_restrict_values(IntPtr seq, IntPtr s, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_values(seq, s, atfunc));
+
+        public static int tsequence_at_values_iter(IntPtr seq, IntPtr set, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_at_values_iter(seq, set, result));
+
+        public static int tnumberseq_cont_restrict_span_iter(IntPtr seq, IntPtr span, bool atfunc, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_span_iter(seq, span, atfunc, result));
+
+        public static int tnumberseq_cont_restrict_spanset_iter(IntPtr seq, IntPtr ss, bool atfunc, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_spanset_iter(seq, ss, atfunc, result));
+
+        public static IntPtr tsegment_at_timestamptz(IntPtr inst1, IntPtr inst2, int interp, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsegment_at_timestamptz(inst1, inst2, interp, t));
+
+        public static int tcontseq_minus_timestamp_iter(IntPtr seq, long t, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_timestamp_iter(seq, t, result));
+
+        public static int tcontseq_minus_tstzset_iter(IntPtr seq, IntPtr s, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_tstzset_iter(seq, s, result));
+
+        public static int tcontseq_at_tstzspanset1(IntPtr seq, IntPtr ss, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_at_tstzspanset1(seq, ss, result));
+
+        public static int tcontseq_minus_tstzspanset_iter(IntPtr seq, IntPtr ss, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_minus_tstzspanset_iter(seq, ss, result));
+
+        public static IntPtr tcontseq_at_tstzspan(IntPtr seq, IntPtr s)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_tstzspan(seq, s));
+
+        public static IntPtr tcontseq_at_timestamptz(IntPtr seq, long t)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_at_timestamptz(seq, t));
+
+        public static IntPtr tcontseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_restrict_tstzspanset(seq, ss, atfunc));
+
+        public static bool tdiscseq_value_at_timestamptz(IntPtr seq, long t, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tdiscseq_value_at_timestamptz(seq, t, result));
+
+        public static IntPtr tnumberseq_disc_restrict_span(IntPtr seq, IntPtr span, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_disc_restrict_span(seq, span, atfunc));
+
+        public static IntPtr tnumberseq_disc_restrict_spanset(IntPtr seq, IntPtr ss, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_disc_restrict_spanset(seq, ss, atfunc));
+
+        public static IntPtr tnumberseq_cont_restrict_span(IntPtr seq, IntPtr span, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_span(seq, span, atfunc));
+
+        public static IntPtr tnumberseq_cont_restrict_spanset(IntPtr seq, IntPtr ss, bool atfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumberseq_cont_restrict_spanset(seq, ss, atfunc));
+
+        public static double tnumberseq_cont_twavg(IntPtr seq)
+            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberseq_cont_twavg(seq));
+
+        public static int span_num_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr start_bin, IntPtr end_bin)
+            => SafeExecution<int>(() => MEOSExternalFunctions.span_num_bins(s, size, origin, start_bin, end_bin));
+
+        public static IntPtr temporal_time_bin_init(IntPtr temp, IntPtr duration, long torigin, IntPtr nbins)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_time_bin_init(temp, duration, torigin, nbins));
+
+        public static IntPtr tbox_tile_state_make(IntPtr temp, IntPtr box, IntPtr vsize, IntPtr duration, IntPtr xorigin, long torigin)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_tile_state_make(temp, box, vsize, duration, xorigin, torigin));
+
+        public static void tbox_tile_state_next(IntPtr state)
+            => SafeExecution(() => MEOSExternalFunctions.tbox_tile_state_next(state));
+
+        public static void tbox_tile_state_set(IntPtr value, long t, IntPtr vsize, long tunits, int basetype, int spantype, IntPtr box)
+            => SafeExecution(() => MEOSExternalFunctions.tbox_tile_state_set(value, t, vsize, tunits, basetype, spantype, box));
+
+        public static long interval_units(IntPtr interval)
+            => SafeExecution<long>(() => MEOSExternalFunctions.interval_units(interval));
+
+        public static long timestamptz_bin_start(long timestamp, long tunits, long torigin)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamptz_bin_start(timestamp, tunits, torigin));
+
+        public static int datum_bin(IntPtr value, IntPtr size, IntPtr offset, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_bin(value, size, offset, basetype));
+
+        public static IntPtr tnumber_value_time_tile_init(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, long torigin, IntPtr ntiles)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_value_time_tile_init(temp, vsize, duration, vorigin, torigin, ntiles));
+
+        public static bool tbox_tile_state_get(IntPtr state, IntPtr box)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tbox_tile_state_get(state, box));
+
+        public static IntPtr temporal_transform_wcount(IntPtr temp, IntPtr interval, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_transform_wcount(temp, interval, count));
+
+        public static IntPtr tnumber_transform_wavg(IntPtr temp, IntPtr interval, IntPtr count)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tnumber_transform_wavg(temp, interval, count));
+
+        public static IntPtr temporal_wagg_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, bool min, bool crossings)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_wagg_transfn(state, temp, interval, func, min, crossings));
+
+        public static IntPtr temporal_wagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, IntPtr transform)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_wagg_transform_transfn(state, temp, interval, func, transform));
+
+        public static void tinstant_set(IntPtr inst, IntPtr value, long t)
+            => SafeExecution(() => MEOSExternalFunctions.tinstant_set(inst, value, t));
+
+        public static double tnumberinst_double(IntPtr inst)
+            => SafeExecution<double>(() => MEOSExternalFunctions.tnumberinst_double(inst));
+
+        public static string tinstant_to_string(IntPtr inst, int maxdd, IntPtr value_out)
+            => SafeExecution<string>(() => MEOSExternalFunctions.tinstant_to_string(inst, maxdd, value_out));
+
+        public static bool tinstant_restrict_values_test(IntPtr inst, IntPtr s, bool atfunc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_values_test(inst, s, atfunc));
+
+        public static bool tnumberinst_restrict_span_test(IntPtr inst, IntPtr s, bool atfunc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumberinst_restrict_span_test(inst, s, atfunc));
+
+        public static bool tnumberinst_restrict_spanset_test(IntPtr inst, IntPtr ss, bool atfunc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tnumberinst_restrict_spanset_test(inst, ss, atfunc));
+
+        public static bool tinstant_restrict_tstzset_test(IntPtr inst, IntPtr s, bool atfunc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_tstzset_test(inst, s, atfunc));
+
+        public static bool tinstant_restrict_tstzspanset_test(IntPtr inst, IntPtr ss, bool atfunc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tinstant_restrict_tstzspanset_test(inst, ss, atfunc));
+
+        public static bool intersection_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tinstant(inst1, inst2, inter1, inter2));
+
+        public static int tfloat_arithop_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, long lower, long upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tfloat_arithop_turnpt(start1, end1, start2, end2, param, lower, upper, t1, t2));
+
+        public static IntPtr arithop_tnumber_number(IntPtr temp, IntPtr value, IntPtr oper, IntPtr func, bool invert)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.arithop_tnumber_number(temp, value, oper, func, invert));
+
+        public static IntPtr arithop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr oper, IntPtr func, IntPtr tpfunc)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.arithop_tnumber_tnumber(temp1, temp2, oper, func, tpfunc));
+
+        public static bool float_collinear(double x1, double x2, double x3, double ratio)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.float_collinear(x1, x2, x3, ratio));
+
+        public static double floatsegm_interpolate(double value1, double value2, IntPtr value)
+            => SafeExecution<double>(() => MEOSExternalFunctions.floatsegm_interpolate(value1, value2, value));
+
+        public static IntPtr floatsegm_locate(double value1, double value2, double value)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.floatsegm_locate(value1, value2, value));
+
+        public static int tnumbersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int basetype, long lower, long upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tnumbersegm_intersection(start1, end1, start2, end2, basetype, lower, upper, t1, t2));
+
+        public static bool tsequence_norm_test(IntPtr value1, IntPtr value2, IntPtr value3, int basetype, int interp, long t1, long t2, long t3)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_norm_test(value1, value2, value3, basetype, interp, t1, t2, t3));
+
+        public static bool tsequence_join_test(IntPtr seq1, IntPtr seq2, IntPtr removelast, IntPtr removefirst)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_join_test(seq1, seq2, removelast, removefirst));
+
+        public static IntPtr tsequence_join(IntPtr seq1, IntPtr seq2, bool removelast, bool removefirst)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_join(seq1, seq2, removelast, removefirst));
+
+        public static IntPtr tinstarr_normalize(IntPtr instants, int interp, int count, IntPtr newcount)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstarr_normalize(instants, interp, count, newcount));
+
+        public static int tcontseq_find_timestamptz(IntPtr seq, long t)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tcontseq_find_timestamptz(seq, t));
+
+        public static int tdiscseq_find_timestamptz(IntPtr seq, long t)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tdiscseq_find_timestamptz(seq, t));
+
+        public static IntPtr tseqarr2_to_tseqarr(IntPtr sequences, IntPtr countseqs, int count, int totalseqs)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqarr2_to_tseqarr(sequences, countseqs, count, totalseqs));
+
+        public static bool ensure_valid_tinstarr_common(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tinstarr_common(instants, count, lower_inc, upper_inc, interp));
+
+        public static IntPtr tsequence_make_exp1(IntPtr instants, int count, int maxcount, bool lower_inc, bool upper_inc, int interp, bool normalize, IntPtr bbox)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequence_make_exp1(instants, count, maxcount, lower_inc, upper_inc, interp, normalize, bbox));
+
+        public static bool synchronize_tsequence_tsequence(IntPtr seq1, IntPtr seq2, IntPtr sync1, IntPtr sync2, bool interpoint)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequence_tsequence(seq1, seq2, sync1, sync2, interpoint));
+
+        public static int tfloatsegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, long lower, long upper, IntPtr t)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tfloatsegm_intersection_value(start, end, value, lower, upper, t));
+
+        public static int tsegment_intersection_value(IntPtr start, IntPtr end, IntPtr value, int temptype, long lower, long upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_intersection_value(start, end, value, temptype, lower, upper, t1, t2));
+
+        public static int tsegment_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int temptype, long lower, long upper, IntPtr t1, IntPtr t2)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_intersection(start1, end1, start2, end2, temptype, lower, upper, t1, t2));
+
+        public static int tsegment_value_at_timestamptz(IntPtr start, IntPtr end, int temptype, long lower, long upper, long t)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsegment_value_at_timestamptz(start, end, temptype, lower, upper, t));
+
+        public static bool intersection_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tdiscseq(seq1, seq2, inter1, inter2));
+
+        public static bool intersection_tcontseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tcontseq_tdiscseq(seq1, seq2, inter1, inter2));
+
+        public static bool intersection_tdiscseq_tcontseq(IntPtr @is, IntPtr seq2, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tcontseq(@is, seq2, inter1, inter2));
+
+        public static bool intersection_tsequence_tinstant(IntPtr seq, IntPtr inst, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequence_tinstant(seq, inst, inter1, inter2));
+
+        public static bool intersection_tinstant_tsequence(IntPtr inst, IntPtr seq, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tsequence(inst, seq, inter1, inter2));
+
+        public static string tsequence_to_string(IntPtr seq, int maxdd, bool component, IntPtr value_out)
+            => SafeExecution<string>(() => MEOSExternalFunctions.tsequence_to_string(seq, maxdd, component, value_out));
+
+        public static bool ensure_increasing_timestamps(IntPtr inst1, IntPtr inst2, bool strict)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_increasing_timestamps(inst1, inst2, strict));
+
+        public static void bbox_expand(IntPtr box1, IntPtr box2, int temptype)
+            => SafeExecution(() => MEOSExternalFunctions.bbox_expand(box1, box2, temptype));
+
+        public static bool ensure_valid_tinstarr(IntPtr instants, int count, bool merge, int interp)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tinstarr(instants, count, merge, interp));
+
+        public static bool tsequence_make_valid(IntPtr instants, int count, bool lower_inc, bool upper_inc, int interp)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequence_make_valid(instants, count, lower_inc, upper_inc, interp));
+
+        public static void tnumberseq_shift_scale_value_iter(IntPtr seq, IntPtr origin, IntPtr delta, bool hasdelta, double scale)
+            => SafeExecution(() => MEOSExternalFunctions.tnumberseq_shift_scale_value_iter(seq, origin, delta, hasdelta, scale));
+
+        public static void tsequence_shift_scale_time_iter(IntPtr seq, long delta, double scale)
+            => SafeExecution(() => MEOSExternalFunctions.tsequence_shift_scale_time_iter(seq, delta, scale));
+
+        public static int tstepseq_to_linear_iter(IntPtr seq, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstepseq_to_linear_iter(seq, result));
+
+        public static IntPtr tstepseq_to_linear(IntPtr seq)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tstepseq_to_linear(seq));
+
+        public static int tsequence_segments_iter(IntPtr seq, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_segments_iter(seq, result));
+
+        public static int tsequence_timestamps_iter(IntPtr seq, IntPtr result)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tsequence_timestamps_iter(seq, result));
+
+        public static bool tsequenceset_find_timestamptz(IntPtr ss, long t, IntPtr loc)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.tsequenceset_find_timestamptz(ss, t, loc));
+
+        public static IntPtr tseqarr_normalize(IntPtr sequences, int count, IntPtr newcount)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tseqarr_normalize(sequences, count, newcount));
+
+        public static double datum_distance(IntPtr value1, IntPtr value2, int basetype, short flags)
+            => SafeExecution<double>(() => MEOSExternalFunctions.datum_distance(value1, value2, basetype, flags));
+
+        public static IntPtr ensure_valid_tinstarr_gaps(IntPtr instants, int count, bool merge, double maxdist, IntPtr maxt, IntPtr nsplits)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.ensure_valid_tinstarr_gaps(instants, count, merge, maxdist, maxt, nsplits));
+
+        public static bool ensure_valid_tseqarr(IntPtr sequences, int count)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_valid_tseqarr(sequences, count));
+
+        public static bool synchronize_tsequenceset_tsequence(IntPtr ss, IntPtr seq, IntPtr mode, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequenceset_tsequence(ss, seq, mode, inter1, inter2));
+
+        public static bool synchronize_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr mode, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.synchronize_tsequenceset_tsequenceset(ss1, ss2, mode, inter1, inter2));
+
+        public static bool intersection_tsequenceset_tinstant(IntPtr ss, IntPtr inst, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequenceset_tinstant(ss, inst, inter1, inter2));
+
+        public static bool intersection_tinstant_tsequenceset(IntPtr inst, IntPtr ss, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tinstant_tsequenceset(inst, ss, inter1, inter2));
+
+        public static bool intersection_tsequenceset_tdiscseq(IntPtr ss, IntPtr @is, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequenceset_tdiscseq(ss, @is, inter1, inter2));
+
+        public static bool intersection_tdiscseq_tsequenceset(IntPtr @is, IntPtr ss, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tdiscseq_tsequenceset(@is, ss, inter1, inter2));
+
+        public static bool intersection_tsequence_tsequenceset(IntPtr seq, IntPtr ss, IntPtr mode, IntPtr inter1, IntPtr inter2)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.intersection_tsequence_tsequenceset(seq, ss, mode, inter1, inter2));
+
+        public static string tsequenceset_to_string(IntPtr ss, int maxdd, IntPtr value_out)
+            => SafeExecution<string>(() => MEOSExternalFunctions.tsequenceset_to_string(ss, maxdd, value_out));
+
+        public static int datum_textcat(IntPtr l, IntPtr r)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_textcat(l, r));
+
+        public static int datum_lower(IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_lower(value));
+
+        public static int datum_upper(IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_upper(value));
+
+        public static int datum_initcap(IntPtr value)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_initcap(value));
+
+        public static IntPtr textfunc_ttext(IntPtr temp, int func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext(temp, func));
+
+        public static IntPtr textfunc_ttext_text(IntPtr temp, IntPtr value, IntPtr func, bool invert)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext_text(temp, value, func, invert));
+
+        public static IntPtr textfunc_ttext_ttext(IntPtr temp1, IntPtr temp2, IntPtr func)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.textfunc_ttext_ttext(temp1, temp2, func));
+
+        public static IntPtr datum_as_wkb(IntPtr value, int type, IntPtr variant, IntPtr size_out)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.datum_as_wkb(value, type, variant, size_out));
+
+        public static string datum_as_hexwkb(IntPtr value, int type, IntPtr variant, IntPtr size)
+            => SafeExecution<string>(() => MEOSExternalFunctions.datum_as_hexwkb(value, type, variant, size));
+
+        public static int type_from_wkb(IntPtr wkb, ulong size, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.type_from_wkb(wkb, size, type));
+
+        public static int type_from_hexwkb(string hexwkb, ulong size, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.type_from_hexwkb(hexwkb, size, type));
+
+        public static bool ensure_end_input(IntPtr str, string type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_end_input(str, type));
+
+        public static void p_whitespace(IntPtr str)
+            => SafeExecution(() => MEOSExternalFunctions.p_whitespace(str));
+
+        public static bool p_delimchar(IntPtr str, byte delim)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_delimchar(str, delim));
+
+        public static bool p_obrace(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_obrace(str));
+
+        public static bool ensure_obrace(IntPtr str, string type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_obrace(str, type));
+
+        public static bool p_cbrace(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cbrace(str));
+
+        public static bool ensure_cbrace(IntPtr str, string type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_cbrace(str, type));
+
+        public static bool p_obracket(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_obracket(str));
+
+        public static bool p_cbracket(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cbracket(str));
+
+        public static bool p_oparen(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_oparen(str));
+
+        public static bool ensure_oparen(IntPtr str, string type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_oparen(str, type));
+
+        public static bool p_cparen(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_cparen(str));
+
+        public static bool ensure_cparen(IntPtr str, string type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.ensure_cparen(str, type));
+
+        public static bool p_comma(IntPtr str)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.p_comma(str));
+
+        public static bool basetype_parse(IntPtr str, int basetypid, byte delim, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_parse(str, basetypid, delim, result));
+
+        public static bool double_parse(IntPtr str, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.double_parse(str, result));
+
+        public static bool elem_parse(IntPtr str, int basetype, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.elem_parse(str, basetype, result));
+
+        public static IntPtr set_parse(IntPtr str, int basetype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.set_parse(str, basetype));
+
+        public static bool span_parse(IntPtr str, int spantype, bool end, IntPtr span)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.span_parse(str, spantype, end, span));
+
+        public static IntPtr spanset_parse(IntPtr str, int spantype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.spanset_parse(str, spantype));
+
+        public static IntPtr tbox_parse(IntPtr str)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tbox_parse(str));
+
+        public static long timestamp_parse(IntPtr str)
+            => SafeExecution<long>(() => MEOSExternalFunctions.timestamp_parse(str));
+
+        public static IntPtr tinstant_parse(IntPtr str, int temptype, bool end)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tinstant_parse(str, temptype, end));
+
+        public static IntPtr tdiscseq_parse(IntPtr str, int temptype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tdiscseq_parse(str, temptype));
+
+        public static IntPtr tcontseq_parse(IntPtr str, int temptype, int interp, bool end)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tcontseq_parse(str, temptype, interp, end));
+
+        public static IntPtr tsequenceset_parse(IntPtr str, int temptype, int interp)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.tsequenceset_parse(str, temptype, interp));
+
+        public static IntPtr temporal_parse(IntPtr str, int temptype)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.temporal_parse(str, temptype));
+
+        public static int datum_copy(IntPtr value, int typid)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_copy(value, typid));
+
+        public static double datum_double(IntPtr d, int type)
+            => SafeExecution<double>(() => MEOSExternalFunctions.datum_double(d, type));
+
+        public static int double_datum(double d, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.double_datum(d, type));
+
+        public static IntPtr bstring2bytea(IntPtr wkb, ulong size)
+            => SafeExecution<IntPtr>(() => MEOSExternalFunctions.bstring2bytea(wkb, size));
+
+        public static bool basetype_in(string str, int type, bool end, IntPtr result)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.basetype_in(str, type, end, result));
+
+        public static string basetype_out(IntPtr value, int type, int maxdd)
+            => SafeExecution<string>(() => MEOSExternalFunctions.basetype_out(value, type, maxdd));
+
+        public static void pfree_array(IntPtr array, int count)
+            => SafeExecution(() => MEOSExternalFunctions.pfree_array(array, count));
+
+        public static string stringarr_to_string(IntPtr strings, int count, ulong outlen, string prefix, byte open, byte close, bool quotes, bool spaces)
+            => SafeExecution<string>(() => MEOSExternalFunctions.stringarr_to_string(strings, count, outlen, prefix, open, close, quotes, spaces));
+
+        public static void datumarr_sort(IntPtr values, int count, int basetype)
+            => SafeExecution(() => MEOSExternalFunctions.datumarr_sort(values, count, basetype));
+
+        public static void tstzarr_sort(IntPtr times, int count)
+            => SafeExecution(() => MEOSExternalFunctions.tstzarr_sort(times, count));
+
+        public static void spanarr_sort(IntPtr spans, int count)
+            => SafeExecution(() => MEOSExternalFunctions.spanarr_sort(spans, count));
+
+        public static void tinstarr_sort(IntPtr instants, int count)
+            => SafeExecution(() => MEOSExternalFunctions.tinstarr_sort(instants, count));
+
+        public static void tseqarr_sort(IntPtr sequences, int count)
+            => SafeExecution(() => MEOSExternalFunctions.tseqarr_sort(sequences, count));
+
+        public static int datumarr_remove_duplicates(IntPtr values, int count, int basetype)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datumarr_remove_duplicates(values, count, basetype));
+
+        public static int tstzarr_remove_duplicates(IntPtr values, int count)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tstzarr_remove_duplicates(values, count));
+
+        public static int tinstarr_remove_duplicates(IntPtr instants, int count)
+            => SafeExecution<int>(() => MEOSExternalFunctions.tinstarr_remove_duplicates(instants, count));
+
+        public static int datum_add(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_add(l, r, type));
+
+        public static int datum_sub(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_sub(l, r, type));
+
+        public static int datum_mult(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_mult(l, r, type));
+
+        public static int datum_div(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_div(l, r, type));
+
+        public static int datum_cmp(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum_cmp(l, r, type));
+
+        public static bool datum_eq(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_eq(l, r, type));
+
+        public static bool datum_ne(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_ne(l, r, type));
+
+        public static bool datum_lt(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_lt(l, r, type));
+
+        public static bool datum_le(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_le(l, r, type));
+
+        public static bool datum_gt(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_gt(l, r, type));
+
+        public static bool datum_ge(IntPtr l, IntPtr r, int type)
+            => SafeExecution<bool>(() => MEOSExternalFunctions.datum_ge(l, r, type));
+
+        public static int datum2_eq(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_eq(l, r, type));
+
+        public static int datum2_ne(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_ne(l, r, type));
+
+        public static int datum2_lt(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_lt(l, r, type));
+
+        public static int datum2_le(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_le(l, r, type));
+
+        public static int datum2_gt(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_gt(l, r, type));
+
+        public static int datum2_ge(IntPtr l, IntPtr r, int type)
+            => SafeExecution<int>(() => MEOSExternalFunctions.datum2_ge(l, r, type));
+
+        public static double hypot3d(double x, double y, double z)
+            => SafeExecution<double>(() => MEOSExternalFunctions.hypot3d(x, y, z));
 
     }
 }

--- a/MEOS.NET/Internal/MEOSExternalFunctions.cs
+++ b/MEOS.NET/Internal/MEOSExternalFunctions.cs
@@ -13,6 +13,273 @@ namespace MEOS.NET.Internal
             private const string DllPath = "meos";
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string describeH3Error(uint err);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint latLngToCell(IntPtr g, int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToLatLng(ulong h3, IntPtr g);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToBoundary(ulong h3, IntPtr gp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint maxGridDiskSize(int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDiskUnsafe(ulong origin, int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDiskDistancesUnsafe(ulong origin, int k, IntPtr @out, IntPtr distances);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDiskDistancesSafe(ulong origin, int k, IntPtr @out, IntPtr distances);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDisksUnsafe(IntPtr h3Set, int length, int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDisk(ulong origin, int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDiskDistances(ulong origin, int k, IntPtr @out, IntPtr distances);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint maxGridRingSize(int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridRingUnsafe(ulong origin, int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridRing(ulong origin, int k, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint maxPolygonToCellsSize(IntPtr geoPolygon, int res, uint flags, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint polygonToCells(IntPtr geoPolygon, int res, uint flags, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint maxPolygonToCellsSizeExperimental(IntPtr polygon, int res, uint flags, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint polygonToCellsExperimental(IntPtr polygon, int res, uint flags, long size, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellsToLinkedMultiPolygon(IntPtr h3Set, int numHexes, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void destroyLinkedMultiPolygon(IntPtr polygon);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double degsToRads(double degrees);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double radsToDegs(double radians);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double greatCircleDistanceRads(IntPtr a, IntPtr b);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double greatCircleDistanceKm(IntPtr a, IntPtr b);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double greatCircleDistanceM(IntPtr a, IntPtr b);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getHexagonAreaAvgKm2(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getHexagonAreaAvgM2(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellAreaRads2(ulong h, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellAreaKm2(ulong h, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellAreaM2(ulong h, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getHexagonEdgeLengthAvgKm(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getHexagonEdgeLengthAvgM(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint edgeLengthRads(ulong edge, IntPtr length);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint edgeLengthKm(ulong edge, IntPtr length);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint edgeLengthM(ulong edge, IntPtr length);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getNumCells(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int res0CellCount();
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getRes0Cells(IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pentagonCount();
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getPentagons(int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int getResolution(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int getBaseCellNumber(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getIndexDigit(ulong h, int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint constructCell(int res, int baseCellNumber, IntPtr digits, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint stringToH3(string str, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint h3ToString(ulong h, string str, ulong sz);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isValidCell(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isValidIndex(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToParent(ulong h, int parentRes, IntPtr parent);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToChildrenSize(ulong h, int childRes, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToChildren(ulong h, int childRes, IntPtr children);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToCenterChild(ulong h, int childRes, IntPtr child);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToChildPos(ulong child, int parentRes, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint childPosToCell(long childPos, ulong parent, int childRes, IntPtr child);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint compactCells(IntPtr h3Set, IntPtr compactedSet, long numHexes);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint uncompactCellsSize(IntPtr compactedSet, long numCompacted, int res, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint uncompactCells(IntPtr compactedSet, long numCompacted, IntPtr outSet, long numOut, int res);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isResClassIII(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isPentagon(ulong h);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint maxFaceCount(ulong h3, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getIcosahedronFaces(ulong h3, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint areNeighborCells(ulong origin, ulong destination, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellsToDirectedEdge(ulong origin, ulong destination, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isValidDirectedEdge(ulong edge);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getDirectedEdgeOrigin(ulong edge, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint getDirectedEdgeDestination(ulong edge, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint directedEdgeToCells(ulong edge, IntPtr originDestination);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint originToDirectedEdges(ulong origin, IntPtr edges);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint directedEdgeToBoundary(ulong edge, IntPtr gb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToVertex(ulong origin, int vertexNum, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToVertexes(ulong origin, IntPtr vertexes);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint vertexToLatLng(ulong vertex, IntPtr point);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int isValidVertex(ulong vertex);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridDistance(ulong origin, ulong h3, IntPtr distance);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridPathCellsSize(ulong start, ulong end, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint gridPathCells(ulong start, ulong end, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint cellToLocalIj(ulong origin, ulong h3, uint mode, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint localIjToCell(ulong origin, IntPtr ij, uint mode, IntPtr @out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int date_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string date_out(int d);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int interval_cmp(IntPtr interv1, IntPtr interv2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr interval_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string interval_out(IntPtr interv);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long time_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string time_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamp_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string timestamp_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamptz_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string timestamptz_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr meos_array_create(int elem_size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
@@ -132,7 +399,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr add_interval_interval(IntPtr interv1, IntPtr interv2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int add_timestamptz_interval(int t, IntPtr interv);
+            public static partial long add_timestamptz_interval(long t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -145,10 +412,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr cstring2text(string str);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int date_to_timestamp(int dateVal);
+            public static partial long date_to_timestamp(int dateVal);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int date_to_timestamptz(int d);
+            public static partial long date_to_timestamptz(int d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double float_exp(double d);
@@ -169,7 +436,7 @@ namespace MEOS.NET.Internal
             public static partial int int32_cmp(int l, int r);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int int64_cmp(int l, int r);
+            public static partial int int64_cmp(long l, long r);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs);
@@ -181,10 +448,10 @@ namespace MEOS.NET.Internal
             public static partial int minus_date_int(int d, int days);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int minus_timestamptz_interval(int t, IntPtr interv);
+            public static partial long minus_timestamptz_interval(long t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_timestamptz(int t1, int t2);
+            public static partial IntPtr minus_timestamptz_timestamptz(long t1, long t2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr mul_interval_double(IntPtr interv, double factor);
@@ -205,16 +472,16 @@ namespace MEOS.NET.Internal
             public static partial string pg_interval_out(IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_timestamp_in(string str, int typmod);
+            public static partial long pg_timestamp_in(string str, int typmod);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string pg_timestamp_out(int t);
+            public static partial string pg_timestamp_out(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_timestamptz_in(string str, int typmod);
+            public static partial long pg_timestamptz_in(string str, int typmod);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string pg_timestamptz_out(int t);
+            public static partial string pg_timestamptz_out(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial string text2cstring(IntPtr txt);
@@ -244,13 +511,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textcat_text_text(IntPtr txt1, IntPtr txt2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamptz_shift(int t, IntPtr interv);
+            public static partial long timestamptz_shift(long t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamp_to_date(int t);
+            public static partial int timestamp_to_date(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamptz_to_date(int t);
+            public static partial int timestamptz_to_date(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigintset_in(string str);
@@ -259,7 +526,7 @@ namespace MEOS.NET.Internal
             public static partial string bigintset_out(IntPtr set);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_expand(IntPtr s, int value);
+            public static partial IntPtr bigintspan_expand(IntPtr s, long value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigintspan_in(string str);
@@ -397,7 +664,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr bigintset_make(IntPtr values, int count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_make(int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
+            public static partial IntPtr bigintspan_make(long lower, long upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr dateset_make(IntPtr values, int count);
@@ -436,10 +703,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzset_make(IntPtr values, int count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_make(int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
+            public static partial IntPtr tstzspan_make(long lower, long upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_to_set(int i);
+            public static partial IntPtr bigint_to_set(long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigint_to_span(int i);
@@ -514,13 +781,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr text_to_set(IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_set(int t);
+            public static partial IntPtr timestamptz_to_set(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_span(int t);
+            public static partial IntPtr timestamptz_to_span(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_spanset(int t);
+            public static partial IntPtr timestamptz_to_spanset(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_to_dateset(IntPtr s);
@@ -532,10 +799,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzspanset_to_datespanset(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintset_end_value(IntPtr s);
+            public static partial long bigintset_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintset_start_value(IntPtr s);
+            public static partial long bigintset_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -545,22 +812,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr bigintset_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspan_lower(IntPtr s);
+            public static partial long bigintspan_lower(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspan_upper(IntPtr s);
+            public static partial long bigintspan_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspan_width(IntPtr s);
+            public static partial long bigintspan_width(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspanset_lower(IntPtr ss);
+            public static partial long bigintspanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspanset_upper(IntPtr ss);
+            public static partial long bigintspanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigintspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
+            public static partial long bigintspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int dateset_end_value(IntPtr s);
@@ -666,19 +933,19 @@ namespace MEOS.NET.Internal
             public static partial int intspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int set_hash(IntPtr s);
+            public static partial uint set_hash(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int set_hash_extended(IntPtr s, int seed);
+            public static partial ulong set_hash_extended(IntPtr s, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_num_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_hash(IntPtr s);
+            public static partial uint span_hash(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_hash_extended(IntPtr s, int seed);
+            public static partial ulong span_hash_extended(IntPtr s, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -692,10 +959,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_end_span(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spanset_hash(IntPtr ss);
+            public static partial uint spanset_hash(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spanset_hash_extended(IntPtr ss, int seed);
+            public static partial ulong spanset_hash_extended(IntPtr ss, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -734,10 +1001,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textset_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzset_end_value(IntPtr s);
+            public static partial long tstzset_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzset_start_value(IntPtr s);
+            public static partial long tstzset_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -750,25 +1017,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzspan_duration(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspan_lower(IntPtr s);
+            public static partial long tstzspan_lower(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspan_upper(IntPtr s);
+            public static partial long tstzspan_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_duration(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspanset_end_timestamptz(IntPtr ss);
+            public static partial long tstzspanset_end_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspanset_lower(IntPtr ss);
+            public static partial long tstzspanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tstzspanset_num_timestamps(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspanset_start_timestamptz(IntPtr ss);
+            public static partial long tstzspanset_start_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_timestamps(IntPtr ss);
@@ -778,16 +1045,16 @@ namespace MEOS.NET.Internal
             public static partial bool tstzspanset_timestamptz_n(IntPtr ss, int n, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzspanset_upper(IntPtr ss);
+            public static partial long tstzspanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintset_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintset_shift_scale(IntPtr s, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintspan_shift_scale(IntPtr s, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspanset_shift_scale(IntPtr ss, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintspanset_shift_scale(IntPtr ss, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr dateset_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
@@ -880,25 +1147,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textset_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamptz_tprecision(int t, IntPtr duration, int torigin);
+            public static partial long timestamptz_tprecision(long t, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_shift_scale(IntPtr s, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, int torigin);
+            public static partial IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspan_shift_scale(IntPtr s, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, int torigin);
+            public static partial IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, int torigin);
+            public static partial IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_cmp(IntPtr s1, IntPtr s2);
@@ -1001,7 +1268,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_bigint(IntPtr s, int i);
+            public static partial bool adjacent_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1025,11 +1292,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_timestamptz(IntPtr s, int t);
+            public static partial bool adjacent_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_bigint(IntPtr ss, int i);
+            public static partial bool adjacent_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1045,7 +1312,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool adjacent_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1057,15 +1324,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_set(int i, IntPtr s);
+            public static partial bool contained_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_span(int i, IntPtr s);
+            public static partial bool contained_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_spanset(int i, IntPtr ss);
+            public static partial bool contained_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1129,19 +1396,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_set(int t, IntPtr s);
+            public static partial bool contained_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_span(int t, IntPtr s);
+            public static partial bool contained_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_spanset(int t, IntPtr ss);
+            public static partial bool contained_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_bigint(IntPtr s, int i);
+            public static partial bool contains_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1165,11 +1432,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_timestamptz(IntPtr s, int t);
+            public static partial bool contains_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_bigint(IntPtr s, int i);
+            public static partial bool contains_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1193,11 +1460,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_timestamptz(IntPtr s, int t);
+            public static partial bool contains_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_bigint(IntPtr ss, int i);
+            public static partial bool contains_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1221,7 +1488,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool contains_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1261,7 +1528,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_set_timestamptz(IntPtr s, int t);
+            public static partial bool after_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1269,7 +1536,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_span_timestamptz(IntPtr s, int t);
+            public static partial bool after_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1277,19 +1544,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool after_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_set(int t, IntPtr s);
+            public static partial bool after_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_span(int t, IntPtr s);
+            public static partial bool after_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_spanset(int t, IntPtr ss);
+            public static partial bool after_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1309,7 +1576,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_set_timestamptz(IntPtr s, int t);
+            public static partial bool before_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1317,7 +1584,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_span_timestamptz(IntPtr s, int t);
+            public static partial bool before_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1325,31 +1592,31 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool before_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_set(int t, IntPtr s);
+            public static partial bool before_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_span(int t, IntPtr s);
+            public static partial bool before_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_spanset(int t, IntPtr ss);
+            public static partial bool before_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_set(int i, IntPtr s);
+            public static partial bool left_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_span(int i, IntPtr s);
+            public static partial bool left_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_spanset(int i, IntPtr ss);
+            public static partial bool left_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1377,7 +1644,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_set_bigint(IntPtr s, int i);
+            public static partial bool left_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1397,7 +1664,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_span_bigint(IntPtr s, int i);
+            public static partial bool left_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1417,7 +1684,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_spanset_bigint(IntPtr ss, int i);
+            public static partial bool left_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1457,7 +1724,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_set_timestamptz(IntPtr s, int t);
+            public static partial bool overafter_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1465,7 +1732,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_span_timestamptz(IntPtr s, int t);
+            public static partial bool overafter_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1473,19 +1740,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool overafter_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_set(int t, IntPtr s);
+            public static partial bool overafter_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_span(int t, IntPtr s);
+            public static partial bool overafter_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_spanset(int t, IntPtr ss);
+            public static partial bool overafter_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1505,7 +1772,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_set_timestamptz(IntPtr s, int t);
+            public static partial bool overbefore_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1513,7 +1780,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_span_timestamptz(IntPtr s, int t);
+            public static partial bool overbefore_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1521,31 +1788,31 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_spanset_timestamptz(IntPtr ss, int t);
+            public static partial bool overbefore_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_set(int t, IntPtr s);
+            public static partial bool overbefore_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_span(int t, IntPtr s);
+            public static partial bool overbefore_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_spanset(int t, IntPtr ss);
+            public static partial bool overbefore_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_set(int i, IntPtr s);
+            public static partial bool overleft_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_span(int i, IntPtr s);
+            public static partial bool overleft_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_spanset(int i, IntPtr ss);
+            public static partial bool overleft_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1573,7 +1840,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_set_bigint(IntPtr s, int i);
+            public static partial bool overleft_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1593,7 +1860,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_span_bigint(IntPtr s, int i);
+            public static partial bool overleft_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1613,7 +1880,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_spanset_bigint(IntPtr ss, int i);
+            public static partial bool overleft_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1637,15 +1904,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_set(int i, IntPtr s);
+            public static partial bool overright_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_span(int i, IntPtr s);
+            public static partial bool overright_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_spanset(int i, IntPtr ss);
+            public static partial bool overright_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1673,7 +1940,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_set_bigint(IntPtr s, int i);
+            public static partial bool overright_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1693,7 +1960,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_span_bigint(IntPtr s, int i);
+            public static partial bool overright_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1713,7 +1980,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_spanset_bigint(IntPtr ss, int i);
+            public static partial bool overright_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1737,15 +2004,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_set(int i, IntPtr s);
+            public static partial bool right_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_span(int i, IntPtr s);
+            public static partial bool right_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_spanset(int i, IntPtr ss);
+            public static partial bool right_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1773,7 +2040,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_set_bigint(IntPtr s, int i);
+            public static partial bool right_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1793,7 +2060,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_span_bigint(IntPtr s, int i);
+            public static partial bool right_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1813,7 +2080,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_spanset_bigint(IntPtr ss, int i);
+            public static partial bool right_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1836,7 +2103,7 @@ namespace MEOS.NET.Internal
             public static partial bool right_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_bigint_set(int i, IntPtr s);
+            public static partial IntPtr intersection_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_date_set(int d, IntPtr s);
@@ -1848,7 +2115,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_int_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_bigint(IntPtr s, int i);
+            public static partial IntPtr intersection_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_set_date(IntPtr s, int d);
@@ -1866,10 +2133,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_timestamptz(IntPtr s, int t);
+            public static partial IntPtr intersection_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_bigint(IntPtr s, int i);
+            public static partial IntPtr intersection_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_span_date(IntPtr s, int d);
@@ -1887,10 +2154,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_timestamptz(IntPtr s, int t);
+            public static partial IntPtr intersection_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_bigint(IntPtr ss, int i);
+            public static partial IntPtr intersection_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_spanset_date(IntPtr ss, int d);
@@ -1908,22 +2175,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_timestamptz(IntPtr ss, int t);
+            public static partial IntPtr intersection_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_timestamptz_set(int t, IntPtr s);
+            public static partial IntPtr intersection_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_set(int i, IntPtr s);
+            public static partial IntPtr minus_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_span(int i, IntPtr s);
+            public static partial IntPtr minus_bigint_span(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_spanset(int i, IntPtr ss);
+            public static partial IntPtr minus_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_date_set(int d, IntPtr s);
@@ -1953,7 +2220,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_int_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_bigint(IntPtr s, int i);
+            public static partial IntPtr minus_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_set_date(IntPtr s, int d);
@@ -1971,10 +2238,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_timestamptz(IntPtr s, int t);
+            public static partial IntPtr minus_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_bigint(IntPtr s, int i);
+            public static partial IntPtr minus_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_span_date(IntPtr s, int d);
@@ -1992,10 +2259,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_timestamptz(IntPtr s, int t);
+            public static partial IntPtr minus_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_bigint(IntPtr ss, int i);
+            public static partial IntPtr minus_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_spanset_date(IntPtr ss, int d);
@@ -2013,28 +2280,28 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_timestamptz(IntPtr ss, int t);
+            public static partial IntPtr minus_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_set(int t, IntPtr s);
+            public static partial IntPtr minus_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_span(int t, IntPtr s);
+            public static partial IntPtr minus_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_spanset(int t, IntPtr ss);
+            public static partial IntPtr minus_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_set(int i, IntPtr s);
+            public static partial IntPtr union_bigint_set(long i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_span(IntPtr s, int i);
+            public static partial IntPtr union_bigint_span(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_spanset(int i, IntPtr ss);
+            public static partial IntPtr union_bigint_spanset(long i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_date_set(int d, IntPtr s);
@@ -2064,7 +2331,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_int_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_bigint(IntPtr s, int i);
+            public static partial IntPtr union_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_set_date(IntPtr s, int d);
@@ -2082,10 +2349,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_timestamptz(IntPtr s, int t);
+            public static partial IntPtr union_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_bigint(IntPtr s, int i);
+            public static partial IntPtr union_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_span_date(IntPtr s, int d);
@@ -2103,10 +2370,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_timestamptz(IntPtr s, int t);
+            public static partial IntPtr union_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_bigint(IntPtr ss, int i);
+            public static partial IntPtr union_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_spanset_date(IntPtr ss, int d);
@@ -2124,31 +2391,31 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_timestamptz(IntPtr ss, int t);
+            public static partial IntPtr union_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_set(int t, IntPtr s);
+            public static partial IntPtr union_timestamptz_set(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_span(int t, IntPtr s);
+            public static partial IntPtr union_timestamptz_span(long t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_spanset(int t, IntPtr ss);
+            public static partial IntPtr union_timestamptz_spanset(long t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_bigintset_bigintset(IntPtr s1, IntPtr s2);
+            public static partial long distance_bigintset_bigintset(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2);
+            public static partial long distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s);
+            public static partial long distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2);
+            public static partial long distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_dateset_dateset(IntPtr s1, IntPtr s2);
@@ -2187,7 +2454,7 @@ namespace MEOS.NET.Internal
             public static partial int distance_intspanset_intspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_set_bigint(IntPtr s, int i);
+            public static partial long distance_set_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_set_date(IntPtr s, int d);
@@ -2199,10 +2466,10 @@ namespace MEOS.NET.Internal
             public static partial int distance_set_int(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_set_timestamptz(IntPtr s, int t);
+            public static partial double distance_set_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_span_bigint(IntPtr s, int i);
+            public static partial long distance_span_bigint(IntPtr s, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_span_date(IntPtr s, int d);
@@ -2214,10 +2481,10 @@ namespace MEOS.NET.Internal
             public static partial int distance_span_int(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_span_timestamptz(IntPtr s, int t);
+            public static partial double distance_span_timestamptz(IntPtr s, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_spanset_bigint(IntPtr ss, int i);
+            public static partial long distance_spanset_bigint(IntPtr ss, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_spanset_date(IntPtr ss, int d);
@@ -2229,7 +2496,7 @@ namespace MEOS.NET.Internal
             public static partial int distance_spanset_int(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_spanset_timestamptz(IntPtr ss, int t);
+            public static partial double distance_spanset_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double distance_tstzset_tstzset(IntPtr s1, IntPtr s2);
@@ -2244,10 +2511,10 @@ namespace MEOS.NET.Internal
             public static partial double distance_tstzspanset_tstzspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_extent_transfn(IntPtr state, int i);
+            public static partial IntPtr bigint_extent_transfn(IntPtr state, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_union_transfn(IntPtr state, int i);
+            public static partial IntPtr bigint_union_transfn(IntPtr state, long i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr date_extent_transfn(IntPtr state, int d);
@@ -2295,19 +2562,19 @@ namespace MEOS.NET.Internal
             public static partial IntPtr text_union_transfn(IntPtr state, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_extent_transfn(IntPtr state, int t);
+            public static partial IntPtr timestamptz_extent_transfn(IntPtr state, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_union_transfn(IntPtr state, int t);
+            public static partial IntPtr timestamptz_union_transfn(IntPtr state, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int bigint_get_bin(int value, int vsize, int vorigin);
+            public static partial long bigint_get_bin(long value, long vsize, long vorigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_bins(IntPtr s, int vsize, int vorigin, IntPtr count);
+            public static partial IntPtr bigintspan_bins(IntPtr s, long vsize, long vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count);
+            public static partial IntPtr bigintspanset_bins(IntPtr ss, long vsize, long vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int date_get_bin(int d, IntPtr duration, int torigin);
@@ -2337,13 +2604,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamptz_get_bin(int t, IntPtr duration, int torigin);
+            public static partial long timestamptz_get_bin(long t, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_bins(IntPtr s, IntPtr duration, int origin, IntPtr count);
+            public static partial IntPtr tstzspan_bins(IntPtr s, IntPtr duration, long origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, int torigin, IntPtr count);
+            public static partial IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial string tbox_as_hexwkb(IntPtr box, IntPtr variant, IntPtr size);
@@ -2364,13 +2631,13 @@ namespace MEOS.NET.Internal
             public static partial string tbox_out(IntPtr box, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr float_timestamptz_to_tbox(double d, int t);
+            public static partial IntPtr float_timestamptz_to_tbox(double d, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr float_tstzspan_to_tbox(double d, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr int_timestamptz_to_tbox(int i, int t);
+            public static partial IntPtr int_timestamptz_to_tbox(int i, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr int_tstzspan_to_tbox(int i, IntPtr s);
@@ -2379,7 +2646,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr numspan_tstzspan_to_tbox(IntPtr span, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_timestamptz_to_tbox(IntPtr span, int t);
+            public static partial IntPtr numspan_timestamptz_to_tbox(IntPtr span, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tbox_copy(IntPtr box);
@@ -2412,13 +2679,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbox_to_tstzspan(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_tbox(int t);
+            public static partial IntPtr timestamptz_to_tbox(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tbox_hash(IntPtr box);
+            public static partial uint tbox_hash(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tbox_hash_extended(IntPtr box, int seed);
+            public static partial ulong tbox_hash_extended(IntPtr box, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2637,7 +2904,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbool_from_base_temp([MarshalAs(UnmanagedType.U1)] bool b, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tboolinst_make([MarshalAs(UnmanagedType.U1)] bool b, int t);
+            public static partial IntPtr tboolinst_make([MarshalAs(UnmanagedType.U1)] bool b, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tboolseq_from_base_tstzset([MarshalAs(UnmanagedType.U1)] bool b, IntPtr s);
@@ -2655,7 +2922,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_from_base_temp(double d, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatinst_make(double d, int t);
+            public static partial IntPtr tfloatinst_make(double d, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloatseq_from_base_tstzset(double d, IntPtr s);
@@ -2670,7 +2937,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tint_from_base_temp(int i, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintinst_make(int i, int t);
+            public static partial IntPtr tintinst_make(int i, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tintseq_from_base_tstzset(int i, IntPtr s);
@@ -2694,7 +2961,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr ttext_from_base_temp(IntPtr txt, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ttextinst_make(IntPtr txt, int t);
+            public static partial IntPtr ttextinst_make(IntPtr txt, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr ttextseq_from_base_tstzset(IntPtr txt, IntPtr s);
@@ -2733,7 +3000,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbool_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tbool_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2752,10 +3019,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_end_sequence(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_end_timestamptz(IntPtr temp);
+            public static partial long temporal_end_timestamptz(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_hash(IntPtr temp);
+            public static partial uint temporal_hash(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_instant_n(IntPtr temp, int n);
@@ -2804,7 +3071,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_start_sequence(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_start_timestamptz(IntPtr temp);
+            public static partial long temporal_start_timestamptz(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_stops(IntPtr temp, double maxdist, IntPtr minduration);
@@ -2843,7 +3110,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tfloat_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tfloat_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2866,7 +3133,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tint_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tint_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2901,7 +3168,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ttext_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool ttext_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2977,7 +3244,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_append_tsequence(IntPtr temp, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_delete_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
+            public static partial IntPtr temporal_delete_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool connect);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_delete_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
@@ -3007,7 +3274,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbool_minus_value(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool b);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_after_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr temporal_after_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_at_max(IntPtr temp);
@@ -3016,7 +3283,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_at_min(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_at_timestamptz(IntPtr temp, int t);
+            public static partial IntPtr temporal_at_timestamptz(IntPtr temp, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_at_tstzset(IntPtr temp, IntPtr s);
@@ -3031,7 +3298,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_at_values(IntPtr temp, IntPtr set);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_before_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr temporal_before_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_minus_max(IntPtr temp);
@@ -3040,7 +3307,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_minus_min(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_minus_timestamptz(IntPtr temp, int t);
+            public static partial IntPtr temporal_minus_timestamptz(IntPtr temp, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_minus_tstzset(IntPtr temp, IntPtr s);
@@ -4087,7 +4354,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_wsum_transfn(IntPtr state, IntPtr temp, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_tcount_transfn(IntPtr state, int t);
+            public static partial IntPtr timestamptz_tcount_transfn(IntPtr state, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tint_tmax_transfn(IntPtr state, IntPtr temp);
@@ -4147,10 +4414,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_simplify_min_tdelta(IntPtr temp, IntPtr mint);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, int origin);
+            public static partial IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, long origin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tsample(IntPtr temp, IntPtr duration, int origin, int interp);
+            public static partial IntPtr temporal_tsample(IntPtr temp, IntPtr duration, long origin, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double temporal_dyntimewarp_distance(IntPtr temp1, IntPtr temp2);
@@ -4168,13 +4435,13 @@ namespace MEOS.NET.Internal
             public static partial double temporal_hausdorff_distance(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, int origin, IntPtr count);
+            public static partial IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, long origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_time_split(IntPtr temp, IntPtr duration, int torigin, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr temporal_time_split(IntPtr temp, IntPtr duration, long torigin, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count);
+            public static partial IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloat_value_bins(IntPtr temp, double vsize, double vorigin, IntPtr count);
@@ -4186,22 +4453,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_value_split(IntPtr temp, double size, double origin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count);
+            public static partial IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count);
+            public static partial IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloatbox_value_tiles(IntPtr box, double vsize, double vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count);
+            public static partial IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count);
+            public static partial IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tint_value_bins(IntPtr temp, int vsize, int vorigin, IntPtr count);
@@ -4213,19 +4480,304 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tint_value_split(IntPtr temp, int vsize, int vorigin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, int torigin, IntPtr count);
+            public static partial IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count);
+            public static partial IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tintbox_value_tiles(IntPtr box, int xsize, int xorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, int torigin, IntPtr count);
+            public static partial IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, long torigin, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_subtype(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_subtype_all(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string tempsubtype_name(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tempsubtype_from_string(string str, IntPtr subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string meosoper_name(IntPtr oper);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr meosoper_from_string(string name);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string interptype_name(int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int interptype_from_string(string interp_str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string meostype_name(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int temptype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int settype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spantype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spantype_spansettype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spansettype_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int basetype_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int basetype_settype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geo_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool meos_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanum_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanum_temptype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool time_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_numset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timeset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_set_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanumset_type(int settype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geoset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_geoset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spatialset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_spatialset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_canon_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool type_span_bbox(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_tbox_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_span_tbox_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numspan_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numspan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_numspan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespan_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_timespanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temporal_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temporal_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_supports_linear(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_byvalue(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_varlength(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial short meostype_length(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool talphanum_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool talpha_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spatial_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tspatial_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tspatial_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeo_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeo_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeo_type_all(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeo_type_all(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeometry_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeometry_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeodetic_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeodetic_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int geo_get_srid(IntPtr g);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_as_ewkb(IntPtr gs, string endian, IntPtr size);
@@ -4585,7 +5137,7 @@ namespace MEOS.NET.Internal
             public static partial string stbox_out(IntPtr box, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_timestamptz_to_stbox(IntPtr gs, int t);
+            public static partial IntPtr geo_timestamptz_to_stbox(IntPtr gs, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_tstzspan_to_stbox(IntPtr gs, IntPtr s);
@@ -4615,7 +5167,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr stbox_to_tstzspan(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_stbox(int t);
+            public static partial IntPtr timestamptz_to_stbox(long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_to_stbox(IntPtr s);
@@ -4630,10 +5182,10 @@ namespace MEOS.NET.Internal
             public static partial double stbox_area(IntPtr box, [MarshalAs(UnmanagedType.U1)] bool spheroid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int stbox_hash(IntPtr box);
+            public static partial uint stbox_hash(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int stbox_hash_extended(IntPtr box, int seed);
+            public static partial ulong stbox_hash_extended(IntPtr box, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -4884,7 +5436,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeo_from_base_temp(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeoinst_make(IntPtr gs, int t);
+            public static partial IntPtr tgeoinst_make(IntPtr gs, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseq_from_base_tstzset(IntPtr gs, IntPtr s);
@@ -4899,7 +5451,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tpoint_from_base_temp(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointinst_make(IntPtr gs, int t);
+            public static partial IntPtr tpointinst_make(IntPtr gs, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tpointseq_from_base_tstzset(IntPtr gs, IntPtr s);
@@ -4978,7 +5530,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tgeo_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -5137,7 +5689,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeo_space_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeo_split_each_n_stboxes(IntPtr temp, int elem_count, IntPtr count);
@@ -5578,25 +6130,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr stbox_get_space_tile(IntPtr point, double xsize, double ysize, double zsize, IntPtr sorigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_get_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin);
+            public static partial IntPtr stbox_get_space_time_tile(IntPtr point, long t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_get_time_tile(int t, IntPtr duration, int torigin);
+            public static partial IntPtr stbox_get_time_tile(long t, IntPtr duration, long torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr stbox_space_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, long torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_cluster_kmeans(IntPtr geoms, uint ngeoms, uint k);
@@ -5653,10 +6205,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr geom_to_cbuffer(IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_hash(IntPtr cb);
+            public static partial uint cbuffer_hash(IntPtr cb);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_hash_extended(IntPtr cb, int seed);
+            public static partial ulong cbuffer_hash_extended(IntPtr cb, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr cbuffer_point(IntPtr cb);
@@ -5704,7 +6256,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr cbuffer_tstzspan_to_stbox(IntPtr cb, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, int t);
+            public static partial IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double distance_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
@@ -6141,399 +6693,31 @@ namespace MEOS.NET.Internal
             public static partial IntPtr ttouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_cbuffer_geo(IntPtr cb, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_cbuffer_stbox(IntPtr cb, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_cbufferset_cbuffer(IntPtr s, IntPtr cb);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool cbuffer_collinear(IntPtr cb1, IntPtr cb2, IntPtr cbuf3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffersegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffersegm_locate(IntPtr start, IntPtr end, IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffer_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string cbuffer_wkt_out(int value, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffer_point_p(IntPtr cb);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_round(int buffer, int size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr cbuffer_transf_pj(IntPtr cb, int srid_to, IntPtr pj);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double cbuffer_distance(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_distance(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_contains(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_covers(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_disjoint(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_intersects(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_dwithin(IntPtr cb1, IntPtr cb2, double dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int cbuffer_touches(IntPtr cb1, IntPtr cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_contains(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_covers(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_disjoint(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_intersects(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_dwithin(int cb1, int cb2, int dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cbuffer_touches(int cb1, int cb2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_subtype(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_subtype_all(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string tempsubtype_name(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tempsubtype_from_string(string str, IntPtr subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string meosoper_name(IntPtr oper);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr meosoper_from_string(string name);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string interptype_name(int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int interptype_from_string(string interp_str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string meostype_name(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temptype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int settype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spantype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spantype_spansettype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spansettype_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int basetype_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int basetype_settype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geo_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool meos_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanum_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanum_temptype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool time_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_numset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timeset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_set_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanumset_type(int settype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geoset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_geoset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatialset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_spatialset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_canon_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool type_span_bbox(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_tbox_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_span_tbox_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numspan_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numspan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_numspan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespan_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_timespanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_supports_linear(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_byvalue(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_varlength(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial short meostype_length(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool talphanum_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool talpha_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tspatial_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tspatial_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeo_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_type_all(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeo_type_all(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeometry_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeometry_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeodetic_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeodetic_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr gsl_get_generation_rng();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr gsl_get_aggregation_rng();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_ceil(IntPtr d);
+            public static partial ulong datum_ceil(ulong d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_degrees(IntPtr d, IntPtr normalize);
+            public static partial ulong datum_degrees(ulong d, ulong normalize);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_float_round(IntPtr value, IntPtr size);
+            public static partial ulong datum_float_round(ulong value, ulong size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_floor(IntPtr d);
+            public static partial ulong datum_floor(ulong d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_hash(IntPtr d, int basetype);
+            public static partial uint datum_hash(ulong d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_hash_extended(IntPtr d, int basetype, int seed);
+            public static partial ulong datum_hash_extended(ulong d, int basetype, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_radians(IntPtr d);
+            public static partial ulong datum_radians(ulong d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void floatspan_round_set(IntPtr s, int maxdd, IntPtr result);
@@ -6566,10 +6750,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_make_free(IntPtr values, int count, int basetype, [MarshalAs(UnmanagedType.U1)] bool order);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr span_make(IntPtr lower, IntPtr upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype);
+            public static partial IntPtr span_make(ulong lower, ulong upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void span_set(IntPtr lower, IntPtr upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype, int spantype, IntPtr s);
+            public static partial void span_set(ulong lower, ulong upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype, int spantype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr spanset_make_exp(IntPtr spans, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize, [MarshalAs(UnmanagedType.U1)] bool order);
@@ -6584,25 +6768,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_spanset(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void value_set_span(IntPtr value, int basetype, IntPtr s);
+            public static partial void value_set_span(ulong value, int basetype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_set(IntPtr d, int basetype);
+            public static partial IntPtr value_set(ulong d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_span(IntPtr d, int basetype);
+            public static partial IntPtr value_span(ulong d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_spanset(IntPtr d, int basetype);
+            public static partial IntPtr value_spanset(ulong d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int numspan_width(IntPtr s);
+            public static partial ulong numspan_width(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int numspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
+            public static partial ulong numspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int set_end_value(IntPtr s);
+            public static partial ulong set_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_mem_size(IntPtr s);
@@ -6614,7 +6798,7 @@ namespace MEOS.NET.Internal
             public static partial void set_set_span(IntPtr s, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int set_start_value(IntPtr s);
+            public static partial ulong set_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6627,7 +6811,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spanset_lower(IntPtr ss);
+            public static partial ulong spanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int spanset_mem_size(IntPtr ss);
@@ -6636,7 +6820,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_sps(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spanset_upper(IntPtr ss);
+            public static partial ulong spanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void datespan_set_tstzspan(IntPtr s1, IntPtr s2);
@@ -6648,16 +6832,16 @@ namespace MEOS.NET.Internal
             public static partial void intspan_set_floatspan(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numset_shift_scale(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numset_shift_scale(IntPtr s, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_expand(IntPtr s, IntPtr value);
+            public static partial IntPtr numspan_expand(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_shift_scale(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numspan_shift_scale(IntPtr s, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numspanset_shift_scale(IntPtr ss, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr set_compact(IntPtr s);
@@ -6669,7 +6853,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_compact(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_expand_value(IntPtr box, IntPtr value, int basetyp);
+            public static partial IntPtr tbox_expand_value(IntPtr box, ulong value, int basetyp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr textcat_textset_text_common(IntPtr s, IntPtr txt, [MarshalAs(UnmanagedType.U1)] bool invert);
@@ -6679,39 +6863,39 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_value(IntPtr s, IntPtr value);
+            public static partial bool adjacent_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool adjacent_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool adjacent_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_set(IntPtr value, IntPtr s);
+            public static partial bool contained_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_span(IntPtr value, IntPtr s);
+            public static partial bool contained_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool contained_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_value(IntPtr s, IntPtr value);
+            public static partial bool contains_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_value(IntPtr s, IntPtr value);
+            public static partial bool contains_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool contains_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6719,27 +6903,27 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_set_value(IntPtr s, IntPtr value);
+            public static partial bool left_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_span_value(IntPtr s, IntPtr value);
+            public static partial bool left_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool left_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_set(IntPtr value, IntPtr s);
+            public static partial bool left_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_span(IntPtr value, IntPtr s);
+            public static partial bool left_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool left_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6747,75 +6931,75 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_set_value(IntPtr s, IntPtr value);
+            public static partial bool overleft_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_span_value(IntPtr s, IntPtr value);
+            public static partial bool overleft_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool overleft_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_set(IntPtr value, IntPtr s);
+            public static partial bool overleft_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_span(IntPtr value, IntPtr s);
+            public static partial bool overleft_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool overleft_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_set_value(IntPtr s, IntPtr value);
+            public static partial bool overright_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_span_value(IntPtr s, IntPtr value);
+            public static partial bool overright_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool overright_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_set(IntPtr value, IntPtr s);
+            public static partial bool overright_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_span(IntPtr value, IntPtr s);
+            public static partial bool overright_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool overright_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_set(IntPtr value, IntPtr s);
+            public static partial bool right_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_set_value(IntPtr s, IntPtr value);
+            public static partial bool right_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_span(IntPtr value, IntPtr s);
+            public static partial bool right_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_spanset(IntPtr value, IntPtr ss);
+            public static partial bool right_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_span_value(IntPtr s, IntPtr value);
+            public static partial bool right_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_spanset_value(IntPtr ss, IntPtr value);
+            public static partial bool right_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6842,100 +7026,100 @@ namespace MEOS.NET.Internal
             public static partial bool inter_span_span(IntPtr s1, IntPtr s2, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_value(IntPtr s, IntPtr value);
+            public static partial IntPtr intersection_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_value(IntPtr s, IntPtr value);
+            public static partial IntPtr intersection_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_value(IntPtr ss, IntPtr value);
+            public static partial IntPtr intersection_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_set(IntPtr value, IntPtr s);
+            public static partial IntPtr intersection_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_span(IntPtr value, IntPtr s);
+            public static partial IntPtr intersection_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_spanset(IntPtr value, IntPtr ss);
+            public static partial IntPtr intersection_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int mi_span_span(IntPtr s1, IntPtr s2, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_value(IntPtr s, IntPtr value);
+            public static partial IntPtr minus_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_value(IntPtr s, IntPtr value);
+            public static partial IntPtr minus_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_value(IntPtr ss, IntPtr value);
+            public static partial IntPtr minus_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_set(IntPtr value, IntPtr s);
+            public static partial IntPtr minus_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_span(IntPtr value, IntPtr s);
+            public static partial IntPtr minus_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_spanset(IntPtr value, IntPtr ss);
+            public static partial IntPtr minus_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr super_union_span_span(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_value(IntPtr s, IntPtr value);
+            public static partial IntPtr union_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_value(IntPtr s, IntPtr value);
+            public static partial IntPtr union_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_value(IntPtr ss, IntPtr value);
+            public static partial IntPtr union_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_set(IntPtr value, IntPtr s);
+            public static partial IntPtr union_value_set(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_span(IntPtr value, IntPtr s);
+            public static partial IntPtr union_value_span(ulong value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_spanset(IntPtr value, IntPtr ss);
+            public static partial IntPtr union_value_spanset(ulong value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_set_set(IntPtr s1, IntPtr s2);
+            public static partial ulong distance_set_set(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_set_value(IntPtr s, IntPtr value);
+            public static partial ulong distance_set_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_span_span(IntPtr s1, IntPtr s2);
+            public static partial ulong distance_span_span(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_span_value(IntPtr s, IntPtr value);
+            public static partial ulong distance_span_value(IntPtr s, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_spanset_span(IntPtr ss, IntPtr s);
+            public static partial ulong distance_spanset_span(IntPtr ss, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_spanset_spanset(IntPtr ss1, IntPtr ss2);
+            public static partial ulong distance_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_spanset_value(IntPtr ss, IntPtr value);
+            public static partial ulong distance_spanset_value(IntPtr ss, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int distance_value_value(IntPtr l, IntPtr r, int basetype);
+            public static partial ulong distance_value_value(ulong l, ulong r, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanbase_extent_transfn(IntPtr state, IntPtr value, int basetype);
+            public static partial IntPtr spanbase_extent_transfn(IntPtr state, ulong value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_union_transfn(IntPtr state, IntPtr value, int basetype);
+            public static partial IntPtr value_union_transfn(IntPtr state, ulong value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_tstzspan_to_tbox(IntPtr d, int basetype, IntPtr s);
+            public static partial IntPtr number_tstzspan_to_tbox(ulong d, int basetype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_timestamptz_to_tbox(IntPtr d, int basetype, int t);
+            public static partial IntPtr number_timestamptz_to_tbox(ulong d, int basetype, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tbox_set(IntPtr s, IntPtr p, IntPtr box);
@@ -6947,10 +7131,10 @@ namespace MEOS.NET.Internal
             public static partial void int_set_tbox(int i, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void number_set_tbox(IntPtr d, int basetype, IntPtr box);
+            public static partial void number_set_tbox(ulong d, int basetype, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_tbox(IntPtr value, int basetype);
+            public static partial IntPtr number_tbox(ulong value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void numset_set_tbox(IntPtr s, IntPtr box);
@@ -6959,7 +7143,7 @@ namespace MEOS.NET.Internal
             public static partial void numspan_set_tbox(IntPtr span, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void timestamptz_set_tbox(int t, IntPtr box);
+            public static partial void timestamptz_set_tbox(long t, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tstzset_set_tbox(IntPtr s, IntPtr box);
@@ -6968,7 +7152,7 @@ namespace MEOS.NET.Internal
             public static partial void tstzspan_set_tbox(IntPtr s, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_shift_scale_value(IntPtr box, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tbox_shift_scale_value(IntPtr box, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tbox_expand(IntPtr box1, IntPtr box2);
@@ -7089,28 +7273,28 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_from_mfjson(string mfjson, int temptype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_from_base_temp(IntPtr value, int temptype, IntPtr temp);
+            public static partial IntPtr temporal_from_base_temp(ulong value, int temptype, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_copy(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_make(IntPtr value, int temptype, int t);
+            public static partial IntPtr tinstant_make(ulong value, int temptype, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_make_free(IntPtr value, int temptype, int t);
+            public static partial IntPtr tinstant_make_free(ulong value, int temptype, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_copy(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_temp(IntPtr value, int temptype, IntPtr seq);
+            public static partial IntPtr tsequence_from_base_temp(ulong value, int temptype, IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_tstzset(IntPtr value, int temptype, IntPtr s);
+            public static partial IntPtr tsequence_from_base_tstzset(ulong value, int temptype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_tstzspan(IntPtr value, int temptype, IntPtr s, int interp);
+            public static partial IntPtr tsequence_from_base_tstzspan(ulong value, int temptype, IntPtr s, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_make_exp(IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
@@ -7125,10 +7309,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tseqsetarr_to_tseqset(IntPtr seqsets, int count, int totalseqs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_from_base_temp(IntPtr value, int temptype, IntPtr ss);
+            public static partial IntPtr tsequenceset_from_base_temp(ulong value, int temptype, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_from_base_tstzspanset(IntPtr value, int temptype, IntPtr ss, int interp);
+            public static partial IntPtr tsequenceset_from_base_tstzspanset(ulong value, int temptype, IntPtr ss, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_make_exp(IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
@@ -7164,7 +7348,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_end_inst(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_end_value(IntPtr temp);
+            public static partial ulong temporal_end_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_inst_n(IntPtr temp, int n);
@@ -7176,7 +7360,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_max_inst_p(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_max_value(IntPtr temp);
+            public static partial ulong temporal_max_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial ulong temporal_mem_size(IntPtr temp);
@@ -7185,7 +7369,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_min_inst_p(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_min_value(IntPtr temp);
+            public static partial ulong temporal_min_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_sequences_p(IntPtr temp, IntPtr count);
@@ -7197,7 +7381,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_start_inst(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_start_value(IntPtr temp);
+            public static partial ulong temporal_start_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_values_p(IntPtr temp, IntPtr count);
@@ -7210,7 +7394,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_values(IntPtr temp, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tinstant_hash(IntPtr inst);
+            public static partial uint tinstant_hash(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_insts(IntPtr inst, IntPtr count);
@@ -7225,14 +7409,14 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_timestamps(IntPtr inst, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tinstant_value_p(IntPtr inst);
+            public static partial ulong tinstant_value_p(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tinstant_value(IntPtr inst);
+            public static partial ulong tinstant_value(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tinstant_value_at_timestamptz(IntPtr inst, int t, IntPtr result);
+            public static partial bool tinstant_value_at_timestamptz(IntPtr inst, long t, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_values_p(IntPtr inst, IntPtr count);
@@ -7259,10 +7443,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_duration(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_end_timestamptz(IntPtr seq);
+            public static partial long tsequence_end_timestamptz(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_hash(IntPtr seq);
+            public static partial uint tsequence_hash(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_insts_p(IntPtr seq);
@@ -7271,13 +7455,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_max_inst_p(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_max_val(IntPtr seq);
+            public static partial ulong tsequence_max_val(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_min_inst_p(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_min_val(IntPtr seq);
+            public static partial ulong tsequence_min_val(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_segments(IntPtr seq, IntPtr count);
@@ -7286,7 +7470,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_seqs(IntPtr seq, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_start_timestamptz(IntPtr seq);
+            public static partial long tsequence_start_timestamptz(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_time(IntPtr seq);
@@ -7296,7 +7480,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequence_value_at_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool tsequence_value_at_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_values_p(IntPtr seq, IntPtr count);
@@ -7305,10 +7489,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_duration(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequenceset_end_timestamptz(IntPtr ss);
+            public static partial long tsequenceset_end_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequenceset_hash(IntPtr ss);
+            public static partial uint tsequenceset_hash(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_inst_n(IntPtr ss, int n);
@@ -7320,13 +7504,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_max_inst_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequenceset_max_val(IntPtr ss);
+            public static partial ulong tsequenceset_max_val(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_min_inst_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequenceset_min_val(IntPtr ss);
+            public static partial ulong tsequenceset_min_val(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tsequenceset_num_instants(IntPtr ss);
@@ -7341,7 +7525,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_sequences_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequenceset_start_timestamptz(IntPtr ss);
+            public static partial long tsequenceset_start_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_time(IntPtr ss);
@@ -7355,7 +7539,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequenceset_value_at_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool tsequenceset_value_at_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -7386,16 +7570,16 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_to_tsequenceset(IntPtr inst, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_shift_scale_value(IntPtr temp, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumber_shift_scale_value(IntPtr temp, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberinst_shift_value(IntPtr inst, IntPtr shift);
+            public static partial IntPtr tnumberinst_shift_value(IntPtr inst, ulong shift);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_shift_scale_value(IntPtr seq, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumberseq_shift_scale_value(IntPtr seq, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseqset_shift_scale_value(IntPtr ss, IntPtr start, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumberseqset_shift_scale_value(IntPtr ss, ulong start, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tsequence_restart(IntPtr seq, int count);
@@ -7458,7 +7642,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_append_tsequence(IntPtr seq1, IntPtr seq2, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_delete_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
+            public static partial IntPtr tsequence_delete_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool connect);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_delete_tstzset(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
@@ -7485,7 +7669,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_append_tsequence(IntPtr ss, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_delete_timestamptz(IntPtr ss, int t);
+            public static partial IntPtr tsequenceset_delete_timestamptz(IntPtr ss, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_delete_tstzset(IntPtr ss, IntPtr s);
@@ -7518,19 +7702,19 @@ namespace MEOS.NET.Internal
             public static partial void tsequenceset_set_bbox(IntPtr ss, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_after_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tcontseq_after_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_before_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tcontseq_before_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tcontseq_restrict_minmax(IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_after_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tdiscseq_after_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_before_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tdiscseq_before_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tdiscseq_restrict_minmax(IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7543,7 +7727,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_restrict_minmax(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_restrict_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr temporal_restrict_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_restrict_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7555,20 +7739,20 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_restrict_tstzspanset(IntPtr temp, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_restrict_value(IntPtr temp, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr temporal_restrict_value(IntPtr temp, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_restrict_values(IntPtr temp, IntPtr set, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool temporal_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_after_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tinstant_after_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_before_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tinstant_before_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_tstzspan(IntPtr inst, IntPtr period, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7577,13 +7761,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_restrict_tstzspanset(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_restrict_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tinstant_restrict_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_tstzset(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_restrict_value(IntPtr inst, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tinstant_restrict_value(IntPtr inst, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_values(IntPtr inst, IntPtr set, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7607,7 +7791,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnumberseqset_restrict_spanset(IntPtr ss, IntPtr spanset, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_at_timestamptz(IntPtr seq, int t);
+            public static partial IntPtr tsequence_at_timestamptz(IntPtr seq, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_restrict_tstzspan(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7616,10 +7800,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_after_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tsequenceset_after_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_before_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tsequenceset_before_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_minmax(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7631,13 +7815,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_restrict_tstzspanset(IntPtr ss, IntPtr ps, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_tstzset(IntPtr ss, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_restrict_value(IntPtr ss, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tsequenceset_restrict_value(IntPtr ss, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_values(IntPtr ss, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7664,76 +7848,76 @@ namespace MEOS.NET.Internal
             public static partial bool tsequenceset_eq(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_eq_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_eq_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_eq_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_eq_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ne_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_ne_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ne_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_ne_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ge_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_ge_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ge_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_ge_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_gt_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_gt_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_gt_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_gt_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_le_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_le_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_le_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_le_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_lt_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int always_lt_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_lt_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int always_lt_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_eq_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_eq_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_eq_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_eq_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ne_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_ne_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ne_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_ne_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ge_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_ge_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ge_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_ge_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_gt_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_gt_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_gt_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_gt_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_le_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_le_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_le_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_le_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_lt_base_temporal(IntPtr value, IntPtr temp);
+            public static partial int ever_lt_base_temporal(ulong value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_lt_temporal_base(IntPtr temp, IntPtr value);
+            public static partial int ever_lt_temporal_base(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tnumberinst_abs(IntPtr inst);
@@ -7757,13 +7941,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnumberseqset_delta_value(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdistance_tnumber_number(IntPtr temp, IntPtr value);
+            public static partial IntPtr tdistance_tnumber_number(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nad_tbox_tbox(IntPtr box1, IntPtr box2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double nad_tnumber_number(IntPtr temp, IntPtr value);
+            public static partial double nad_tnumber_number(IntPtr temp, ulong value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nad_tnumber_tbox(IntPtr temp, IntPtr box);
@@ -7823,1055 +8007,31 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_app_tseq_transfn(IntPtr state, IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr span_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr count);
+            public static partial IntPtr span_bins(IntPtr s, ulong size, ulong origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanset_bins(IntPtr ss, IntPtr size, IntPtr origin, IntPtr count);
+            public static partial IntPtr spanset_bins(IntPtr ss, ulong size, ulong origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_bins(IntPtr temp, IntPtr size, IntPtr origin, IntPtr count);
+            public static partial IntPtr tnumber_value_bins(IntPtr temp, ulong size, ulong origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_time_boxes(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, IntPtr count);
+            public static partial IntPtr tnumber_value_time_boxes(IntPtr temp, ulong vsize, IntPtr duration, ulong vorigin, long torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_split(IntPtr temp, IntPtr vsize, IntPtr vorigin, IntPtr bins, IntPtr count);
+            public static partial IntPtr tnumber_value_split(IntPtr temp, ulong vsize, ulong vorigin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_get_value_time_tile(IntPtr value, int t, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, int basetype, int spantype);
+            public static partial IntPtr tbox_get_value_time_tile(ulong value, long t, ulong vsize, IntPtr duration, ulong vorigin, long torigin, int basetype, int spantype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_time_split(IntPtr temp, IntPtr size, IntPtr duration, IntPtr vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string double2_out(IntPtr d, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void double2_set(double a, double b, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double2_add(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double2_eq(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string double3_out(IntPtr d, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void double3_set(double a, double b, double c, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double3_add(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double3_eq(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string double4_out(IntPtr d, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void double4_set(double a, double b, double c, double d, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double4_add(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double4_eq(IntPtr d1, IntPtr d2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double2_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double3_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double4_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double2segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double3segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr double4segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_atoi(string s, int size, int c);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_X(int type, short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_Z(int type, short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_T(int type, short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_not_Z(int type, short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_null(IntPtr ptr);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_one_not_null(IntPtr ptr1, IntPtr ptr2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_one_true([MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_interp(int temptype, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_continuous(IntPtr temp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_interp(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_continuous_interp(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_linear_interp(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_nonlinear_interp(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_common_dimension(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_temporal_isof_type(IntPtr temp, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_temporal_isof_basetype(IntPtr temp, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_temporal_isof_subtype(IntPtr temp, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_temporal_type(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnumber_numspan(IntPtr temp, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnumber_numspanset(IntPtr temp, IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnumber_tbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_temporal_set(IntPtr temp, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_temporal_temporal(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnumber_tnumber(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_negative(int i);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_positive(int i);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool not_negative_datum(IntPtr size, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_negative_datum(IntPtr size, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool positive_datum(IntPtr size, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_positive_datum(IntPtr size, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_day_duration(IntPtr duration);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool positive_duration(IntPtr duration);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_positive_duration(IntPtr duration);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_bbox_ptr(IntPtr temp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr mode, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string mobilitydb_version();
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string mobilitydb_full_version();
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr round_fn(int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_bbox_restrict_value(IntPtr temp, IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tcbuffer_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tcbuffer_stbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcbuffersegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcbuffersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcbuffersegm_dwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool cbuffer_set_stbox(IntPtr cb, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void cbufferarr_set_stbox(IntPtr values, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool cbuffer_timestamptz_set_stbox(IntPtr cb, int t, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool cbuffer_tstzspan_set_stbox(IntPtr cb, IntPtr s, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tcbufferinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tcbufferinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tcbufferseq_expand_stbox(IntPtr seq, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbufferinst_trav_area(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbufferseq_trav_area(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbufferseqset_trav_area(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbuffersegm_trav_area(IntPtr inst1, IntPtr inst2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbuffer_restrict_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbuffer_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcbuffer_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinterrel_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool tinter);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinterrel_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool tinter);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int lwproj_lookup(int srid_from, int srid_to, IntPtr pj);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spheroid_init_from_srid(int srid, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void srid_check_latlong(int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int srid_is_latlong(int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geom_serialize(IntPtr lwgeom);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geog_serialize(IntPtr lwgeom);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr postgis_valid_typmod(IntPtr gs, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string geo_as_wkt(IntPtr gs, int precision, [MarshalAs(UnmanagedType.U1)] bool extended);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr box2d_to_lwgeom(IntPtr box, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr box3d_to_lwgeom(IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr POSTGIS2GEOS(IntPtr pglwgeom);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr GEOS2POSTGIS(IntPtr geom, byte want3d);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geom_spatialrel(IntPtr gs1, IntPtr gs2, IntPtr rel);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwgeom_line_interpolate_point(IntPtr geom, double fraction, int srid, byte repeat);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void point_get_coords(IntPtr point, [MarshalAs(UnmanagedType.U1)] bool hasz, IntPtr x, IntPtr y, IntPtr z);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tstzset_stbox_slice(IntPtr tsdatum, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tstzspanset_stbox_slice(IntPtr psdatum, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool stbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool stbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool stbox_index_recheck(int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void mobilitydb_init();
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_stbox(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_geo(IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcomp_geo_tgeo(IntPtr gs, IntPtr temp, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_geoaggstate(IntPtr state, int srid, [MarshalAs(UnmanagedType.U1)] bool hasz);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_geoaggstate_state(IntPtr state1, IntPtr state2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_transform_tcentroid(IntPtr temp, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointinst_tcentroid_finalfn(IntPtr instants, int count, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointseq_tcentroid_finalfn(IntPtr sequences, int count, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool point3d_min_dist(IntPtr p1, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr fraction);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tgeompointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tgeogpointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double tnumberinst_distance(IntPtr inst1, IntPtr inst2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double tinstant_distance(IntPtr inst1, IntPtr inst2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointseq_at_geom(IntPtr seq, IntPtr gs, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointseq_interperiods(IntPtr seq, IntPtr gs, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void datum_point4d(IntPtr value, IntPtr p);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int geopoint_cmp(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geopoint_eq(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geopoint_same(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_point_eq(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_point_same(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_point_eq(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_point_ne(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_point_same(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_point_nsame(IntPtr point1, IntPtr point2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_geom_centroid(IntPtr geo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_geog_centroid(IntPtr geo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_extract_elements(IntPtr gs, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_serialize(IntPtr geom);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_distance_fn(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr pt_distance_fn(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_distance2d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_distance3d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geog_distance(IntPtr geog1, IntPtr geog2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_pt_distance2d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_pt_distance3d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial short spatial_flags(IntPtr d, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_srid_is_latlong(int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_spatial_validity(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_geodetic(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geodetic(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geodetic_geo(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geodetic_tspatial_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geodetic_tspatial_base(IntPtr temp, IntPtr @base);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_srid_known(int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_srid(int srid1, int srid2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_dimensionality(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_spatial_dimensionality(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_spatial_dimensionality(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_dimensionality_geo(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_spatial_dimensionality_stbox_geo(IntPtr box, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geodetic_stbox_geo(IntPtr box, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_Z_geo(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_not_Z_geo(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_M_geo(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_not_M_geo(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_geodetic_geo(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_point_type(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_mline_type(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool circle_type(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_circle_type(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_not_empty(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_stbox_geo(IntPtr box, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tspatial_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tspatial_base(IntPtr temp, IntPtr @base);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tspatial_tspatial(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_spatial_stbox_stbox(IntPtr box1, IntPtr box2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tgeo_stbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_geo_geo(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tgeo_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpoint_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpoint_tpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool mline_type(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_get_coord(IntPtr temp, int coord);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eacomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr closest_point2d_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr closest_point3dz_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr closest_point_on_segment_sphere(IntPtr p, IntPtr A, IntPtr B, IntPtr closest, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void interpolate_point4d_spheroid(IntPtr p1, IntPtr p2, IntPtr p, IntPtr s, double f);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geopoint_make(double x, double y, double z, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool geodetic, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwcircle_make(double x, double y, double radius, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geocircle_make(double x, double y, double radius, int srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr pointsegm_locate(IntPtr start, IntPtr end, IntPtr point, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tgeompointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tgeogpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geopoint_collinear(IntPtr value1, IntPtr value2, IntPtr value3, double ratio, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool geodetic);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwpointarr_remove_duplicates(IntPtr points, int count, IntPtr newcount);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwpointarr_make_trajectory(IntPtr points, int count, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwline_make(IntPtr value1, IntPtr value2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr lwcoll_from_points_lines(IntPtr points, IntPtr lines, int npoints, int nlines);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tpointseq_stops_iter(IntPtr seq, double maxdist, int mintunits, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_contains(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_covers(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_disjoint2d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_disjoint3d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geog_disjoint(IntPtr geog1, IntPtr geog2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_intersects2d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_intersects3d(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geog_intersects(IntPtr geog1, IntPtr geog2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_touches(IntPtr geom1, IntPtr geom2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_dwithin2d(IntPtr geom1, IntPtr geom2, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_dwithin3d(IntPtr geom1, IntPtr geom2, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geog_dwithin(IntPtr geog1, IntPtr geog2, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geom_relate_pattern(IntPtr geog1, IntPtr geog2, IntPtr p);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_disjoint_fn(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_disjoint_fn_geo(short flags1, IntPtr flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_intersects_fn(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_intersects_fn_geo(short flags1, IntPtr flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_dwithin_fn(short flags1, short flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_dwithin_fn_geo(short flags1, IntPtr flags2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tpointsegm_tdwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spatialrel_geo_geo(IntPtr gs1, IntPtr gs2, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spatialrel_tgeo_tgeo(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_intersects_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tpoint_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_touches_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_dwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_dwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_spatialrel_tspatial_geo(IntPtr temp, IntPtr gs, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_spatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialrel_tspatial_base(IntPtr temp, IntPtr @base, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinterrel_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool tinter);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinterrel_tspatial_base(IntPtr temp, IntPtr @base, [MarshalAs(UnmanagedType.U1)] bool tinter, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinterrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool tinter);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdwithin_tspatial_tspatial(IntPtr sync1, IntPtr sync2, IntPtr dist, IntPtr func, IntPtr tpfn);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tdwithin_add_solutions(int solutions, int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc1, int t1, int t2, IntPtr instants, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdwithin_tspatial_spatial(IntPtr temp, IntPtr @base, IntPtr dist, IntPtr func, IntPtr tpfn);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bitmatrix_make(IntPtr count, int ndims);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tpoint_set_tiles(IntPtr temp, IntPtr state, IntPtr bm);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_at_tile(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void stbox_tile_state_set(double x, double y, double z, int t, double xsize, double ysize, double zsize, int tunits, [MarshalAs(UnmanagedType.U1)] bool hasx, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool hast, int srid, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_tile_state_make(IntPtr temp, IntPtr box, double xsize, double ysize, double zsize, IntPtr duration, int sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void stbox_tile_state_next(IntPtr state);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool stbox_tile_state_get(IntPtr state, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_space_time_tile_init(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr ntiles);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool hasx, [MarshalAs(UnmanagedType.U1)] bool hast);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr create_trip(IntPtr lines, IntPtr maxSpeeds, IntPtr categories, uint noEdges, int startTime, [MarshalAs(UnmanagedType.U1)] bool disturbData, int verbosity);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spatialarr_wkt_out(IntPtr spatialarr, int basetype, int count, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string spatialbase_as_text(IntPtr value, int type, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string spatialbase_as_ewkt(IntPtr value, int type, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool point_transf_pj(IntPtr gs, int srid_to, IntPtr pj);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tgeoinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tgeoinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tgeoseq_expand_stbox(IntPtr seq, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tspatialinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tspatialinstarr_set_stbox(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tspatialseqarr_set_stbox(IntPtr sequences, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tspatialseq_expand_stbox(IntPtr seq, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void spatialarr_set_bbox(IntPtr values, int basetype, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_tspatial_stbox(IntPtr temp, IntPtr box, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool srid_parse(IntPtr str, IntPtr srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_parse_elem(IntPtr str, int temptype, byte delim, IntPtr temp_srid, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geo_parse(IntPtr str, int basetype, byte delim, IntPtr srid, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_parse(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_parse(IntPtr str, int temptype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialinst_parse(IntPtr str, int temptype, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr temp_srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialseq_disc_parse(IntPtr str, int temptype, IntPtr temp_srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialseq_cont_parse(IntPtr str, int temptype, int interp, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr temp_srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatialseqset_parse(IntPtr str, int temptype, int interp, IntPtr temp_srid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tspatial_parse(IntPtr str, int temptype);
+            public static partial IntPtr tnumber_value_time_split(IntPtr temp, ulong size, IntPtr duration, ulong vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr proj_get_context();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_geo_round(IntPtr value, IntPtr size);
+            public static partial ulong datum_geo_round(ulong value, ulong size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr point_round(IntPtr gs, int maxdd);
@@ -8891,7 +8051,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_set_stbox(IntPtr d, int basetype, IntPtr box);
+            public static partial bool spatial_set_stbox(ulong d, int basetype, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void spatialset_set_stbox(IntPtr set, IntPtr box);
@@ -8917,6 +8077,9 @@ namespace MEOS.NET.Internal
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static partial bool inter_stbox_stbox(IntPtr box1, IntPtr box2, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr stbox_geo(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeogpointinst_from_mfjson(IntPtr mfjson, int srid);
@@ -8994,6 +8157,9 @@ namespace MEOS.NET.Internal
             public static partial void tspatial_set_stbox(IntPtr temp, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tgeoinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tspatialseq_set_stbox(IntPtr seq, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
@@ -9027,11 +8193,11 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeoseqset_restrict_stbox(IntPtr ss, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spatial_srid(IntPtr d, int basetype);
+            public static partial int spatial_srid(ulong d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_set_srid(IntPtr d, int basetype, int srid);
+            public static partial bool spatial_set_srid(ulong d, int basetype, int srid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tspatialinst_srid(IntPtr inst);
@@ -9076,6 +8242,9 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseqset_split_n_stboxes(IntPtr ss, int max_count, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_get_coord(IntPtr temp, int coord);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeominst_tgeoginst(IntPtr inst, [MarshalAs(UnmanagedType.U1)] bool oper);
@@ -9144,10 +8313,10 @@ namespace MEOS.NET.Internal
             public static partial string nsegment_out(IntPtr ns, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npoint_make(int rid, double pos);
+            public static partial IntPtr npoint_make(long rid, double pos);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr nsegment_make(int rid, double pos1, double pos2);
+            public static partial IntPtr nsegment_make(long rid, double pos1, double pos2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geompoint_to_npoint(IntPtr gs);
@@ -9171,35 +8340,35 @@ namespace MEOS.NET.Internal
             public static partial IntPtr nsegment_to_stbox(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int npoint_hash(IntPtr np);
+            public static partial uint npoint_hash(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int npoint_hash_extended(IntPtr np, int seed);
+            public static partial ulong npoint_hash_extended(IntPtr np, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double npoint_position(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int npoint_route(IntPtr np);
+            public static partial long npoint_route(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nsegment_end_position(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int nsegment_route(IntPtr ns);
+            public static partial long nsegment_route(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nsegment_start_position(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool route_exists(int rid);
+            public static partial bool route_exists(long rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr route_geom(int rid);
+            public static partial IntPtr route_geom(long rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double route_length(int rid);
+            public static partial double route_length(long rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr npoint_round(IntPtr np, int maxdd);
@@ -9217,7 +8386,7 @@ namespace MEOS.NET.Internal
             public static partial int nsegment_srid(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npoint_timestamptz_to_stbox(IntPtr np, int t);
+            public static partial IntPtr npoint_timestamptz_to_stbox(IntPtr np, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr npoint_tstzspan_to_stbox(IntPtr np, IntPtr s);
@@ -9344,7 +8513,7 @@ namespace MEOS.NET.Internal
             public static partial string tnpoint_out(IntPtr temp, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointinst_make(IntPtr np, int t);
+            public static partial IntPtr tnpointinst_make(IntPtr np, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeompoint_to_tnpoint(IntPtr temp);
@@ -9362,7 +8531,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnpoint_positions(IntPtr temp, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnpoint_route(IntPtr temp);
+            public static partial long tnpoint_route(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tnpoint_routes(IntPtr temp);
@@ -9530,10 +8699,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr pose_to_stbox(IntPtr pose);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pose_hash(IntPtr pose);
+            public static partial uint pose_hash(IntPtr pose);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pose_hash_extended(IntPtr pose, int seed);
+            public static partial ulong pose_hash_extended(IntPtr pose, ulong seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr pose_orientation(IntPtr pose);
@@ -9563,7 +8732,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr pose_tstzspan_to_stbox(IntPtr pose, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr pose_timestamptz_to_stbox(IntPtr pose, int t);
+            public static partial IntPtr pose_timestamptz_to_stbox(IntPtr pose, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double distance_pose_geo(IntPtr pose, IntPtr gs);
@@ -9689,7 +8858,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tpose_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tpose_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -9807,7 +8976,7 @@ namespace MEOS.NET.Internal
             public static partial string trgeo_out(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, int t);
+            public static partial IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, long t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_tpose_to_trgeo(IntPtr gs, IntPtr temp);
@@ -9874,7 +9043,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr trgeo_append_tsequence(IntPtr temp, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_delete_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
+            public static partial IntPtr trgeo_delete_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool connect);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr trgeo_delete_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
@@ -9895,19 +9064,19 @@ namespace MEOS.NET.Internal
             public static partial IntPtr trgeo_to_tinstant(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_after_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr trgeo_after_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_before_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr trgeo_before_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_restrict_value(IntPtr temp, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr trgeo_restrict_value(IntPtr temp, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr trgeo_restrict_values(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_restrict_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr trgeo_restrict_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr trgeo_restrict_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -10007,1547 +9176,6 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tne_trgeo_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnpoint_npoint(IntPtr temp, IntPtr np);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnpoint_npointset(IntPtr temp, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnpoint_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnpoint_stbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool common_rid_tnpoint_npoint(IntPtr temp, IntPtr np);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool common_rid_tnpoint_npointset(IntPtr temp, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool common_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool npoint_collinear(IntPtr np1, IntPtr np2, IntPtr np3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npointsegm_locate(IntPtr start, IntPtr end, IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npointarr_geom(IntPtr points, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr nsegmentarr_geom(IntPtr segments, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr nsegmentarr_normalize(IntPtr segments, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string npoint_wkt_out(IntPtr value, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void npoint_set(int rid, double pos, IntPtr np);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void nsegment_set(int rid, double pos1, double pos2, IntPtr ns);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_npoint_round(IntPtr npoint, IntPtr size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointinst_tgeompointinst(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_tgeompointseq_disc(IntPtr @is);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_tgeompointseq_cont(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseqset_tgeompointseqset(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeompointinst_tnpointinst(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeompointseq_tnpointseq(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeompointseqset_tnpointseqset(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointinst_positions(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_positions(IntPtr seq, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseqset_positions(IntPtr ss, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnpointinst_route(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointinst_routes(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_disc_routes(IntPtr @is);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_cont_routes(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseqset_routes(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointseq_linear_positions(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpoint_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpoint_restrict_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpoint_restrict_npointset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool npoint_set_stbox(IntPtr np, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void npointarr_set_stbox(IntPtr values, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool nsegment_set_stbox(IntPtr ns, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool npoint_timestamptz_set_stbox(IntPtr np, int t, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool npoint_tstzspan_set_stbox(IntPtr np, IntPtr s, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tnpointinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tnpointinstarr_set_stbox(IntPtr inst, int count, int interp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tnpointseq_expand_stbox(IntPtr seq, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_npoint_distance(IntPtr np1, IntPtr np2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npoint_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr nsegment_parse(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overlaps_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_rid_tnpoint_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_rid_npoint_tnpoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_rid_tnpoint_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overlaps_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool same_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_rid_tnpointinst(IntPtr inst1, IntPtr inst2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpoint_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_pose_geo(IntPtr pose, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_pose_stbox(IntPtr pose, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_pose_pose(IntPtr pose1, IntPtr pose2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_poseset_pose(IntPtr s, IntPtr pose);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool pose_collinear(IntPtr pose1, IntPtr pose2, IntPtr pose3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr posesegm_interpolate(IntPtr start, IntPtr end, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr posesegm_locate(IntPtr start, IntPtr end, IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string pose_wkt_out(IntPtr pose, [MarshalAs(UnmanagedType.U1)] bool extended, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr pose_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_pose_point(IntPtr pose);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_pose_rotation(IntPtr pose);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_pose_round(IntPtr pose, IntPtr size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pose_distance(IntPtr pose1, IntPtr pose2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool pose_set_stbox(IntPtr pose, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void posearr_set_stbox(IntPtr values, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool pose_timestamptz_set_stbox(IntPtr pose, int t, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool pose_tstzspan_set_stbox(IntPtr pose, IntPtr p, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpose_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpose_pose(IntPtr temp, IntPtr pose);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpose_stbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tpose_tpose(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tposesegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tposesegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tposeinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tposeinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tposeseq_expand_stbox(IntPtr seq, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpose_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpose_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpose_restrict_elevation(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int geo_get_srid(IntPtr g);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int date_in(string str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string date_out(int d);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int interval_cmp(IntPtr interv1, IntPtr interv2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr interval_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string interval_out(IntPtr interv);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long time_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string time_out(long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamp_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string timestamp_out(long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string timestamptz_out(long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_has_geom(short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_trgeo_geo(IntPtr temp, IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_trgeo_stbox(IntPtr temp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_geom_p(IntPtr temp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string trgeo_wkt_out(IntPtr temp, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_tposeinst_to_trgeo(IntPtr gs, IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_tposeseq_to_trgeo(IntPtr gs, IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_tposeseqset_to_trgeo(IntPtr gs, IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool trgeo_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoinst_geom_p(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong trgeoinst_pose_varsize(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoinst_set_pose(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoinst_tposeinst(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoinst_make1(IntPtr geom, IntPtr pose, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_to_tinstant(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_to_tinstant(IntPtr ts);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_geom_p(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong trgeoseq_pose_varsize(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoseq_set_pose(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_tposeseq(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool trgeoseq_make_valid(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, [MarshalAs(UnmanagedType.U1)] bool linear);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make1_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make1(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make_free_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseq_make_free(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoinst_to_tsequence(IntPtr inst, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_geom_p(IntPtr ts);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_tposeseqset(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_make1_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_make_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_make(IntPtr geom, IntPtr sequences, int count, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_make_free(IntPtr geom, IntPtr sequences, int count, [MarshalAs(UnmanagedType.U1)] bool normalize);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_make_gaps(IntPtr geom, IntPtr instants, int count, int interp, IntPtr maxt, double maxdist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeoseqset_to_tsequence(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_to_tsequence(IntPtr temp, string interp_str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_to_tsequenceset(IntPtr temp, string interp_str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoinst_set_stbox(IntPtr geom, IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoinstarr_static_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoinstarr_rotating_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void trgeoinstarr_compute_bbox(IntPtr geom, IntPtr instants, int count, int interp, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr trgeo_parse(IntPtr str, int temptype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_contains_geo_trgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_geo_trgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_covers_trgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ea_disjoint_trgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_geom(IntPtr gs1, IntPtr gs2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void lwgeom_apply_pose(IntPtr pose, IntPtr geom);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double geom_radius(IntPtr gs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int v_clip_tpoly_point(IntPtr poly, IntPtr point, IntPtr pose, IntPtr poly_feature, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int v_clip_tpoly_tpoly(IntPtr poly1, IntPtr poly2, IntPtr pose1, IntPtr pose2, IntPtr poly1_feature, IntPtr poly2_feature, IntPtr dist);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void apply_pose_point4d(IntPtr p, IntPtr pose);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tinstant(IntPtr inst, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tsequence(IntPtr seq, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tsequenceset(IntPtr ss, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_temporal(IntPtr temp, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tinstant_base(IntPtr inst, IntPtr value, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tsequence_base(IntPtr seq, IntPtr value, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tsequenceset_base(IntPtr ss, IntPtr value, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tcontseq_tcontseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eafunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eafunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int int4_in(string str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string int4_out(int val);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long int8_in(string str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string int8_out(long val);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int float8_in(string num, string type_name, string orig_string);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_dsin(int arg1);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_dcos(int arg1);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_datan(int arg1);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int pg_datan2(int arg1, int arg2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr interval_negate(IntPtr interval);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr pg_interval_justify_hours(IntPtr span);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint hash_bytes_uint32(uint k);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint pg_hashint8(long val);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint pg_hashfloat8(int key);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong hash_bytes_uint32_extended(uint k, ulong seed);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong pg_hashint8extended(long val, ulong seed);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong pg_hashfloat8extended(int key, ulong seed);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint pg_hashtext(IntPtr key);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong pg_hashtextextended(IntPtr key, ulong seed);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string set_out_fn(IntPtr s, int maxdd, IntPtr value_out);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_set_isof_type(IntPtr s, int settype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_set_set(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_find_value(IntPtr s, IntPtr arg1, IntPtr loc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr set_unnest_state_make(IntPtr set);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void set_unnest_state_next(IntPtr state);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_skiplist_subtype(IntPtr state, IntPtr subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void skiplist_set_extra(IntPtr state, IntPtr data, ulong size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr skiplist_headval(IntPtr list);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_span_isof_type(IntPtr s, int spantype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_span_isof_basetype(IntPtr s, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_span_type(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_span_span(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void span_deserialize(IntPtr s, IntPtr lower, IntPtr upper);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_bound_cmp(IntPtr b1, IntPtr b2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_bound_qsort_cmp(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_lower_cmp(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_upper_cmp(IntPtr s1, IntPtr s2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_decr_bound(IntPtr upper, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_incr_bound(IntPtr upper, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanarr_normalize(IntPtr spans, int count, [MarshalAs(UnmanagedType.U1)] bool sort, IntPtr newcount);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void span_bounds_shift_scale_value(IntPtr shift, IntPtr width, int type, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth, IntPtr lower, IntPtr upper);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void span_bounds_shift_scale_time(IntPtr shift, IntPtr duration, IntPtr lower, IntPtr upper);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void floatspan_floor_ceil_iter(IntPtr s, int func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void numspan_delta_scale_iter(IntPtr s, IntPtr origin, IntPtr delta, [MarshalAs(UnmanagedType.U1)] bool hasdelta, double scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tstzspan_delta_scale_iter(IntPtr s, long origin, long delta, double scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void numspan_shift_scale_iter(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth, IntPtr delta, IntPtr scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tstzspan_shift_scale1(IntPtr s, IntPtr shift, IntPtr duration, IntPtr delta, IntPtr scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int mi_span_value(IntPtr s, IntPtr value, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double dist_double_value_value(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int common_entry_cmp(IntPtr i1, IntPtr i2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_index_recheck(int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_spanset_isof_type(IntPtr ss, int spansettype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_spanset_type(IntPtr ss1, IntPtr ss2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_spanset_span_type(IntPtr ss, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_spanset_span(IntPtr ss, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_spanset_spanset(IntPtr ss1, IntPtr ss2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spanset_find_value(IntPtr ss, IntPtr v, IntPtr loc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_and(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_or(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr boolop_tbool_bool(IntPtr temp, IntPtr b, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr boolop_tbool_tbool(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_same_dimensionality_tbox(IntPtr box1, IntPtr box2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr set_tbox(IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr span_tbox(IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_tstzspan(IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_intspan(IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_floatspan(IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbox_index_recheck(int strategy);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_min_int32(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_max_int32(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_min_float8(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_max_float8(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sum_int32(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sum_float8(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_min_text(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_max_text(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sum_double2(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sum_double3(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sum_double4(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temporal_skiplist_common(IntPtr list, IntPtr values, int count, IntPtr lower, IntPtr upper, IntPtr update);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_skiplist_merge(IntPtr spliced, int spliced_count, IntPtr values, int count, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr newcount, IntPtr tofree, IntPtr nfree);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_tagg(IntPtr instants1, int count1, IntPtr instants2, int count2, IntPtr func, IntPtr newcount, IntPtr tofree, IntPtr nfree);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_tagg(IntPtr sequences1, int count1, IntPtr sequences2, int count2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr newcount);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool interpoint);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tagg_combinefn(IntPtr state1, IntPtr state2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_tagg_transfn(IntPtr state, IntPtr inst, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_tavg_finalfn(IntPtr instants, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_tavg_finalfn(IntPtr sequences, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberinst_transform_tavg(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_transform_tcount(IntPtr temp, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_transform_tagg(IntPtr temp, IntPtr count, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_tagg_transfn(IntPtr state, IntPtr ss, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tagg_transfn(IntPtr state, IntPtr temp, IntPtr arg2, [MarshalAs(UnmanagedType.U1)] bool crossings);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr transform);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double temporal_similarity(IntPtr temp1, IntPtr temp2, IntPtr simfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_similarity_path(IntPtr temp1, IntPtr temp2, IntPtr count, IntPtr simfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong temporal_bbox_size(int tempype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tinstarr_set_bbox(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, IntPtr bbox);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tsequence_compute_bbox(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tseqarr_compute_bbox(IntPtr sequences, int count, IntPtr bbox);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tsequenceset_compute_bbox(IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_temporal_tstzspan(IntPtr temp, IntPtr s, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_tnumber_numspan(IntPtr temp, IntPtr span, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_tnumber_tbox(IntPtr temp, IntPtr box, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool boxop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eacomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eacomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int eacomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_at_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_restrict_value(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_restrict_values(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_minus_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_restrict_tstzset(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_restrict_value_iter(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_delete_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_delete_tstzset(IntPtr seq, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_delete_tstzspanset(IntPtr seq, IntPtr ss);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_at_tstzset(IntPtr seq, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_minus_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_minus_tstzset(IntPtr seq, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_minus_tstzspan(IntPtr seq, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_restrict_value(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_restrict_values(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_at_values_iter(IntPtr seq, IntPtr set, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnumberseq_cont_restrict_span_iter(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnumberseq_cont_restrict_spanset_iter(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsegment_at_timestamptz(IntPtr inst1, IntPtr inst2, int interp, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_minus_timestamp_iter(IntPtr seq, long t, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_minus_tstzset_iter(IntPtr seq, IntPtr s, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_at_tstzspanset1(IntPtr seq, IntPtr ss, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_minus_tstzspanset_iter(IntPtr seq, IntPtr ss, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_at_tstzspan(IntPtr seq, IntPtr s);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_at_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tdiscseq_value_at_timestamptz(IntPtr seq, long t, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_disc_restrict_span(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_disc_restrict_spanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_cont_restrict_span(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_cont_restrict_spanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double tnumberseq_cont_twavg(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int span_num_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr start_bin, IntPtr end_bin);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_time_bin_init(IntPtr temp, IntPtr duration, long torigin, IntPtr nbins);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_tile_state_make(IntPtr temp, IntPtr box, IntPtr vsize, IntPtr duration, IntPtr xorigin, long torigin);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tbox_tile_state_next(IntPtr state);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tbox_tile_state_set(IntPtr value, long t, IntPtr vsize, long tunits, int basetype, int spantype, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long interval_units(IntPtr interval);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_bin_start(long timestamp, long tunits, long torigin);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_bin(IntPtr value, IntPtr size, IntPtr offset, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_time_tile_init(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, long torigin, IntPtr ntiles);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbox_tile_state_get(IntPtr state, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_transform_wcount(IntPtr temp, IntPtr interval, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_transform_wavg(IntPtr temp, IntPtr interval, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_wagg_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool crossings);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_wagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, IntPtr transform);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tinstant_set(IntPtr inst, IntPtr value, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double tnumberinst_double(IntPtr inst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string tinstant_to_string(IntPtr inst, int maxdd, IntPtr value_out);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tinstant_restrict_values_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumberinst_restrict_span_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumberinst_restrict_spanset_test(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tinstant_restrict_tstzset_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tinstant_restrict_tstzspanset_test(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tfloat_arithop_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, long lower, long upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr arithop_tnumber_number(IntPtr temp, IntPtr value, IntPtr oper, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr arithop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr oper, IntPtr func, IntPtr tpfunc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool float_collinear(double x1, double x2, double x3, double ratio);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double floatsegm_interpolate(double value1, double value2, IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr floatsegm_locate(double value1, double value2, double value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tnumbersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int basetype, long lower, long upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequence_norm_test(IntPtr value1, IntPtr value2, IntPtr value3, int basetype, int interp, long t1, long t2, long t3);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequence_join_test(IntPtr seq1, IntPtr seq2, IntPtr removelast, IntPtr removefirst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_join(IntPtr seq1, IntPtr seq2, [MarshalAs(UnmanagedType.U1)] bool removelast, [MarshalAs(UnmanagedType.U1)] bool removefirst);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstarr_normalize(IntPtr instants, int interp, int count, IntPtr newcount);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tcontseq_find_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tdiscseq_find_timestamptz(IntPtr seq, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tseqarr2_to_tseqarr(IntPtr sequences, IntPtr countseqs, int count, int totalseqs);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tinstarr_common(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_make_exp1(IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize, IntPtr bbox);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool synchronize_tsequence_tsequence(IntPtr seq1, IntPtr seq2, IntPtr sync1, IntPtr sync2, [MarshalAs(UnmanagedType.U1)] bool interpoint);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tfloatsegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, long lower, long upper, IntPtr t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsegment_intersection_value(IntPtr start, IntPtr end, IntPtr value, int temptype, long lower, long upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsegment_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int temptype, long lower, long upper, IntPtr t1, IntPtr t2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsegment_value_at_timestamptz(IntPtr start, IntPtr end, int temptype, long lower, long upper, long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tcontseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tdiscseq_tcontseq(IntPtr @is, IntPtr seq2, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tsequence_tinstant(IntPtr seq, IntPtr inst, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tinstant_tsequence(IntPtr inst, IntPtr seq, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string tsequence_to_string(IntPtr seq, int maxdd, [MarshalAs(UnmanagedType.U1)] bool component, IntPtr value_out);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_increasing_timestamps(IntPtr inst1, IntPtr inst2, [MarshalAs(UnmanagedType.U1)] bool strict);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void bbox_expand(IntPtr box1, IntPtr box2, int temptype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tinstarr(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool merge, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequence_make_valid(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tnumberseq_shift_scale_value_iter(IntPtr seq, IntPtr origin, IntPtr delta, [MarshalAs(UnmanagedType.U1)] bool hasdelta, double scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tsequence_shift_scale_time_iter(IntPtr seq, long delta, double scale);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstepseq_to_linear_iter(IntPtr seq, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstepseq_to_linear(IntPtr seq);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_segments_iter(IntPtr seq, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tsequence_timestamps_iter(IntPtr seq, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequenceset_find_timestamptz(IntPtr ss, long t, IntPtr loc);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tseqarr_normalize(IntPtr sequences, int count, IntPtr newcount);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double datum_distance(IntPtr value1, IntPtr value2, int basetype, short flags);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ensure_valid_tinstarr_gaps(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool merge, double maxdist, IntPtr maxt, IntPtr nsplits);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_valid_tseqarr(IntPtr sequences, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool synchronize_tsequenceset_tsequence(IntPtr ss, IntPtr seq, IntPtr mode, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool synchronize_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr mode, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tsequenceset_tinstant(IntPtr ss, IntPtr inst, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tinstant_tsequenceset(IntPtr inst, IntPtr ss, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tsequenceset_tdiscseq(IntPtr ss, IntPtr @is, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tdiscseq_tsequenceset(IntPtr @is, IntPtr ss, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool intersection_tsequence_tsequenceset(IntPtr seq, IntPtr ss, IntPtr mode, IntPtr inter1, IntPtr inter2);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string tsequenceset_to_string(IntPtr ss, int maxdd, IntPtr value_out);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_textcat(IntPtr l, IntPtr r);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_lower(IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_upper(IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_initcap(IntPtr value);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr textfunc_ttext(IntPtr temp, int func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr textfunc_ttext_text(IntPtr temp, IntPtr value, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr textfunc_ttext_ttext(IntPtr temp1, IntPtr temp2, IntPtr func);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr datum_as_wkb(IntPtr value, int type, IntPtr variant, IntPtr size_out);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string datum_as_hexwkb(IntPtr value, int type, IntPtr variant, IntPtr size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int type_from_wkb(IntPtr wkb, ulong size, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int type_from_hexwkb(string hexwkb, ulong size, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_end_input(IntPtr str, string type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void p_whitespace(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_delimchar(IntPtr str, byte delim);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_obrace(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_obrace(IntPtr str, string type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_cbrace(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_cbrace(IntPtr str, string type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_obracket(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_cbracket(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_oparen(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_oparen(IntPtr str, string type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_cparen(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_cparen(IntPtr str, string type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool p_comma(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_parse(IntPtr str, int basetypid, byte delim, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool double_parse(IntPtr str, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool elem_parse(IntPtr str, int basetype, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr set_parse(IntPtr str, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_parse(IntPtr str, int spantype, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr span);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanset_parse(IntPtr str, int spantype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_parse(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamp_parse(IntPtr str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_parse(IntPtr str, int temptype, [MarshalAs(UnmanagedType.U1)] bool end);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_parse(IntPtr str, int temptype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_parse(IntPtr str, int temptype, int interp, [MarshalAs(UnmanagedType.U1)] bool end);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_parse(IntPtr str, int temptype, int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_parse(IntPtr str, int temptype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_copy(IntPtr value, int typid);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double datum_double(IntPtr d, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int double_datum(double d, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bstring2bytea(IntPtr wkb, ulong size);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_in(string str, int type, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string basetype_out(IntPtr value, int type, int maxdd);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void pfree_array(IntPtr array, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string stringarr_to_string(IntPtr strings, int count, ulong outlen, string prefix, byte open, byte close, [MarshalAs(UnmanagedType.U1)] bool quotes, [MarshalAs(UnmanagedType.U1)] bool spaces);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void datumarr_sort(IntPtr values, int count, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tstzarr_sort(IntPtr times, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void spanarr_sort(IntPtr spans, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tinstarr_sort(IntPtr instants, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tseqarr_sort(IntPtr sequences, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datumarr_remove_duplicates(IntPtr values, int count, int basetype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tstzarr_remove_duplicates(IntPtr values, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int tinstarr_remove_duplicates(IntPtr instants, int count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_add(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_sub(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_mult(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_div(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum_cmp(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_eq(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_ne(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_lt(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_le(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_gt(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool datum_ge(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_eq(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_ne(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_lt(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_le(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_gt(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int datum2_ge(IntPtr l, IntPtr r, int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double hypot3d(double x, double y, double z);
 
         }
     }

--- a/MEOS.NET/Internal/MEOSExternalFunctions.cs
+++ b/MEOS.NET/Internal/MEOSExternalFunctions.cs
@@ -13,37 +13,28 @@ namespace MEOS.NET.Internal
             private const string DllPath = "meos";
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int date_in(string str);
+            public static partial IntPtr meos_array_create(int elem_size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string date_out(int d);
+            public static partial void meos_array_add(IntPtr array, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int interval_cmp(IntPtr interv1, IntPtr interv2);
+            public static partial IntPtr meos_array_get(IntPtr array, int n);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr interval_in(string str, int typmod);
+            public static partial int meos_array_count(IntPtr array);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string interval_out(IntPtr interv);
+            public static partial void meos_array_reset(IntPtr array);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long time_in(string str, int typmod);
+            public static partial void meos_array_reset_free(IntPtr array);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string time_out(long t);
+            public static partial void meos_array_destroy(IntPtr array);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamp_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string timestamp_out(long t);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_in(string str, int typmod);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string timestamptz_out(long t);
+            public static partial void meos_array_destroy_free(IntPtr array);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr rtree_create_intspan();
@@ -70,10 +61,16 @@ namespace MEOS.NET.Internal
             public static partial void rtree_free(IntPtr rtree);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void rtree_insert(IntPtr rtree, IntPtr box, long id);
+            public static partial void rtree_insert(IntPtr rtree, IntPtr box, int id);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr rtree_search(IntPtr rtree, IntPtr query, IntPtr count);
+            public static partial void rtree_insert_temporal(IntPtr rtree, IntPtr temp, int id);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int rtree_search(IntPtr rtree, IntPtr op, IntPtr query, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int rtree_search_temporal(IntPtr rtree, IntPtr op, IntPtr temp, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void meos_error(int errlevel, int errcode, string format);
@@ -135,7 +132,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr add_interval_interval(IntPtr interv1, IntPtr interv2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long add_timestamptz_interval(long t, IntPtr interv);
+            public static partial int add_timestamptz_interval(int t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -148,10 +145,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr cstring2text(string str);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long date_to_timestamp(int dateVal);
+            public static partial int date_to_timestamp(int dateVal);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long date_to_timestamptz(int d);
+            public static partial int date_to_timestamptz(int d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double float_exp(double d);
@@ -172,7 +169,7 @@ namespace MEOS.NET.Internal
             public static partial int int32_cmp(int l, int r);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int int64_cmp(long l, long r);
+            public static partial int int64_cmp(int l, int r);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr interval_make(int years, int months, int weeks, int days, int hours, int mins, double secs);
@@ -184,10 +181,10 @@ namespace MEOS.NET.Internal
             public static partial int minus_date_int(int d, int days);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long minus_timestamptz_interval(long t, IntPtr interv);
+            public static partial int minus_timestamptz_interval(int t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_timestamptz(long t1, long t2);
+            public static partial IntPtr minus_timestamptz_timestamptz(int t1, int t2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr mul_interval_double(IntPtr interv, double factor);
@@ -208,16 +205,16 @@ namespace MEOS.NET.Internal
             public static partial string pg_interval_out(IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long pg_timestamp_in(string str, int typmod);
+            public static partial int pg_timestamp_in(string str, int typmod);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string pg_timestamp_out(long t);
+            public static partial string pg_timestamp_out(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long pg_timestamptz_in(string str, int typmod);
+            public static partial int pg_timestamptz_in(string str, int typmod);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string pg_timestamptz_out(long t);
+            public static partial string pg_timestamptz_out(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial string text2cstring(IntPtr txt);
@@ -247,13 +244,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textcat_text_text(IntPtr txt1, IntPtr txt2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_shift(long t, IntPtr interv);
+            public static partial int timestamptz_shift(int t, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamp_to_date(long t);
+            public static partial int timestamp_to_date(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int timestamptz_to_date(long t);
+            public static partial int timestamptz_to_date(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigintset_in(string str);
@@ -262,7 +259,7 @@ namespace MEOS.NET.Internal
             public static partial string bigintset_out(IntPtr set);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_expand(IntPtr s, long value);
+            public static partial IntPtr bigintspan_expand(IntPtr s, int value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigintspan_in(string str);
@@ -400,7 +397,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr bigintset_make(IntPtr values, int count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_make(long lower, long upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
+            public static partial IntPtr bigintspan_make(int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr dateset_make(IntPtr values, int count);
@@ -439,10 +436,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzset_make(IntPtr values, int count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_make(long lower, long upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
+            public static partial IntPtr tstzspan_make(int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_to_set(long i);
+            public static partial IntPtr bigint_to_set(int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr bigint_to_span(int i);
@@ -517,13 +514,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr text_to_set(IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_set(long t);
+            public static partial IntPtr timestamptz_to_set(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_span(long t);
+            public static partial IntPtr timestamptz_to_span(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_spanset(long t);
+            public static partial IntPtr timestamptz_to_spanset(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_to_dateset(IntPtr s);
@@ -535,10 +532,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzspanset_to_datespanset(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintset_end_value(IntPtr s);
+            public static partial int bigintset_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintset_start_value(IntPtr s);
+            public static partial int bigintset_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -548,22 +545,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr bigintset_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspan_lower(IntPtr s);
+            public static partial int bigintspan_lower(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspan_upper(IntPtr s);
+            public static partial int bigintspan_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspan_width(IntPtr s);
+            public static partial int bigintspan_width(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspanset_lower(IntPtr ss);
+            public static partial int bigintspanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspanset_upper(IntPtr ss);
+            public static partial int bigintspanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigintspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
+            public static partial int bigintspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int dateset_end_value(IntPtr s);
@@ -669,19 +666,19 @@ namespace MEOS.NET.Internal
             public static partial int intspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint set_hash(IntPtr s);
+            public static partial int set_hash(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong set_hash_extended(IntPtr s, ulong seed);
+            public static partial int set_hash_extended(IntPtr s, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_num_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint span_hash(IntPtr s);
+            public static partial int span_hash(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong span_hash_extended(IntPtr s, ulong seed);
+            public static partial int span_hash_extended(IntPtr s, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -695,10 +692,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_end_span(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint spanset_hash(IntPtr ss);
+            public static partial int spanset_hash(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong spanset_hash_extended(IntPtr ss, ulong seed);
+            public static partial int spanset_hash_extended(IntPtr ss, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -737,10 +734,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textset_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzset_end_value(IntPtr s);
+            public static partial int tstzset_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzset_start_value(IntPtr s);
+            public static partial int tstzset_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -753,25 +750,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tstzspan_duration(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspan_lower(IntPtr s);
+            public static partial int tstzspan_lower(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspan_upper(IntPtr s);
+            public static partial int tstzspan_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_duration(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspanset_end_timestamptz(IntPtr ss);
+            public static partial int tstzspanset_end_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspanset_lower(IntPtr ss);
+            public static partial int tstzspanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tstzspanset_num_timestamps(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspanset_start_timestamptz(IntPtr ss);
+            public static partial int tstzspanset_start_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_timestamps(IntPtr ss);
@@ -781,16 +778,16 @@ namespace MEOS.NET.Internal
             public static partial bool tstzspanset_timestamptz_n(IntPtr ss, int n, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tstzspanset_upper(IntPtr ss);
+            public static partial int tstzspanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintset_shift_scale(IntPtr s, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintset_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_shift_scale(IntPtr s, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintspan_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspanset_shift_scale(IntPtr ss, long shift, long width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr bigintspanset_shift_scale(IntPtr ss, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr dateset_shift_scale(IntPtr s, int shift, int width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
@@ -883,25 +880,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr textset_upper(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_tprecision(long t, IntPtr duration, long torigin);
+            public static partial int timestamptz_tprecision(int t, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_shift_scale(IntPtr s, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, long torigin);
+            public static partial IntPtr tstzset_tprecision(IntPtr s, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspan_shift_scale(IntPtr s, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, long torigin);
+            public static partial IntPtr tstzspan_tprecision(IntPtr s, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr duration);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, long torigin);
+            public static partial IntPtr tstzspanset_tprecision(IntPtr ss, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_cmp(IntPtr s1, IntPtr s2);
@@ -1004,7 +1001,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_bigint(IntPtr s, long i);
+            public static partial bool adjacent_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1028,11 +1025,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_timestamptz(IntPtr s, long t);
+            public static partial bool adjacent_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_bigint(IntPtr ss, long i);
+            public static partial bool adjacent_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1048,7 +1045,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool adjacent_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1060,15 +1057,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_set(long i, IntPtr s);
+            public static partial bool contained_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_span(long i, IntPtr s);
+            public static partial bool contained_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_bigint_spanset(long i, IntPtr ss);
+            public static partial bool contained_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1132,19 +1129,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_set(long t, IntPtr s);
+            public static partial bool contained_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_span(long t, IntPtr s);
+            public static partial bool contained_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_timestamptz_spanset(long t, IntPtr ss);
+            public static partial bool contained_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_bigint(IntPtr s, long i);
+            public static partial bool contains_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1168,11 +1165,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_timestamptz(IntPtr s, long t);
+            public static partial bool contains_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_bigint(IntPtr s, long i);
+            public static partial bool contains_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1196,11 +1193,11 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_timestamptz(IntPtr s, long t);
+            public static partial bool contains_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_bigint(IntPtr ss, long i);
+            public static partial bool contains_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1224,7 +1221,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool contains_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1264,7 +1261,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_set_timestamptz(IntPtr s, long t);
+            public static partial bool after_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1272,7 +1269,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_span_timestamptz(IntPtr s, long t);
+            public static partial bool after_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1280,19 +1277,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool after_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_set(long t, IntPtr s);
+            public static partial bool after_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_span(long t, IntPtr s);
+            public static partial bool after_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool after_timestamptz_spanset(long t, IntPtr ss);
+            public static partial bool after_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1312,7 +1309,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_set_timestamptz(IntPtr s, long t);
+            public static partial bool before_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1320,7 +1317,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_span_timestamptz(IntPtr s, long t);
+            public static partial bool before_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1328,31 +1325,31 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool before_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_set(long t, IntPtr s);
+            public static partial bool before_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_span(long t, IntPtr s);
+            public static partial bool before_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool before_timestamptz_spanset(long t, IntPtr ss);
+            public static partial bool before_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_set(long i, IntPtr s);
+            public static partial bool left_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_span(long i, IntPtr s);
+            public static partial bool left_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_bigint_spanset(long i, IntPtr ss);
+            public static partial bool left_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1380,7 +1377,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_set_bigint(IntPtr s, long i);
+            public static partial bool left_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1400,7 +1397,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_span_bigint(IntPtr s, long i);
+            public static partial bool left_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1420,7 +1417,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_spanset_bigint(IntPtr ss, long i);
+            public static partial bool left_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1460,7 +1457,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_set_timestamptz(IntPtr s, long t);
+            public static partial bool overafter_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1468,7 +1465,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_span_timestamptz(IntPtr s, long t);
+            public static partial bool overafter_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1476,19 +1473,19 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool overafter_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_set(long t, IntPtr s);
+            public static partial bool overafter_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_span(long t, IntPtr s);
+            public static partial bool overafter_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overafter_timestamptz_spanset(long t, IntPtr ss);
+            public static partial bool overafter_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1508,7 +1505,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_set_timestamptz(IntPtr s, long t);
+            public static partial bool overbefore_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1516,7 +1513,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_span_timestamptz(IntPtr s, long t);
+            public static partial bool overbefore_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1524,31 +1521,31 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_spanset_timestamptz(IntPtr ss, long t);
+            public static partial bool overbefore_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_set(long t, IntPtr s);
+            public static partial bool overbefore_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_span(long t, IntPtr s);
+            public static partial bool overbefore_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overbefore_timestamptz_spanset(long t, IntPtr ss);
+            public static partial bool overbefore_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_set(long i, IntPtr s);
+            public static partial bool overleft_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_span(long i, IntPtr s);
+            public static partial bool overleft_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_bigint_spanset(long i, IntPtr ss);
+            public static partial bool overleft_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1576,7 +1573,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_set_bigint(IntPtr s, long i);
+            public static partial bool overleft_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1596,7 +1593,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_span_bigint(IntPtr s, long i);
+            public static partial bool overleft_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1616,7 +1613,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_spanset_bigint(IntPtr ss, long i);
+            public static partial bool overleft_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1640,15 +1637,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_set(long i, IntPtr s);
+            public static partial bool overright_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_span(long i, IntPtr s);
+            public static partial bool overright_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_bigint_spanset(long i, IntPtr ss);
+            public static partial bool overright_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1676,7 +1673,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_set_bigint(IntPtr s, long i);
+            public static partial bool overright_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1696,7 +1693,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_span_bigint(IntPtr s, long i);
+            public static partial bool overright_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1716,7 +1713,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_spanset_bigint(IntPtr ss, long i);
+            public static partial bool overright_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1740,15 +1737,15 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_set(long i, IntPtr s);
+            public static partial bool right_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_span(long i, IntPtr s);
+            public static partial bool right_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_bigint_spanset(long i, IntPtr ss);
+            public static partial bool right_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1776,7 +1773,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_set_bigint(IntPtr s, long i);
+            public static partial bool right_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1796,7 +1793,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_span_bigint(IntPtr s, long i);
+            public static partial bool right_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1816,7 +1813,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_spanset_bigint(IntPtr ss, long i);
+            public static partial bool right_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -1839,7 +1836,7 @@ namespace MEOS.NET.Internal
             public static partial bool right_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_bigint_set(long i, IntPtr s);
+            public static partial IntPtr intersection_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_date_set(int d, IntPtr s);
@@ -1851,7 +1848,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_int_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_bigint(IntPtr s, long i);
+            public static partial IntPtr intersection_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_set_date(IntPtr s, int d);
@@ -1869,10 +1866,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_timestamptz(IntPtr s, long t);
+            public static partial IntPtr intersection_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_bigint(IntPtr s, long i);
+            public static partial IntPtr intersection_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_span_date(IntPtr s, int d);
@@ -1890,10 +1887,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_timestamptz(IntPtr s, long t);
+            public static partial IntPtr intersection_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_bigint(IntPtr ss, long i);
+            public static partial IntPtr intersection_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_spanset_date(IntPtr ss, int d);
@@ -1911,22 +1908,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intersection_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_timestamptz(IntPtr ss, long t);
+            public static partial IntPtr intersection_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr intersection_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_timestamptz_set(long t, IntPtr s);
+            public static partial IntPtr intersection_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_set(long i, IntPtr s);
+            public static partial IntPtr minus_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_span(long i, IntPtr s);
+            public static partial IntPtr minus_bigint_span(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_bigint_spanset(long i, IntPtr ss);
+            public static partial IntPtr minus_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_date_set(int d, IntPtr s);
@@ -1956,7 +1953,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_int_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_bigint(IntPtr s, long i);
+            public static partial IntPtr minus_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_set_date(IntPtr s, int d);
@@ -1974,10 +1971,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_timestamptz(IntPtr s, long t);
+            public static partial IntPtr minus_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_bigint(IntPtr s, long i);
+            public static partial IntPtr minus_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_span_date(IntPtr s, int d);
@@ -1995,10 +1992,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_timestamptz(IntPtr s, long t);
+            public static partial IntPtr minus_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_bigint(IntPtr ss, long i);
+            public static partial IntPtr minus_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_spanset_date(IntPtr ss, int d);
@@ -2016,28 +2013,28 @@ namespace MEOS.NET.Internal
             public static partial IntPtr minus_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_timestamptz(IntPtr ss, long t);
+            public static partial IntPtr minus_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr minus_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_set(long t, IntPtr s);
+            public static partial IntPtr minus_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_span(long t, IntPtr s);
+            public static partial IntPtr minus_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_timestamptz_spanset(long t, IntPtr ss);
+            public static partial IntPtr minus_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_set(long i, IntPtr s);
+            public static partial IntPtr union_bigint_set(int i, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_span(IntPtr s, long i);
+            public static partial IntPtr union_bigint_span(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_bigint_spanset(long i, IntPtr ss);
+            public static partial IntPtr union_bigint_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_date_set(int d, IntPtr s);
@@ -2067,7 +2064,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_int_spanset(int i, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_bigint(IntPtr s, long i);
+            public static partial IntPtr union_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_set_date(IntPtr s, int d);
@@ -2085,10 +2082,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_set_text(IntPtr s, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_timestamptz(IntPtr s, long t);
+            public static partial IntPtr union_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_bigint(IntPtr s, long i);
+            public static partial IntPtr union_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_span_date(IntPtr s, int d);
@@ -2106,10 +2103,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_span_spanset(IntPtr s, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_timestamptz(IntPtr s, long t);
+            public static partial IntPtr union_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_bigint(IntPtr ss, long i);
+            public static partial IntPtr union_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_spanset_date(IntPtr ss, int d);
@@ -2127,31 +2124,31 @@ namespace MEOS.NET.Internal
             public static partial IntPtr union_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_timestamptz(IntPtr ss, long t);
+            public static partial IntPtr union_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr union_text_set(IntPtr txt, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_set(long t, IntPtr s);
+            public static partial IntPtr union_timestamptz_set(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_span(long t, IntPtr s);
+            public static partial IntPtr union_timestamptz_span(int t, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_timestamptz_spanset(long t, IntPtr ss);
+            public static partial IntPtr union_timestamptz_spanset(int t, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_bigintset_bigintset(IntPtr s1, IntPtr s2);
+            public static partial int distance_bigintset_bigintset(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2);
+            public static partial int distance_bigintspan_bigintspan(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s);
+            public static partial int distance_bigintspanset_bigintspan(IntPtr ss, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2);
+            public static partial int distance_bigintspanset_bigintspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_dateset_dateset(IntPtr s1, IntPtr s2);
@@ -2190,7 +2187,7 @@ namespace MEOS.NET.Internal
             public static partial int distance_intspanset_intspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_set_bigint(IntPtr s, long i);
+            public static partial int distance_set_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_set_date(IntPtr s, int d);
@@ -2202,10 +2199,10 @@ namespace MEOS.NET.Internal
             public static partial int distance_set_int(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_set_timestamptz(IntPtr s, long t);
+            public static partial double distance_set_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_span_bigint(IntPtr s, long i);
+            public static partial int distance_span_bigint(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_span_date(IntPtr s, int d);
@@ -2217,10 +2214,10 @@ namespace MEOS.NET.Internal
             public static partial int distance_span_int(IntPtr s, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_span_timestamptz(IntPtr s, long t);
+            public static partial double distance_span_timestamptz(IntPtr s, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long distance_spanset_bigint(IntPtr ss, long i);
+            public static partial int distance_spanset_bigint(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int distance_spanset_date(IntPtr ss, int d);
@@ -2232,7 +2229,7 @@ namespace MEOS.NET.Internal
             public static partial int distance_spanset_int(IntPtr ss, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double distance_spanset_timestamptz(IntPtr ss, long t);
+            public static partial double distance_spanset_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double distance_tstzset_tstzset(IntPtr s1, IntPtr s2);
@@ -2247,10 +2244,10 @@ namespace MEOS.NET.Internal
             public static partial double distance_tstzspanset_tstzspanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_extent_transfn(IntPtr state, long i);
+            public static partial IntPtr bigint_extent_transfn(IntPtr state, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigint_union_transfn(IntPtr state, long i);
+            public static partial IntPtr bigint_union_transfn(IntPtr state, int i);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr date_extent_transfn(IntPtr state, int d);
@@ -2298,19 +2295,19 @@ namespace MEOS.NET.Internal
             public static partial IntPtr text_union_transfn(IntPtr state, IntPtr txt);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_extent_transfn(IntPtr state, long t);
+            public static partial IntPtr timestamptz_extent_transfn(IntPtr state, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_union_transfn(IntPtr state, long t);
+            public static partial IntPtr timestamptz_union_transfn(IntPtr state, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long bigint_get_bin(long value, long vsize, long vorigin);
+            public static partial int bigint_get_bin(int value, int vsize, int vorigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspan_bins(IntPtr s, long vsize, long vorigin, IntPtr count);
+            public static partial IntPtr bigintspan_bins(IntPtr s, int vsize, int vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr bigintspanset_bins(IntPtr ss, long vsize, long vorigin, IntPtr count);
+            public static partial IntPtr bigintspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int date_get_bin(int d, IntPtr duration, int torigin);
@@ -2340,13 +2337,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr intspanset_bins(IntPtr ss, int vsize, int vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long timestamptz_get_bin(long t, IntPtr duration, long torigin);
+            public static partial int timestamptz_get_bin(int t, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspan_bins(IntPtr s, IntPtr duration, long origin, IntPtr count);
+            public static partial IntPtr tstzspan_bins(IntPtr s, IntPtr duration, int origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, long torigin, IntPtr count);
+            public static partial IntPtr tstzspanset_bins(IntPtr ss, IntPtr duration, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial string tbox_as_hexwkb(IntPtr box, IntPtr variant, IntPtr size);
@@ -2367,13 +2364,13 @@ namespace MEOS.NET.Internal
             public static partial string tbox_out(IntPtr box, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr float_timestamptz_to_tbox(double d, long t);
+            public static partial IntPtr float_timestamptz_to_tbox(double d, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr float_tstzspan_to_tbox(double d, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr int_timestamptz_to_tbox(int i, long t);
+            public static partial IntPtr int_timestamptz_to_tbox(int i, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr int_tstzspan_to_tbox(int i, IntPtr s);
@@ -2382,7 +2379,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr numspan_tstzspan_to_tbox(IntPtr span, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_timestamptz_to_tbox(IntPtr span, long t);
+            public static partial IntPtr numspan_timestamptz_to_tbox(IntPtr span, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tbox_copy(IntPtr box);
@@ -2415,13 +2412,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbox_to_tstzspan(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_tbox(long t);
+            public static partial IntPtr timestamptz_to_tbox(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint tbox_hash(IntPtr box);
+            public static partial int tbox_hash(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tbox_hash_extended(IntPtr box, ulong seed);
+            public static partial int tbox_hash_extended(IntPtr box, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2640,7 +2637,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbool_from_base_temp([MarshalAs(UnmanagedType.U1)] bool b, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tboolinst_make([MarshalAs(UnmanagedType.U1)] bool b, long t);
+            public static partial IntPtr tboolinst_make([MarshalAs(UnmanagedType.U1)] bool b, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tboolseq_from_base_tstzset([MarshalAs(UnmanagedType.U1)] bool b, IntPtr s);
@@ -2658,7 +2655,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_from_base_temp(double d, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatinst_make(double d, long t);
+            public static partial IntPtr tfloatinst_make(double d, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloatseq_from_base_tstzset(double d, IntPtr s);
@@ -2673,7 +2670,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tint_from_base_temp(int i, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintinst_make(int i, long t);
+            public static partial IntPtr tintinst_make(int i, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tintseq_from_base_tstzset(int i, IntPtr s);
@@ -2697,7 +2694,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr ttext_from_base_temp(IntPtr txt, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ttextinst_make(IntPtr txt, long t);
+            public static partial IntPtr ttextinst_make(IntPtr txt, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr ttextseq_from_base_tstzset(IntPtr txt, IntPtr s);
@@ -2736,7 +2733,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tbool_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tbool_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2755,10 +2752,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_end_sequence(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long temporal_end_timestamptz(IntPtr temp);
+            public static partial int temporal_end_timestamptz(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint temporal_hash(IntPtr temp);
+            public static partial int temporal_hash(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_instant_n(IntPtr temp, int n);
@@ -2807,7 +2804,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_start_sequence(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long temporal_start_timestamptz(IntPtr temp);
+            public static partial int temporal_start_timestamptz(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_stops(IntPtr temp, double maxdist, IntPtr minduration);
@@ -2846,7 +2843,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tfloat_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tfloat_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2869,7 +2866,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tint_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tint_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2904,7 +2901,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ttext_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool ttext_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -2980,7 +2977,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_append_tsequence(IntPtr temp, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_delete_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool connect);
+            public static partial IntPtr temporal_delete_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_delete_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
@@ -3010,7 +3007,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tbool_minus_value(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool b);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_after_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr temporal_after_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_at_max(IntPtr temp);
@@ -3019,7 +3016,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_at_min(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_at_timestamptz(IntPtr temp, long t);
+            public static partial IntPtr temporal_at_timestamptz(IntPtr temp, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_at_tstzset(IntPtr temp, IntPtr s);
@@ -3034,7 +3031,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_at_values(IntPtr temp, IntPtr set);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_before_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr temporal_before_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_minus_max(IntPtr temp);
@@ -3043,7 +3040,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_minus_min(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_minus_timestamptz(IntPtr temp, long t);
+            public static partial IntPtr temporal_minus_timestamptz(IntPtr temp, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_minus_tstzset(IntPtr temp, IntPtr s);
@@ -4060,6 +4057,12 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_extent_transfn(IntPtr s, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_merge_transfn(IntPtr state, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_merge_combinefn(IntPtr state1, IntPtr state2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_tagg_finalfn(IntPtr state);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
@@ -4084,7 +4087,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_wsum_transfn(IntPtr state, IntPtr temp, IntPtr interv);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_tcount_transfn(IntPtr state, long t);
+            public static partial IntPtr timestamptz_tcount_transfn(IntPtr state, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tint_tmax_transfn(IntPtr state, IntPtr temp);
@@ -4144,10 +4147,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_simplify_min_tdelta(IntPtr temp, IntPtr mint);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, long origin);
+            public static partial IntPtr temporal_tprecision(IntPtr temp, IntPtr duration, int origin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_tsample(IntPtr temp, IntPtr duration, long origin, int interp);
+            public static partial IntPtr temporal_tsample(IntPtr temp, IntPtr duration, int origin, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double temporal_dyntimewarp_distance(IntPtr temp1, IntPtr temp2);
@@ -4165,13 +4168,13 @@ namespace MEOS.NET.Internal
             public static partial double temporal_hausdorff_distance(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, long origin, IntPtr count);
+            public static partial IntPtr temporal_time_bins(IntPtr temp, IntPtr duration, int origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_time_split(IntPtr temp, IntPtr duration, long torigin, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr temporal_time_split(IntPtr temp, IntPtr duration, int torigin, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count);
+            public static partial IntPtr tfloat_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloat_value_bins(IntPtr temp, double vsize, double vorigin, IntPtr count);
@@ -4183,22 +4186,22 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tfloat_value_split(IntPtr temp, double size, double origin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count);
+            public static partial IntPtr tfloat_value_time_boxes(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tfloat_value_time_split(IntPtr temp, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count);
+            public static partial IntPtr tfloatbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tfloatbox_value_tiles(IntPtr box, double vsize, double vorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, long torigin, IntPtr count);
+            public static partial IntPtr tfloatbox_value_time_tiles(IntPtr box, double vsize, IntPtr duration, double vorigin, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, long torigin, IntPtr count);
+            public static partial IntPtr tint_time_boxes(IntPtr temp, IntPtr duration, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tint_value_bins(IntPtr temp, int vsize, int vorigin, IntPtr count);
@@ -4210,304 +4213,19 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tint_value_split(IntPtr temp, int vsize, int vorigin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, long torigin, IntPtr count);
+            public static partial IntPtr tint_value_time_boxes(IntPtr temp, int vsize, IntPtr duration, int vorigin, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tint_value_time_split(IntPtr temp, int size, IntPtr duration, int vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, long torigin, IntPtr count);
+            public static partial IntPtr tintbox_time_tiles(IntPtr box, IntPtr duration, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tintbox_value_tiles(IntPtr box, int xsize, int xorigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, long torigin, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_subtype(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_subtype_all(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string tempsubtype_name(int subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tempsubtype_from_string(string str, IntPtr subtype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string meosoper_name(IntPtr oper);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr meosoper_from_string(string name);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string interptype_name(int interp);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int interptype_from_string(string interp_str);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial string meostype_name(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int temptype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int settype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spantype_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spantype_spansettype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spansettype_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int basetype_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int basetype_settype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geo_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool meos_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanum_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanum_temptype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool time_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_numset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timeset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool set_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_set_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool alphanumset_type(int settype);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool geoset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_geoset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatialset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_spatialset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_canon_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool type_span_bbox(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool span_tbox_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_span_tbox_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numspan_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool numspan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_numspan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespan_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespan_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool timespanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_timespanset_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temptype_continuous(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_byvalue(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool basetype_varlength(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial short basetype_length(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool talphanum_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool talpha_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tnumber_spantype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_basetype(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tspatial_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tspatial_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeo_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_type_all(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeo_type_all(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeometry_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeometry_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeodetic_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tgeodetic_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool ensure_tnumber_tpoint_type(int type);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int geo_get_srid(IntPtr g);
+            public static partial IntPtr tintbox_value_time_tiles(IntPtr box, int xsize, IntPtr duration, int xorigin, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_as_ewkb(IntPtr gs, string endian, IntPtr size);
@@ -4867,7 +4585,7 @@ namespace MEOS.NET.Internal
             public static partial string stbox_out(IntPtr box, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr geo_timestamptz_to_stbox(IntPtr gs, long t);
+            public static partial IntPtr geo_timestamptz_to_stbox(IntPtr gs, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_tstzspan_to_stbox(IntPtr gs, IntPtr s);
@@ -4897,7 +4615,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr stbox_to_tstzspan(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr timestamptz_to_stbox(long t);
+            public static partial IntPtr timestamptz_to_stbox(int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tstzset_to_stbox(IntPtr s);
@@ -4912,10 +4630,10 @@ namespace MEOS.NET.Internal
             public static partial double stbox_area(IntPtr box, [MarshalAs(UnmanagedType.U1)] bool spheroid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint stbox_hash(IntPtr box);
+            public static partial int stbox_hash(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong stbox_hash_extended(IntPtr box, ulong seed);
+            public static partial int stbox_hash_extended(IntPtr box, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -5166,7 +4884,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeo_from_base_temp(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeoinst_make(IntPtr gs, long t);
+            public static partial IntPtr tgeoinst_make(IntPtr gs, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseq_from_base_tstzset(IntPtr gs, IntPtr s);
@@ -5181,7 +4899,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tpoint_from_base_temp(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpointinst_make(IntPtr gs, long t);
+            public static partial IntPtr tpointinst_make(IntPtr gs, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tpointseq_from_base_tstzset(IntPtr gs, IntPtr s);
@@ -5260,7 +4978,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tgeo_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+            public static partial bool tgeo_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -5347,13 +5065,19 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeo_minus_value(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_at_geom(IntPtr temp, IntPtr gs, IntPtr zspan);
+            public static partial IntPtr tpoint_at_elevation(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_at_geom(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tpoint_at_value(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_minus_geom(IntPtr temp, IntPtr gs, IntPtr zspan);
+            public static partial IntPtr tpoint_minus_elevation(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_minus_geom(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tpoint_minus_value(IntPtr temp, IntPtr gs);
@@ -5413,7 +5137,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tgeo_space_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr tgeo_space_time_boxes(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeo_split_each_n_stboxes(IntPtr temp, int elem_count, IntPtr count);
@@ -5755,58 +5479,58 @@ namespace MEOS.NET.Internal
             public static partial int etouches_tpoint_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontains_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcontains_geo_tgeo(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontains_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcontains_tgeo_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontains_tgeo_tgeo(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcontains_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcovers_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcovers_geo_tgeo(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcovers_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcovers_tgeo_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcovers_tgeo_tgeo(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tcovers_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdisjoint_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdisjoint_geo_tgeo(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdisjoint_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdisjoint_tgeo_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdisjoint_tgeo_tgeo(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdisjoint_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdwithin_geo_tgeo(IntPtr gs, IntPtr temp, double dist, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdwithin_geo_tgeo(IntPtr gs, IntPtr temp, double dist);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tdwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintersects_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tintersects_geo_tgeo(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintersects_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tintersects_tgeo_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tintersects_tgeo_tgeo(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr tintersects_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ttouches_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr ttouches_geo_tgeo(IntPtr gs, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ttouches_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr ttouches_tgeo_geo(IntPtr temp, IntPtr gs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr ttouches_tgeo_tgeo(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool restr, [MarshalAs(UnmanagedType.U1)] bool atvalue);
+            public static partial IntPtr ttouches_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tdistance_tgeo_geo(IntPtr temp, IntPtr gs);
@@ -5854,25 +5578,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr stbox_get_space_tile(IntPtr point, double xsize, double ysize, double zsize, IntPtr sorigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_get_space_time_tile(IntPtr point, long t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin);
+            public static partial IntPtr stbox_get_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_get_time_tile(long t, IntPtr duration, long torigin);
+            public static partial IntPtr stbox_get_time_tile(int t, IntPtr duration, int torigin);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr stbox_space_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr stbox_space_time_tiles(IntPtr bounds, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, long torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
+            public static partial IntPtr stbox_time_tiles(IntPtr bounds, IntPtr duration, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeo_space_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr sorigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, long torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tgeo_space_time_split(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr space_bins, IntPtr time_bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geo_cluster_kmeans(IntPtr geoms, uint ngeoms, uint k);
@@ -5887,31 +5611,929 @@ namespace MEOS.NET.Internal
             public static partial IntPtr geo_cluster_within(IntPtr geoms, uint ngeoms, double tolerance, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbuffer_as_ewkt(IntPtr cb, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbuffer_as_hexwkb(IntPtr cb, IntPtr variant, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbuffer_as_text(IntPtr cb, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_as_wkb(IntPtr cb, IntPtr variant, IntPtr size_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_from_hexwkb(string hexwkb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_from_wkb(IntPtr wkb, ulong size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbuffer_out(IntPtr cb, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_copy(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_make(IntPtr point, double radius);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_to_geom(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_to_stbox(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferarr_to_geom(IntPtr cbarr, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geom_to_cbuffer(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_hash(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_hash_extended(IntPtr cb, int seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_point(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double cbuffer_radius(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_round(IntPtr cb, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferarr_round(IntPtr cbarr, int count, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void cbuffer_set_srid(IntPtr cb, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_srid(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_transform(IntPtr cb, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_transform_pipeline(IntPtr cb, string pipelinestr, int srid, [MarshalAs(UnmanagedType.U1)] bool is_forward);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int contains_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int covers_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int disjoint_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int dwithin_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int intersects_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int touches_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_tstzspan_to_stbox(IntPtr cb, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_timestamptz_to_stbox(IntPtr cb, int t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_cbuffer_geo(IntPtr cb, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_cbuffer_stbox(IntPtr cb, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_cbuffer_stbox(IntPtr cb, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_cmp(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_eq(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_ge(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_gt(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_le(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_lt(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_ne(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_nsame(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_same(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferset_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbufferset_out(IntPtr s, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferset_make(IntPtr values, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_to_set(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferset_end_value(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferset_start_value(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbufferset_value_n(IntPtr s, int n, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbufferset_values(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_union_transfn(IntPtr state, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_cbuffer_set(IntPtr cb, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_set_cbuffer(IntPtr s, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr intersection_cbuffer_set(IntPtr cb, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr intersection_set_cbuffer(IntPtr s, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr minus_cbuffer_set(IntPtr cb, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr minus_set_cbuffer(IntPtr s, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr union_cbuffer_set(IntPtr cb, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr union_set_cbuffer(IntPtr s, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_make(IntPtr tpoint, IntPtr tfloat);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_points(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_radius(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_trav_area(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool merge_union);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_to_tfloat(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_to_tgeompoint(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeometry_to_tcbuffer(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_expand(IntPtr temp, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_at_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_at_geom(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_at_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_minus_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_minus_geom(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_minus_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tcbuffer_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acontains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acontains_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acontains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acontains_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acovers_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int acovers_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adisjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int adwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int aintersects_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int aintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int aintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int atouches_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int atouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int atouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int econtains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int econtains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int econtains_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ecovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ecovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ecovers_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ecovers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int edisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int edisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int edwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int edwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int edwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eintersects_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int etouches_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int etouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int etouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontains_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontains_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontains_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcovers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcovers_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcovers_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcovers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcovers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_geo_tcbuffer(IntPtr gs, IntPtr temp, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_tcbuffer_geo(IntPtr temp, IntPtr gs, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdisjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdisjoint_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdisjoint_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdisjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdisjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tintersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tintersects_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tintersects_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tintersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tintersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ttouches_geo_tcbuffer(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ttouches_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ttouches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ttouches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ttouches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_cbuffer_cbuffer(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_cbuffer_geo(IntPtr cb, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_cbuffer_stbox(IntPtr cb, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_cbufferset_cbuffer(IntPtr s, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_collinear(IntPtr cb1, IntPtr cb2, IntPtr cbuf3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffersegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffersegm_locate(IntPtr start, IntPtr end, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string cbuffer_wkt_out(int value, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_point_p(IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_round(int buffer, int size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr cbuffer_transf_pj(IntPtr cb, int srid_to, IntPtr pj);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double cbuffer_distance(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_distance(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_contains(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_covers(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_disjoint(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_intersects(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_dwithin(IntPtr cb1, IntPtr cb2, double dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int cbuffer_touches(IntPtr cb1, IntPtr cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_contains(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_covers(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_disjoint(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_intersects(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_dwithin(int cb1, int cb2, int dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cbuffer_touches(int cb1, int cb2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_subtype(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_subtype_all(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string tempsubtype_name(int subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tempsubtype_from_string(string str, IntPtr subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string meosoper_name(IntPtr oper);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr meosoper_from_string(string name);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string interptype_name(int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int interptype_from_string(string interp_str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string meostype_name(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int temptype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int settype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spantype_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spantype_spansettype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spansettype_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int basetype_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int basetype_settype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geo_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool meos_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanum_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanum_temptype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool time_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_numset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timeset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_set_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool alphanumset_type(int settype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geoset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_geoset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spatialset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_spatialset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_canon_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool type_span_bbox(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_tbox_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_span_tbox_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numspan_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool numspan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_numspan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespan_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespan_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool timespanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_timespanset_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temporal_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temporal_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temptype_supports_linear(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_byvalue(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_varlength(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial short meostype_length(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool talphanum_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool talpha_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumber_spantype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spatial_basetype(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tspatial_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tspatial_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeo_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeo_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeo_type_all(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeo_type_all(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeometry_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeometry_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tgeodetic_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tgeodetic_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_tnumber_tpoint_type(int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr gsl_get_generation_rng();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr gsl_get_aggregation_rng();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_ceil(ulong d);
+            public static partial int datum_ceil(IntPtr d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_degrees(ulong d, ulong normalize);
+            public static partial int datum_degrees(IntPtr d, IntPtr normalize);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_float_round(ulong value, ulong size);
+            public static partial int datum_float_round(IntPtr value, IntPtr size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_floor(ulong d);
+            public static partial int datum_floor(IntPtr d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint datum_hash(ulong d, int basetype);
+            public static partial int datum_hash(IntPtr d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_hash_extended(ulong d, int basetype, ulong seed);
+            public static partial int datum_hash_extended(IntPtr d, int basetype, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_radians(ulong d);
+            public static partial int datum_radians(IntPtr d);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void floatspan_round_set(IntPtr s, int maxdd, IntPtr result);
@@ -5944,10 +6566,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_make_free(IntPtr values, int count, int basetype, [MarshalAs(UnmanagedType.U1)] bool order);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr span_make(ulong lower, ulong upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype);
+            public static partial IntPtr span_make(IntPtr lower, IntPtr upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void span_set(ulong lower, ulong upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype, int spantype, IntPtr s);
+            public static partial void span_set(IntPtr lower, IntPtr upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int basetype, int spantype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr spanset_make_exp(IntPtr spans, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize, [MarshalAs(UnmanagedType.U1)] bool order);
@@ -5962,25 +6584,25 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_spanset(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void value_set_span(ulong value, int basetype, IntPtr s);
+            public static partial void value_set_span(IntPtr value, int basetype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_set(ulong d, int basetype);
+            public static partial IntPtr value_set(IntPtr d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_span(ulong d, int basetype);
+            public static partial IntPtr value_span(IntPtr d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_spanset(ulong d, int basetype);
+            public static partial IntPtr value_spanset(IntPtr d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong numspan_width(IntPtr s);
+            public static partial int numspan_width(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong numspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
+            public static partial int numspanset_width(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong set_end_value(IntPtr s);
+            public static partial int set_end_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int set_mem_size(IntPtr s);
@@ -5992,7 +6614,7 @@ namespace MEOS.NET.Internal
             public static partial void set_set_span(IntPtr s, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong set_start_value(IntPtr s);
+            public static partial int set_start_value(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6005,7 +6627,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr set_values(IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong spanset_lower(IntPtr ss);
+            public static partial int spanset_lower(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int spanset_mem_size(IntPtr ss);
@@ -6014,7 +6636,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_sps(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong spanset_upper(IntPtr ss);
+            public static partial int spanset_upper(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void datespan_set_tstzspan(IntPtr s1, IntPtr s2);
@@ -6026,16 +6648,16 @@ namespace MEOS.NET.Internal
             public static partial void intspan_set_floatspan(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numset_shift_scale(IntPtr s, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numset_shift_scale(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_expand(IntPtr s, ulong value);
+            public static partial IntPtr numspan_expand(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspan_shift_scale(IntPtr s, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numspan_shift_scale(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr numspanset_shift_scale(IntPtr ss, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr numspanset_shift_scale(IntPtr ss, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr set_compact(IntPtr s);
@@ -6047,7 +6669,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr spanset_compact(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_expand_value(IntPtr box, ulong value, int basetyp);
+            public static partial IntPtr tbox_expand_value(IntPtr box, IntPtr value, int basetyp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr textcat_textset_text_common(IntPtr s, IntPtr txt, [MarshalAs(UnmanagedType.U1)] bool invert);
@@ -6057,39 +6679,39 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_span_value(IntPtr s, ulong value);
+            public static partial bool adjacent_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_spanset_value(IntPtr ss, ulong value);
+            public static partial bool adjacent_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool adjacent_value_spanset(ulong value, IntPtr ss);
+            public static partial bool adjacent_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_set(ulong value, IntPtr s);
+            public static partial bool contained_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_span(ulong value, IntPtr s);
+            public static partial bool contained_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contained_value_spanset(ulong value, IntPtr ss);
+            public static partial bool contained_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_set_value(IntPtr s, ulong value);
+            public static partial bool contains_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_span_value(IntPtr s, ulong value);
+            public static partial bool contains_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool contains_spanset_value(IntPtr ss, ulong value);
+            public static partial bool contains_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6097,27 +6719,27 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_set_value(IntPtr s, ulong value);
+            public static partial bool left_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_span_value(IntPtr s, ulong value);
+            public static partial bool left_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_spanset_value(IntPtr ss, ulong value);
+            public static partial bool left_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_set(ulong value, IntPtr s);
+            public static partial bool left_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_span(ulong value, IntPtr s);
+            public static partial bool left_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool left_value_spanset(ulong value, IntPtr ss);
+            public static partial bool left_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6125,75 +6747,75 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_set_value(IntPtr s, ulong value);
+            public static partial bool overleft_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_span_value(IntPtr s, ulong value);
+            public static partial bool overleft_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_spanset_value(IntPtr ss, ulong value);
+            public static partial bool overleft_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_set(ulong value, IntPtr s);
+            public static partial bool overleft_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_span(ulong value, IntPtr s);
+            public static partial bool overleft_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overleft_value_spanset(ulong value, IntPtr ss);
+            public static partial bool overleft_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_set_value(IntPtr s, ulong value);
+            public static partial bool overright_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_span_value(IntPtr s, ulong value);
+            public static partial bool overright_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_spanset_value(IntPtr ss, ulong value);
+            public static partial bool overright_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_set(ulong value, IntPtr s);
+            public static partial bool overright_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_span(ulong value, IntPtr s);
+            public static partial bool overright_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool overright_value_spanset(ulong value, IntPtr ss);
+            public static partial bool overright_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_set(ulong value, IntPtr s);
+            public static partial bool right_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_set_value(IntPtr s, ulong value);
+            public static partial bool right_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_span(ulong value, IntPtr s);
+            public static partial bool right_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_value_spanset(ulong value, IntPtr ss);
+            public static partial bool right_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_span_value(IntPtr s, ulong value);
+            public static partial bool right_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool right_spanset_value(IntPtr ss, ulong value);
+            public static partial bool right_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6220,100 +6842,100 @@ namespace MEOS.NET.Internal
             public static partial bool inter_span_span(IntPtr s1, IntPtr s2, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_set_value(IntPtr s, ulong value);
+            public static partial IntPtr intersection_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_span_value(IntPtr s, ulong value);
+            public static partial IntPtr intersection_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_spanset_value(IntPtr ss, ulong value);
+            public static partial IntPtr intersection_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_set(ulong value, IntPtr s);
+            public static partial IntPtr intersection_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_span(ulong value, IntPtr s);
+            public static partial IntPtr intersection_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr intersection_value_spanset(ulong value, IntPtr ss);
+            public static partial IntPtr intersection_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int mi_span_span(IntPtr s1, IntPtr s2, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_set_value(IntPtr s, ulong value);
+            public static partial IntPtr minus_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_span_value(IntPtr s, ulong value);
+            public static partial IntPtr minus_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_spanset_value(IntPtr ss, ulong value);
+            public static partial IntPtr minus_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_set(ulong value, IntPtr s);
+            public static partial IntPtr minus_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_span(ulong value, IntPtr s);
+            public static partial IntPtr minus_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr minus_value_spanset(ulong value, IntPtr ss);
+            public static partial IntPtr minus_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr super_union_span_span(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_set_value(IntPtr s, ulong value);
+            public static partial IntPtr union_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_span_value(IntPtr s, ulong value);
+            public static partial IntPtr union_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_spanset_value(IntPtr ss, ulong value);
+            public static partial IntPtr union_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_set(ulong value, IntPtr s);
+            public static partial IntPtr union_value_set(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_span(ulong value, IntPtr s);
+            public static partial IntPtr union_value_span(IntPtr value, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr union_value_spanset(ulong value, IntPtr ss);
+            public static partial IntPtr union_value_spanset(IntPtr value, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_set_set(IntPtr s1, IntPtr s2);
+            public static partial int distance_set_set(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_set_value(IntPtr s, ulong value);
+            public static partial int distance_set_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_span_span(IntPtr s1, IntPtr s2);
+            public static partial int distance_span_span(IntPtr s1, IntPtr s2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_span_value(IntPtr s, ulong value);
+            public static partial int distance_span_value(IntPtr s, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_spanset_span(IntPtr ss, IntPtr s);
+            public static partial int distance_spanset_span(IntPtr ss, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_spanset_spanset(IntPtr ss1, IntPtr ss2);
+            public static partial int distance_spanset_spanset(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_spanset_value(IntPtr ss, ulong value);
+            public static partial int distance_spanset_value(IntPtr ss, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong distance_value_value(ulong l, ulong r, int basetype);
+            public static partial int distance_value_value(IntPtr l, IntPtr r, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanbase_extent_transfn(IntPtr state, ulong value, int basetype);
+            public static partial IntPtr spanbase_extent_transfn(IntPtr state, IntPtr value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr value_union_transfn(IntPtr state, ulong value, int basetype);
+            public static partial IntPtr value_union_transfn(IntPtr state, IntPtr value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_tstzspan_to_tbox(ulong d, int basetype, IntPtr s);
+            public static partial IntPtr number_tstzspan_to_tbox(IntPtr d, int basetype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_timestamptz_to_tbox(ulong d, int basetype, long t);
+            public static partial IntPtr number_timestamptz_to_tbox(IntPtr d, int basetype, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tbox_set(IntPtr s, IntPtr p, IntPtr box);
@@ -6325,10 +6947,10 @@ namespace MEOS.NET.Internal
             public static partial void int_set_tbox(int i, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void number_set_tbox(ulong d, int basetype, IntPtr box);
+            public static partial void number_set_tbox(IntPtr d, int basetype, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr number_tbox(ulong value, int basetype);
+            public static partial IntPtr number_tbox(IntPtr value, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void numset_set_tbox(IntPtr s, IntPtr box);
@@ -6337,7 +6959,7 @@ namespace MEOS.NET.Internal
             public static partial void numspan_set_tbox(IntPtr span, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void timestamptz_set_tbox(long t, IntPtr box);
+            public static partial void timestamptz_set_tbox(int t, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tstzset_set_tbox(IntPtr s, IntPtr box);
@@ -6346,7 +6968,7 @@ namespace MEOS.NET.Internal
             public static partial void tstzspan_set_tbox(IntPtr s, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_shift_scale_value(IntPtr box, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tbox_shift_scale_value(IntPtr box, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tbox_expand(IntPtr box1, IntPtr box2);
@@ -6467,28 +7089,28 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_from_mfjson(string mfjson, int temptype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_from_base_temp(ulong value, int temptype, IntPtr temp);
+            public static partial IntPtr temporal_from_base_temp(IntPtr value, int temptype, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_copy(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_make(ulong value, int temptype, long t);
+            public static partial IntPtr tinstant_make(IntPtr value, int temptype, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_make_free(ulong value, int temptype, long t);
+            public static partial IntPtr tinstant_make_free(IntPtr value, int temptype, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_copy(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_temp(ulong value, int temptype, IntPtr seq);
+            public static partial IntPtr tsequence_from_base_temp(IntPtr value, int temptype, IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_tstzset(ulong value, int temptype, IntPtr s);
+            public static partial IntPtr tsequence_from_base_tstzset(IntPtr value, int temptype, IntPtr s);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_from_base_tstzspan(ulong value, int temptype, IntPtr s, int interp);
+            public static partial IntPtr tsequence_from_base_tstzspan(IntPtr value, int temptype, IntPtr s, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_make_exp(IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
@@ -6503,10 +7125,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tseqsetarr_to_tseqset(IntPtr seqsets, int count, int totalseqs);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_from_base_temp(ulong value, int temptype, IntPtr ss);
+            public static partial IntPtr tsequenceset_from_base_temp(IntPtr value, int temptype, IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_from_base_tstzspanset(ulong value, int temptype, IntPtr ss, int interp);
+            public static partial IntPtr tsequenceset_from_base_tstzspanset(IntPtr value, int temptype, IntPtr ss, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_make_exp(IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
@@ -6542,7 +7164,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_end_inst(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong temporal_end_value(IntPtr temp);
+            public static partial int temporal_end_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_inst_n(IntPtr temp, int n);
@@ -6554,7 +7176,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_max_inst_p(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong temporal_max_value(IntPtr temp);
+            public static partial int temporal_max_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial ulong temporal_mem_size(IntPtr temp);
@@ -6563,7 +7185,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_min_inst_p(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong temporal_min_value(IntPtr temp);
+            public static partial int temporal_min_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_sequences_p(IntPtr temp, IntPtr count);
@@ -6575,7 +7197,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_start_inst(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong temporal_start_value(IntPtr temp);
+            public static partial int temporal_start_value(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_values_p(IntPtr temp, IntPtr count);
@@ -6588,7 +7210,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_values(IntPtr temp, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint tinstant_hash(IntPtr inst);
+            public static partial int tinstant_hash(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_insts(IntPtr inst, IntPtr count);
@@ -6603,14 +7225,14 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_timestamps(IntPtr inst, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tinstant_value_p(IntPtr inst);
+            public static partial int tinstant_value_p(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tinstant_value(IntPtr inst);
+            public static partial int tinstant_value(IntPtr inst);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tinstant_value_at_timestamptz(IntPtr inst, long t, IntPtr result);
+            public static partial bool tinstant_value_at_timestamptz(IntPtr inst, int t, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_values_p(IntPtr inst, IntPtr count);
@@ -6637,10 +7259,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_duration(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tsequence_end_timestamptz(IntPtr seq);
+            public static partial int tsequence_end_timestamptz(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint tsequence_hash(IntPtr seq);
+            public static partial int tsequence_hash(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_insts_p(IntPtr seq);
@@ -6649,13 +7271,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_max_inst_p(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tsequence_max_val(IntPtr seq);
+            public static partial int tsequence_max_val(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_min_inst_p(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tsequence_min_val(IntPtr seq);
+            public static partial int tsequence_min_val(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_segments(IntPtr seq, IntPtr count);
@@ -6664,7 +7286,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_seqs(IntPtr seq, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tsequence_start_timestamptz(IntPtr seq);
+            public static partial int tsequence_start_timestamptz(IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_time(IntPtr seq);
@@ -6674,7 +7296,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequence_value_at_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool tsequence_value_at_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_values_p(IntPtr seq, IntPtr count);
@@ -6683,10 +7305,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_duration(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool boundspan);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tsequenceset_end_timestamptz(IntPtr ss);
+            public static partial int tsequenceset_end_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint tsequenceset_hash(IntPtr ss);
+            public static partial int tsequenceset_hash(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_inst_n(IntPtr ss, int n);
@@ -6698,13 +7320,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_max_inst_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tsequenceset_max_val(IntPtr ss);
+            public static partial int tsequenceset_max_val(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_min_inst_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong tsequenceset_min_val(IntPtr ss);
+            public static partial int tsequenceset_min_val(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tsequenceset_num_instants(IntPtr ss);
@@ -6719,7 +7341,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_sequences_p(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tsequenceset_start_timestamptz(IntPtr ss);
+            public static partial int tsequenceset_start_timestamptz(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_time(IntPtr ss);
@@ -6733,7 +7355,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool tsequenceset_value_at_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool tsequenceset_value_at_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
@@ -6764,16 +7386,16 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_to_tsequenceset(IntPtr inst, int interp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_shift_scale_value(IntPtr temp, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumber_shift_scale_value(IntPtr temp, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberinst_shift_value(IntPtr inst, ulong shift);
+            public static partial IntPtr tnumberinst_shift_value(IntPtr inst, IntPtr shift);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseq_shift_scale_value(IntPtr seq, ulong shift, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumberseq_shift_scale_value(IntPtr seq, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumberseqset_shift_scale_value(IntPtr ss, ulong start, ulong width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+            public static partial IntPtr tnumberseqset_shift_scale_value(IntPtr ss, IntPtr start, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tsequence_restart(IntPtr seq, int count);
@@ -6836,7 +7458,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_append_tsequence(IntPtr seq1, IntPtr seq2, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_delete_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool connect);
+            public static partial IntPtr tsequence_delete_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_delete_tstzset(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
@@ -6863,7 +7485,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_append_tsequence(IntPtr ss, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_delete_timestamptz(IntPtr ss, long t);
+            public static partial IntPtr tsequenceset_delete_timestamptz(IntPtr ss, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_delete_tstzset(IntPtr ss, IntPtr s);
@@ -6896,19 +7518,19 @@ namespace MEOS.NET.Internal
             public static partial void tsequenceset_set_bbox(IntPtr ss, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_after_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tcontseq_after_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tcontseq_before_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tcontseq_before_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tcontseq_restrict_minmax(IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_after_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tdiscseq_after_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdiscseq_before_timestamptz(IntPtr seq, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tdiscseq_before_timestamptz(IntPtr seq, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tdiscseq_restrict_minmax(IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -6921,7 +7543,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_restrict_minmax(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_restrict_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr temporal_restrict_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_restrict_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -6933,20 +7555,20 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_restrict_tstzspanset(IntPtr temp, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr temporal_restrict_value(IntPtr temp, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr temporal_restrict_value(IntPtr temp, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr temporal_restrict_values(IntPtr temp, IntPtr set, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool temporal_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+            public static partial bool temporal_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_after_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tinstant_after_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_before_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tinstant_before_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_tstzspan(IntPtr inst, IntPtr period, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -6955,13 +7577,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tinstant_restrict_tstzspanset(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_restrict_timestamptz(IntPtr inst, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tinstant_restrict_timestamptz(IntPtr inst, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_tstzset(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tinstant_restrict_value(IntPtr inst, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tinstant_restrict_value(IntPtr inst, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tinstant_restrict_values(IntPtr inst, IntPtr set, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -6985,7 +7607,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnumberseqset_restrict_spanset(IntPtr ss, IntPtr spanset, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequence_at_timestamptz(IntPtr seq, long t);
+            public static partial IntPtr tsequence_at_timestamptz(IntPtr seq, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequence_restrict_tstzspan(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -6994,10 +7616,10 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequence_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_after_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tsequenceset_after_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_before_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool strict);
+            public static partial IntPtr tsequenceset_before_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_minmax(IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7009,13 +7631,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tsequenceset_restrict_tstzspanset(IntPtr ss, IntPtr ps, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, long t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tsequenceset_restrict_timestamptz(IntPtr ss, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_tstzset(IntPtr ss, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tsequenceset_restrict_value(IntPtr ss, ulong value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tsequenceset_restrict_value(IntPtr ss, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tsequenceset_restrict_values(IntPtr ss, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
@@ -7042,76 +7664,76 @@ namespace MEOS.NET.Internal
             public static partial bool tsequenceset_eq(IntPtr ss1, IntPtr ss2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_eq_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_eq_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_eq_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_eq_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ne_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_ne_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ne_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_ne_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ge_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_ge_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_ge_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_ge_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_gt_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_gt_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_gt_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_gt_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_le_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_le_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_le_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_le_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_lt_base_temporal(ulong value, IntPtr temp);
+            public static partial int always_lt_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int always_lt_temporal_base(IntPtr temp, ulong value);
+            public static partial int always_lt_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_eq_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_eq_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_eq_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_eq_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ne_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_ne_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ne_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_ne_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ge_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_ge_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_ge_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_ge_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_gt_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_gt_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_gt_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_gt_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_le_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_le_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_le_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_le_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_lt_base_temporal(ulong value, IntPtr temp);
+            public static partial int ever_lt_base_temporal(IntPtr value, IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int ever_lt_temporal_base(IntPtr temp, ulong value);
+            public static partial int ever_lt_temporal_base(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tnumberinst_abs(IntPtr inst);
@@ -7135,13 +7757,13 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnumberseqset_delta_value(IntPtr ss);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tdistance_tnumber_number(IntPtr temp, ulong value);
+            public static partial IntPtr tdistance_tnumber_number(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nad_tbox_tbox(IntPtr box1, IntPtr box2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double nad_tnumber_number(IntPtr temp, ulong value);
+            public static partial double nad_tnumber_number(IntPtr temp, IntPtr value);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nad_tnumber_tbox(IntPtr temp, IntPtr box);
@@ -7201,31 +7823,1055 @@ namespace MEOS.NET.Internal
             public static partial IntPtr temporal_app_tseq_transfn(IntPtr state, IntPtr seq);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr span_bins(IntPtr s, ulong size, ulong origin, IntPtr count);
+            public static partial IntPtr span_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr spanset_bins(IntPtr ss, ulong size, ulong origin, IntPtr count);
+            public static partial IntPtr spanset_bins(IntPtr ss, IntPtr size, IntPtr origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_bins(IntPtr temp, ulong size, ulong origin, IntPtr count);
+            public static partial IntPtr tnumber_value_bins(IntPtr temp, IntPtr size, IntPtr origin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_time_boxes(IntPtr temp, ulong vsize, IntPtr duration, ulong vorigin, long torigin, IntPtr count);
+            public static partial IntPtr tnumber_value_time_boxes(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_split(IntPtr temp, ulong vsize, ulong vorigin, IntPtr bins, IntPtr count);
+            public static partial IntPtr tnumber_value_split(IntPtr temp, IntPtr vsize, IntPtr vorigin, IntPtr bins, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tbox_get_value_time_tile(ulong value, long t, ulong vsize, IntPtr duration, ulong vorigin, long torigin, int basetype, int spantype);
+            public static partial IntPtr tbox_get_value_time_tile(IntPtr value, int t, IntPtr vsize, IntPtr duration, IntPtr vorigin, int torigin, int basetype, int spantype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnumber_value_time_split(IntPtr temp, ulong size, IntPtr duration, ulong vorigin, long torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+            public static partial IntPtr tnumber_value_time_split(IntPtr temp, IntPtr size, IntPtr duration, IntPtr vorigin, int torigin, IntPtr value_bins, IntPtr time_bins, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string double2_out(IntPtr d, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void double2_set(double a, double b, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double2_add(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double2_eq(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string double3_out(IntPtr d, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void double3_set(double a, double b, double c, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double3_add(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double3_eq(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string double4_out(IntPtr d, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void double4_set(double a, double b, double c, double d, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double4_add(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double4_eq(IntPtr d1, IntPtr d2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double2_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double3_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double4_collinear(IntPtr x1, IntPtr x2, IntPtr x3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double2segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double3segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr double4segm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pg_atoi(string s, int size, int c);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_X(int type, short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_Z(int type, short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_T(int type, short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_not_Z(int type, short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_null(IntPtr ptr);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_one_not_null(IntPtr ptr1, IntPtr ptr2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_one_true([MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_interp(int temptype, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_continuous(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_interp(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_continuous_interp(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_linear_interp(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_nonlinear_interp(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_common_dimension(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_temporal_isof_type(IntPtr temp, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_temporal_isof_basetype(IntPtr temp, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_temporal_isof_subtype(IntPtr temp, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_temporal_type(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnumber_numspan(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnumber_numspanset(IntPtr temp, IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnumber_tbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_temporal_set(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_temporal_temporal(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnumber_tnumber(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_negative(int i);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_positive(int i);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool not_negative_datum(IntPtr size, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_negative_datum(IntPtr size, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool positive_datum(IntPtr size, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_positive_datum(IntPtr size, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_day_duration(IntPtr duration);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool positive_duration(IntPtr duration);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_positive_duration(IntPtr duration);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_bbox_ptr(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr mode, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string mobilitydb_version();
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string mobilitydb_full_version();
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr round_fn(int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool temporal_bbox_restrict_value(IntPtr temp, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tcbuffer_cbuffer(IntPtr temp, IntPtr cb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tcbuffer_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tcbuffer_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcbuffersegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcbuffersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcbuffersegm_dwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcbuffersegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr dist, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_set_stbox(IntPtr cb, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void cbufferarr_set_stbox(IntPtr values, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_timestamptz_set_stbox(IntPtr cb, int t, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool cbuffer_tstzspan_set_stbox(IntPtr cb, IntPtr s, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tcbufferinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tcbufferinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tcbufferseq_expand_stbox(IntPtr seq, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbufferinst_trav_area(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbufferseq_trav_area(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbufferseqset_trav_area(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffersegm_trav_area(IntPtr inst1, IntPtr inst2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_restrict_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcbuffer_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_geo_tcbuffer(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_cbuffer_tcbuffer(IntPtr cb, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tcbuffer_tcbuffer(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinterrel_tcbuffer_cbuffer(IntPtr temp, IntPtr cb, [MarshalAs(UnmanagedType.U1)] bool tinter);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinterrel_tcbuffer_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool tinter);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int lwproj_lookup(int srid_from, int srid_to, IntPtr pj);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spheroid_init_from_srid(int srid, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void srid_check_latlong(int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int srid_is_latlong(int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geom_serialize(IntPtr lwgeom);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geog_serialize(IntPtr lwgeom);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr postgis_valid_typmod(IntPtr gs, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string geo_as_wkt(IntPtr gs, int precision, [MarshalAs(UnmanagedType.U1)] bool extended);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr box2d_to_lwgeom(IntPtr box, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr box3d_to_lwgeom(IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr POSTGIS2GEOS(IntPtr pglwgeom);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr GEOS2POSTGIS(IntPtr geom, byte want3d);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geom_spatialrel(IntPtr gs1, IntPtr gs2, IntPtr rel);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwgeom_line_interpolate_point(IntPtr geom, double fraction, int srid, byte repeat);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void point_get_coords(IntPtr point, [MarshalAs(UnmanagedType.U1)] bool hasz, IntPtr x, IntPtr y, IntPtr z);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tstzset_stbox_slice(IntPtr tsdatum, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tstzspanset_stbox_slice(IntPtr psdatum, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool stbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool stbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool stbox_index_recheck(int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void mobilitydb_init();
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_stbox(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr stbox_geo(IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcomp_geo_tgeo(IntPtr gs, IntPtr temp, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_geoaggstate(IntPtr state, int srid, [MarshalAs(UnmanagedType.U1)] bool hasz);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_geoaggstate_state(IntPtr state1, IntPtr state2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_transform_tcentroid(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpointinst_tcentroid_finalfn(IntPtr instants, int count, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpointseq_tcentroid_finalfn(IntPtr sequences, int count, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool point3d_min_dist(IntPtr p1, IntPtr p2, IntPtr p3, IntPtr p4, IntPtr fraction);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tgeompointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tgeogpointsegm_distance_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double tnumberinst_distance(IntPtr inst1, IntPtr inst2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double tinstant_distance(IntPtr inst1, IntPtr inst2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpointseq_at_geom(IntPtr seq, IntPtr gs, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpointseq_interperiods(IntPtr seq, IntPtr gs, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void datum_point4d(IntPtr value, IntPtr p);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int geopoint_cmp(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geopoint_eq(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geopoint_same(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_point_eq(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_point_same(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_point_eq(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_point_ne(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_point_same(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_point_nsame(IntPtr point1, IntPtr point2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_geom_centroid(IntPtr geo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_geog_centroid(IntPtr geo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_extract_elements(IntPtr gs, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_serialize(IntPtr geom);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_distance_fn(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pt_distance_fn(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_distance2d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_distance3d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geog_distance(IntPtr geog1, IntPtr geog2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_pt_distance2d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_pt_distance3d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial short spatial_flags(IntPtr d, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_srid_is_latlong(int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_spatial_validity(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_geodetic(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geodetic(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geodetic_geo(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geodetic_tspatial_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geodetic_tspatial_base(IntPtr temp, IntPtr @base);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_srid_known(int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_srid(int srid1, int srid2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_dimensionality(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_spatial_dimensionality(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_spatial_dimensionality(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_dimensionality_geo(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_dimensionality_tspatial_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_spatial_dimensionality_stbox_geo(IntPtr box, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geodetic_stbox_geo(IntPtr box, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_Z_geo(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_not_Z_geo(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_M_geo(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_not_M_geo(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_geodetic_geo(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_point_type(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_mline_type(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool circle_type(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_circle_type(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_not_empty(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_stbox_geo(IntPtr box, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tspatial_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tspatial_base(IntPtr temp, IntPtr @base);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tspatial_tspatial(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_spatial_stbox_stbox(IntPtr box1, IntPtr box2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tgeo_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_geo_geo(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tgeo_tgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpoint_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpoint_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool mline_type(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_get_coord(IntPtr temp, int coord);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eacomp_tgeo_geo(IntPtr temp, IntPtr gs, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr closest_point2d_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr closest_point3dz_on_segment_ratio(IntPtr p, IntPtr A, IntPtr B, IntPtr closest);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr closest_point_on_segment_sphere(IntPtr p, IntPtr A, IntPtr B, IntPtr closest, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void interpolate_point4d_spheroid(IntPtr p1, IntPtr p2, IntPtr p, IntPtr s, double f);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geopoint_make(double x, double y, double z, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool geodetic, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwcircle_make(double x, double y, double radius, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geocircle_make(double x, double y, double radius, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pointsegm_locate(IntPtr start, IntPtr end, IntPtr point, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tgeompointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tgeogpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geopoint_collinear(IntPtr value1, IntPtr value2, IntPtr value3, double ratio, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool geodetic);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwpointarr_remove_duplicates(IntPtr points, int count, IntPtr newcount);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwpointarr_make_trajectory(IntPtr points, int count, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwline_make(IntPtr value1, IntPtr value2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr lwcoll_from_points_lines(IntPtr points, IntPtr lines, int npoints, int nlines);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tpointseq_stops_iter(IntPtr seq, double maxdist, int mintunits, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_contains(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_covers(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_disjoint2d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_disjoint3d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geog_disjoint(IntPtr geog1, IntPtr geog2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_intersects2d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_intersects3d(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geog_intersects(IntPtr geog1, IntPtr geog2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_touches(IntPtr geom1, IntPtr geom2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_dwithin2d(IntPtr geom1, IntPtr geom2, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_dwithin3d(IntPtr geom1, IntPtr geom2, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geog_dwithin(IntPtr geog1, IntPtr geog2, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_geom_relate_pattern(IntPtr geog1, IntPtr geog2, IntPtr p);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_disjoint_fn(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_disjoint_fn_geo(short flags1, IntPtr flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_intersects_fn(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_intersects_fn_geo(short flags1, IntPtr flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_dwithin_fn(short flags1, short flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_dwithin_fn_geo(short flags1, IntPtr flags2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tpointsegm_tdwithin_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spatialrel_geo_geo(IntPtr gs1, IntPtr gs2, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int spatialrel_tgeo_tgeo(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_geo_tgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_intersects_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tpoint_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_touches_tgeo_tgeo(IntPtr temp, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_dwithin_tgeo_geo(IntPtr temp, IntPtr gs, double dist, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_dwithin_tgeo_tgeo(IntPtr temp1, IntPtr temp2, double dist, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_spatialrel_tspatial_geo(IntPtr temp, IntPtr gs, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_spatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialrel_tspatial_base(IntPtr temp, IntPtr @base, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr param, IntPtr func, int numparam, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinterrel_tgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool tinter);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinterrel_tspatial_base(IntPtr temp, IntPtr @base, [MarshalAs(UnmanagedType.U1)] bool tinter, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinterrel_tspatial_tspatial(IntPtr temp1, IntPtr temp2, [MarshalAs(UnmanagedType.U1)] bool tinter);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_tspatial_tspatial(IntPtr sync1, IntPtr sync2, IntPtr dist, IntPtr func, IntPtr tpfn);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tdwithin_add_solutions(int solutions, int lower, int upper, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc1, int t1, int t2, IntPtr instants, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdwithin_tspatial_spatial(IntPtr temp, IntPtr @base, IntPtr dist, IntPtr func, IntPtr tpfn);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr bitmatrix_make(IntPtr count, int ndims);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tpoint_set_tiles(IntPtr temp, IntPtr state, IntPtr bm);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_at_tile(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void stbox_tile_state_set(double x, double y, double z, int t, double xsize, double ysize, double zsize, int tunits, [MarshalAs(UnmanagedType.U1)] bool hasx, [MarshalAs(UnmanagedType.U1)] bool hasz, [MarshalAs(UnmanagedType.U1)] bool hast, int srid, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr stbox_tile_state_make(IntPtr temp, IntPtr box, double xsize, double ysize, double zsize, IntPtr duration, int sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool border_inc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void stbox_tile_state_next(IntPtr state);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool stbox_tile_state_get(IntPtr state, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeo_space_time_tile_init(IntPtr temp, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool bitmatrix, [MarshalAs(UnmanagedType.U1)] bool border_inc, IntPtr ntiles);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr stbox_space_time_tile(IntPtr point, int t, double xsize, double ysize, double zsize, IntPtr duration, IntPtr sorigin, int torigin, [MarshalAs(UnmanagedType.U1)] bool hasx, [MarshalAs(UnmanagedType.U1)] bool hast);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr create_trip(IntPtr lines, IntPtr maxSpeeds, IntPtr categories, uint noEdges, int startTime, [MarshalAs(UnmanagedType.U1)] bool disturbData, int verbosity);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr spatialarr_wkt_out(IntPtr spatialarr, int basetype, int count, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string spatialbase_as_text(IntPtr value, int type, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string spatialbase_as_ewkt(IntPtr value, int type, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool point_transf_pj(IntPtr gs, int srid_to, IntPtr pj);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tgeoinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tgeoinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tgeoseq_expand_stbox(IntPtr seq, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tspatialinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tspatialinstarr_set_stbox(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tspatialseqarr_set_stbox(IntPtr sequences, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tspatialseq_expand_stbox(IntPtr seq, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void spatialarr_set_bbox(IntPtr values, int basetype, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_tspatial_stbox(IntPtr temp, IntPtr box, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_tspatial_tspatial(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool srid_parse(IntPtr str, IntPtr srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spatial_parse_elem(IntPtr str, int temptype, byte delim, IntPtr temp_srid, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool geo_parse(IntPtr str, int basetype, byte delim, IntPtr srid, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr stbox_parse(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpoint_parse(IntPtr str, int temptype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialinst_parse(IntPtr str, int temptype, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr temp_srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialseq_disc_parse(IntPtr str, int temptype, IntPtr temp_srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialseq_cont_parse(IntPtr str, int temptype, int interp, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr temp_srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatialseqset_parse(IntPtr str, int temptype, int interp, IntPtr temp_srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tspatial_parse(IntPtr str, int temptype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr proj_get_context();
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong datum_geo_round(ulong value, ulong size);
+            public static partial int datum_geo_round(IntPtr value, IntPtr size);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr point_round(IntPtr gs, int maxdd);
@@ -7245,7 +8891,7 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_set_stbox(ulong d, int basetype, IntPtr box);
+            public static partial bool spatial_set_stbox(IntPtr d, int basetype, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void spatialset_set_stbox(IntPtr set, IntPtr box);
@@ -7271,9 +8917,6 @@ namespace MEOS.NET.Internal
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
             public static partial bool inter_stbox_stbox(IntPtr box1, IntPtr box2, IntPtr result);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr stbox_geo(IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeogpointinst_from_mfjson(IntPtr mfjson, int srid);
@@ -7351,44 +8994,44 @@ namespace MEOS.NET.Internal
             public static partial void tspatial_set_stbox(IntPtr temp, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial void tgeoinst_set_stbox(IntPtr inst, IntPtr box);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tspatialseq_set_stbox(IntPtr seq, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial void tspatialseqset_set_stbox(IntPtr ss, IntPtr box);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeo_restrict_geom(IntPtr temp, IntPtr gs, IntPtr zspan, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tgeo_restrict_elevation(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeo_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeo_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeoinst_restrict_geom(IntPtr inst, IntPtr gs, IntPtr zspan, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tgeoinst_restrict_geom(IntPtr inst, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoinst_restrict_stbox(IntPtr inst, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeoseq_restrict_geom(IntPtr seq, IntPtr gs, IntPtr zspan, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tgeoseq_restrict_geom(IntPtr seq, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseq_restrict_stbox(IntPtr seq, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tgeoseqset_restrict_geom(IntPtr ss, IntPtr gs, IntPtr zspan, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+            public static partial IntPtr tgeoseqset_restrict_geom(IntPtr ss, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseqset_restrict_stbox(IntPtr ss, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial int spatial_srid(ulong d, int basetype);
+            public static partial int spatial_srid(IntPtr d, int basetype);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool spatial_set_srid(ulong d, int basetype, int srid);
+            public static partial bool spatial_set_srid(IntPtr d, int basetype, int srid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial int tspatialinst_srid(IntPtr inst);
@@ -7433,9 +9076,6 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeoseqset_split_n_stboxes(IntPtr ss, int max_count, IntPtr count);
-
-            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tpoint_get_coord(IntPtr temp, int coord);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeominst_tgeoginst(IntPtr inst, [MarshalAs(UnmanagedType.U1)] bool oper);
@@ -7504,10 +9144,10 @@ namespace MEOS.NET.Internal
             public static partial string nsegment_out(IntPtr ns, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npoint_make(long rid, double pos);
+            public static partial IntPtr npoint_make(int rid, double pos);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr nsegment_make(long rid, double pos1, double pos2);
+            public static partial IntPtr nsegment_make(int rid, double pos1, double pos2);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr geompoint_to_npoint(IntPtr gs);
@@ -7531,35 +9171,35 @@ namespace MEOS.NET.Internal
             public static partial IntPtr nsegment_to_stbox(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial uint npoint_hash(IntPtr np);
+            public static partial int npoint_hash(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial ulong npoint_hash_extended(IntPtr np, ulong seed);
+            public static partial int npoint_hash_extended(IntPtr np, int seed);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double npoint_position(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long npoint_route(IntPtr np);
+            public static partial int npoint_route(IntPtr np);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nsegment_end_position(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long nsegment_route(IntPtr ns);
+            public static partial int nsegment_route(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial double nsegment_start_position(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             [return: MarshalAs(UnmanagedType.U1)]
-            public static partial bool route_exists(long rid);
+            public static partial bool route_exists(int rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr route_geom(long rid);
+            public static partial IntPtr route_geom(int rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial double route_length(long rid);
+            public static partial double route_length(int rid);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr npoint_round(IntPtr np, int maxdd);
@@ -7577,7 +9217,7 @@ namespace MEOS.NET.Internal
             public static partial int nsegment_srid(IntPtr ns);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr npoint_timestamptz_to_stbox(IntPtr np, long t);
+            public static partial IntPtr npoint_timestamptz_to_stbox(IntPtr np, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr npoint_tstzspan_to_stbox(IntPtr np, IntPtr s);
@@ -7704,7 +9344,7 @@ namespace MEOS.NET.Internal
             public static partial string tnpoint_out(IntPtr temp, int maxdd);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial IntPtr tnpointinst_make(IntPtr np, long t);
+            public static partial IntPtr tnpointinst_make(IntPtr np, int t);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tgeompoint_to_tnpoint(IntPtr temp);
@@ -7722,7 +9362,7 @@ namespace MEOS.NET.Internal
             public static partial IntPtr tnpoint_positions(IntPtr temp, IntPtr count);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
-            public static partial long tnpoint_route(IntPtr temp);
+            public static partial int tnpoint_route(IntPtr temp);
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tnpoint_routes(IntPtr temp);
@@ -7843,6 +9483,2071 @@ namespace MEOS.NET.Internal
 
             [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
             public static partial IntPtr tne_tnpoint_npoint(IntPtr temp, IntPtr np);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string pose_as_ewkt(IntPtr pose, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string pose_as_hexwkb(IntPtr pose, IntPtr variant, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string pose_as_text(IntPtr pose, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_as_wkb(IntPtr pose, IntPtr variant, IntPtr size_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_from_wkb(IntPtr wkb, ulong size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_from_hexwkb(string hexwkb);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string pose_out(IntPtr pose, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_copy(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_make_2d(double x, double y, double theta, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_make_3d(double x, double y, double z, double W, double X, double Y, double Z, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_make_point2d(IntPtr gs, double theta);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_make_point3d(IntPtr gs, double W, double X, double Y, double Z);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_to_point(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_to_stbox(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pose_hash(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pose_hash_extended(IntPtr pose, int seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_orientation(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double pose_rotation(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_round(IntPtr pose, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr posearr_round(IntPtr posearr, int count, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void pose_set_srid(IntPtr pose, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pose_srid(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_transform(IntPtr pose, int srid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_transform_pipeline(IntPtr pose, string pipelinestr, int srid, [MarshalAs(UnmanagedType.U1)] bool is_forward);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_tstzspan_to_stbox(IntPtr pose, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_timestamptz_to_stbox(IntPtr pose, int t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_pose_geo(IntPtr pose, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_pose_pose(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double distance_pose_stbox(IntPtr pose, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pose_cmp(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_eq(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_ge(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_gt(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_le(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_lt(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_ne(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_nsame(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_same(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr poseset_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string poseset_out(IntPtr s, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr poseset_make(IntPtr values, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_to_set(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr poseset_end_value(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr poseset_start_value(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool poseset_value_n(IntPtr s, int n, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr poseset_values(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_pose_set(IntPtr pose, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_set_pose(IntPtr s, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr intersection_pose_set(IntPtr pose, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr intersection_set_pose(IntPtr s, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr minus_pose_set(IntPtr pose, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr minus_set_pose(IntPtr s, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_union_transfn(IntPtr state, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr union_pose_set(IntPtr pose, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr union_set_pose(IntPtr s, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_make(IntPtr tpoint, IntPtr tradius);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_to_tpoint(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_end_value(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_points(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_rotation(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_start_value(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_trajectory(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tpose_value_at_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tpose_value_n(IntPtr temp, int n, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_values(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_at_geom(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_at_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_at_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_minus_geom(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_minus_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_minus_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tpose_point(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tpose_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tpose_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tpose_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tpose_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_pose_tpose(IntPtr pose, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string trgeo_out(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoinst_make(IntPtr geom, IntPtr pose, int t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_tpose_to_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_to_tpose(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_to_tpoint(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_end_instant(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_end_sequence(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_end_value(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_geom(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_instant_n(IntPtr temp, int n);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_instants(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_points(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_rotation(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_segments(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_sequence_n(IntPtr temp, int i);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_sequences(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_start_instant(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_start_sequence(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_start_value(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool trgeo_value_n(IntPtr temp, int n, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_traversed_area(IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool unary_union);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_append_tinstant(IntPtr temp, IntPtr inst, int interp, double maxdist, IntPtr maxt, [MarshalAs(UnmanagedType.U1)] bool expand);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_append_tsequence(IntPtr temp, IntPtr seq, [MarshalAs(UnmanagedType.U1)] bool expand);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_delete_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool connect);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_delete_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_delete_tstzspan(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool connect);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_delete_tstzspanset(IntPtr temp, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool connect);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_round(IntPtr temp, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_set_interp(IntPtr temp, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_to_tinstant(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_after_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_before_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool strict);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_value(IntPtr temp, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_values(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_timestamptz(IntPtr temp, int t, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_tstzset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_tstzspan(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_restrict_tstzspanset(IntPtr temp, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdistance_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_stbox_trgeo(IntPtr box, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_trgeo_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double nad_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nai_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr shortestline_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_eq_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int always_ne_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_eq_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ever_ne_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr teq_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_geo_trgeo(IntPtr gs, IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tne_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnpoint_npoint(IntPtr temp, IntPtr np);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnpoint_npointset(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnpoint_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnpoint_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tnpointsegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool common_rid_tnpoint_npoint(IntPtr temp, IntPtr np);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool common_rid_tnpoint_npointset(IntPtr temp, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool common_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool npoint_collinear(IntPtr np1, IntPtr np2, IntPtr np3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr npointsegm_interpolate(IntPtr start, IntPtr end, IntPtr ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr npointsegm_locate(IntPtr start, IntPtr end, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr npointarr_geom(IntPtr points, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nsegmentarr_geom(IntPtr segments, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nsegmentarr_normalize(IntPtr segments, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string npoint_wkt_out(IntPtr value, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void npoint_set(int rid, double pos, IntPtr np);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void nsegment_set(int rid, double pos1, double pos2, IntPtr ns);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_npoint_round(IntPtr npoint, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointinst_tgeompointinst(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_tgeompointseq_disc(IntPtr @is);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_tgeompointseq_cont(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseqset_tgeompointseqset(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeompointinst_tnpointinst(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeompointseq_tnpointseq(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tgeompointseqset_tnpointseqset(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointinst_positions(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_positions(IntPtr seq, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseqset_positions(IntPtr ss, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tnpointinst_route(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointinst_routes(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_disc_routes(IntPtr @is);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_cont_routes(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseqset_routes(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpointseq_linear_positions(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpoint_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpoint_restrict_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpoint_restrict_npointset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool npoint_set_stbox(IntPtr np, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void npointarr_set_stbox(IntPtr values, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool nsegment_set_stbox(IntPtr ns, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool npoint_timestamptz_set_stbox(IntPtr np, int t, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool npoint_tstzspan_set_stbox(IntPtr np, IntPtr s, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tnpointinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tnpointinstarr_set_stbox(IntPtr inst, int count, int interp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tnpointseq_expand_stbox(IntPtr seq, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_npoint_distance(IntPtr np1, IntPtr np2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr npoint_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr nsegment_parse(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_rid_tnpoint_bigint(IntPtr temp, int rid, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool overlaps_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_rid_tnpoint_bigintset(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_rid_tnpoint_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_rid_npoint_tnpoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_rid_tnpoint_npoint(IntPtr temp, IntPtr np, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool overlaps_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contains_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool contained_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool same_rid_tnpoint_tnpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_rid_tnpointinst(IntPtr inst1, IntPtr inst2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnpoint_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_pose_geo(IntPtr pose, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_pose_stbox(IntPtr pose, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_pose_pose(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_poseset_pose(IntPtr s, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_collinear(IntPtr pose1, IntPtr pose2, IntPtr pose3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr posesegm_interpolate(IntPtr start, IntPtr end, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr posesegm_locate(IntPtr start, IntPtr end, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string pose_wkt_out(IntPtr pose, [MarshalAs(UnmanagedType.U1)] bool extended, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pose_parse(IntPtr str, [MarshalAs(UnmanagedType.U1)] bool end);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_pose_point(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_pose_rotation(IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_pose_round(IntPtr pose, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pose_distance(IntPtr pose1, IntPtr pose2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_set_stbox(IntPtr pose, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void posearr_set_stbox(IntPtr values, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_timestamptz_set_stbox(IntPtr pose, int t, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool pose_tstzspan_set_stbox(IntPtr pose, IntPtr p, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpose_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpose_pose(IntPtr temp, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpose_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tpose_tpose(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tposesegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tposesegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int lower, int upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tposeinst_set_stbox(IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tposeinstarr_set_stbox(IntPtr instants, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tposeseq_expand_stbox(IntPtr seq, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_restrict_geom(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_restrict_stbox(IntPtr temp, IntPtr box, [MarshalAs(UnmanagedType.U1)] bool border_inc, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tpose_restrict_elevation(IntPtr temp, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int geo_get_srid(IntPtr g);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int date_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string date_out(int d);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int interval_cmp(IntPtr interv1, IntPtr interv2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr interval_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string interval_out(IntPtr interv);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long time_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string time_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamp_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string timestamp_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamptz_in(string str, int typmod);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string timestamptz_out(long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_has_geom(short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_trgeo_geo(IntPtr temp, IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_trgeo_stbox(IntPtr temp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_trgeo_trgeo(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_trgeo_tpoint(IntPtr temp1, IntPtr temp2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_geom_p(IntPtr temp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string trgeo_wkt_out(IntPtr temp, int maxdd, [MarshalAs(UnmanagedType.U1)] bool extended);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_tposeinst_to_trgeo(IntPtr gs, IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_tposeseq_to_trgeo(IntPtr gs, IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr geo_tposeseqset_to_trgeo(IntPtr gs, IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool trgeo_value_at_timestamptz(IntPtr temp, long t, [MarshalAs(UnmanagedType.U1)] bool strict, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoinst_geom_p(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong trgeoinst_pose_varsize(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoinst_set_pose(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoinst_tposeinst(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoinst_make1(IntPtr geom, IntPtr pose, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_to_tinstant(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_to_tinstant(IntPtr ts);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_geom_p(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong trgeoseq_pose_varsize(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoseq_set_pose(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_tposeseq(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool trgeoseq_make_valid(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, [MarshalAs(UnmanagedType.U1)] bool linear);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make1_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make1(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make_free_exp(IntPtr geom, IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseq_make_free(IntPtr geom, IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoinst_to_tsequence(IntPtr inst, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_geom_p(IntPtr ts);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_tposeseqset(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_make1_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_make_exp(IntPtr geom, IntPtr sequences, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_make(IntPtr geom, IntPtr sequences, int count, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_make_free(IntPtr geom, IntPtr sequences, int count, [MarshalAs(UnmanagedType.U1)] bool normalize);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_make_gaps(IntPtr geom, IntPtr instants, int count, int interp, IntPtr maxt, double maxdist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeoseqset_to_tsequence(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_to_tsequence(IntPtr temp, string interp_str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_to_tsequenceset(IntPtr temp, string interp_str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoinst_set_stbox(IntPtr geom, IntPtr inst, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoinstarr_static_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoinstarr_rotating_stbox(IntPtr geom, IntPtr instants, int count, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void trgeoinstarr_compute_bbox(IntPtr geom, IntPtr instants, int count, int interp, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr trgeo_parse(IntPtr str, int temptype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_contains_geo_trgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_geo_trgeo(IntPtr gs, IntPtr temp, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_covers_trgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int ea_disjoint_trgeo_geo(IntPtr temp, IntPtr gs, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_geom(IntPtr gs1, IntPtr gs2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void lwgeom_apply_pose(IntPtr pose, IntPtr geom);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double geom_radius(IntPtr gs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int v_clip_tpoly_point(IntPtr poly, IntPtr point, IntPtr pose, IntPtr poly_feature, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int v_clip_tpoly_tpoly(IntPtr poly1, IntPtr poly2, IntPtr pose1, IntPtr pose2, IntPtr poly1_feature, IntPtr poly2_feature, IntPtr dist);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void apply_pose_point4d(IntPtr p, IntPtr pose);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tinstant(IntPtr inst, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tsequence(IntPtr seq, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tsequenceset(IntPtr ss, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_temporal(IntPtr temp, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tinstant_base(IntPtr inst, IntPtr value, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tsequence_base(IntPtr seq, IntPtr value, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tsequenceset_base(IntPtr ss, IntPtr value, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tcontseq_tcontseq(IntPtr seq1, IntPtr seq2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tfunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eafunc_temporal_base(IntPtr temp, IntPtr value, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eafunc_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr lfinfo);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int int4_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string int4_out(int val);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long int8_in(string str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string int8_out(long val);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int float8_in(string num, string type_name, string orig_string);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pg_dsin(int arg1);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pg_dcos(int arg1);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pg_datan(int arg1);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int pg_datan2(int arg1, int arg2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr interval_negate(IntPtr interval);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr pg_interval_justify_hours(IntPtr span);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint hash_bytes_uint32(uint k);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint pg_hashint8(long val);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint pg_hashfloat8(int key);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong hash_bytes_uint32_extended(uint k, ulong seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong pg_hashint8extended(long val, ulong seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong pg_hashfloat8extended(int key, ulong seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial uint pg_hashtext(IntPtr key);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong pg_hashtextextended(IntPtr key, ulong seed);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string set_out_fn(IntPtr s, int maxdd, IntPtr value_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_set_isof_type(IntPtr s, int settype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_set_set(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool set_find_value(IntPtr s, IntPtr arg1, IntPtr loc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr set_unnest_state_make(IntPtr set);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void set_unnest_state_next(IntPtr state);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_skiplist_subtype(IntPtr state, IntPtr subtype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void skiplist_set_extra(IntPtr state, IntPtr data, ulong size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr skiplist_headval(IntPtr list);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_span_isof_type(IntPtr s, int spantype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_span_isof_basetype(IntPtr s, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_span_type(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_span_span(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void span_deserialize(IntPtr s, IntPtr lower, IntPtr upper);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_bound_cmp(IntPtr b1, IntPtr b2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_bound_qsort_cmp(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_lower_cmp(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_upper_cmp(IntPtr s1, IntPtr s2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_decr_bound(IntPtr upper, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_incr_bound(IntPtr upper, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr spanarr_normalize(IntPtr spans, int count, [MarshalAs(UnmanagedType.U1)] bool sort, IntPtr newcount);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void span_bounds_shift_scale_value(IntPtr shift, IntPtr width, int type, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth, IntPtr lower, IntPtr upper);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void span_bounds_shift_scale_time(IntPtr shift, IntPtr duration, IntPtr lower, IntPtr upper);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void floatspan_floor_ceil_iter(IntPtr s, int func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void numspan_delta_scale_iter(IntPtr s, IntPtr origin, IntPtr delta, [MarshalAs(UnmanagedType.U1)] bool hasdelta, double scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tstzspan_delta_scale_iter(IntPtr s, long origin, long delta, double scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void numspan_shift_scale_iter(IntPtr s, IntPtr shift, IntPtr width, [MarshalAs(UnmanagedType.U1)] bool hasshift, [MarshalAs(UnmanagedType.U1)] bool haswidth, IntPtr delta, IntPtr scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tstzspan_shift_scale1(IntPtr s, IntPtr shift, IntPtr duration, IntPtr delta, IntPtr scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int mi_span_value(IntPtr s, IntPtr value, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double dist_double_value_value(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int common_entry_cmp(IntPtr i1, IntPtr i2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_index_recheck(int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_spanset_isof_type(IntPtr ss, int spansettype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_spanset_type(IntPtr ss1, IntPtr ss2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_spanset_span_type(IntPtr ss, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_spanset_span(IntPtr ss, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_spanset_spanset(IntPtr ss1, IntPtr ss2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool spanset_find_value(IntPtr ss, IntPtr v, IntPtr loc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_and(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_or(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr boolop_tbool_bool(IntPtr temp, IntPtr b, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr boolop_tbool_tbool(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_same_dimensionality_tbox(IntPtr box1, IntPtr box2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr set_tbox(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr span_tbox(IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tbox_tstzspan(IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tbox_intspan(IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tbox_floatspan(IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tbox_index_leaf_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tbox_gist_inner_consistent(IntPtr key, IntPtr query, int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tbox_index_recheck(int strategy);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_min_int32(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_max_int32(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_min_float8(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_max_float8(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sum_int32(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sum_float8(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_min_text(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_max_text(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sum_double2(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sum_double3(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sum_double4(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int temporal_skiplist_common(IntPtr list, IntPtr values, int count, IntPtr lower, IntPtr upper, IntPtr update);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_skiplist_merge(IntPtr spliced, int spliced_count, IntPtr values, int count, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr newcount, IntPtr tofree, IntPtr nfree);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinstant_tagg(IntPtr instants1, int count1, IntPtr instants2, int count2, IntPtr func, IntPtr newcount, IntPtr tofree, IntPtr nfree);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequence_tagg(IntPtr sequences1, int count1, IntPtr sequences2, int count2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr newcount);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool interpoint);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_tagg_combinefn(IntPtr state1, IntPtr state2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinstant_tagg_transfn(IntPtr state, IntPtr inst, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinstant_tavg_finalfn(IntPtr instants, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequence_tavg_finalfn(IntPtr sequences, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumberinst_transform_tavg(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_transform_tcount(IntPtr temp, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_transform_tagg(IntPtr temp, IntPtr count, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequenceset_tagg_transfn(IntPtr state, IntPtr ss, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_tagg_transfn(IntPtr state, IntPtr seq, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_tagg_transfn(IntPtr state, IntPtr temp, IntPtr arg2, [MarshalAs(UnmanagedType.U1)] bool crossings);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_tagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool crossings, IntPtr transform);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double temporal_similarity(IntPtr temp1, IntPtr temp2, IntPtr simfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_similarity_path(IntPtr temp1, IntPtr temp2, IntPtr count, IntPtr simfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial ulong temporal_bbox_size(int tempype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tinstarr_set_bbox(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, IntPtr bbox);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tsequence_compute_bbox(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tseqarr_compute_bbox(IntPtr sequences, int count, IntPtr bbox);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tsequenceset_compute_bbox(IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_temporal_tstzspan(IntPtr temp, IntPtr s, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_tnumber_numspan(IntPtr temp, IntPtr span, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_tnumber_tbox(IntPtr temp, IntPtr box, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool boxop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eacomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eacomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int eacomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool ever);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcomp_base_temporal(IntPtr value, IntPtr temp, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcomp_temporal_base(IntPtr temp, IntPtr value, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcomp_temporal_temporal(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_at_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_restrict_value(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_restrict_values(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_minus_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_restrict_tstzset(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_restrict_value_iter(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_delete_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_delete_tstzset(IntPtr seq, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_delete_tstzspanset(IntPtr seq, IntPtr ss);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_at_tstzset(IntPtr seq, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_minus_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_minus_tstzset(IntPtr seq, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_minus_tstzspan(IntPtr seq, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_restrict_value(IntPtr seq, IntPtr value, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_restrict_values(IntPtr seq, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsequence_at_values_iter(IntPtr seq, IntPtr set, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tnumberseq_cont_restrict_span_iter(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tnumberseq_cont_restrict_spanset_iter(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsegment_at_timestamptz(IntPtr inst1, IntPtr inst2, int interp, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_minus_timestamp_iter(IntPtr seq, long t, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_minus_tstzset_iter(IntPtr seq, IntPtr s, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_at_tstzspanset1(IntPtr seq, IntPtr ss, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_minus_tstzspanset_iter(IntPtr seq, IntPtr ss, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_at_tstzspan(IntPtr seq, IntPtr s);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_at_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_restrict_tstzspanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tdiscseq_value_at_timestamptz(IntPtr seq, long t, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumberseq_disc_restrict_span(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumberseq_disc_restrict_spanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumberseq_cont_restrict_span(IntPtr seq, IntPtr span, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumberseq_cont_restrict_spanset(IntPtr seq, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double tnumberseq_cont_twavg(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int span_num_bins(IntPtr s, IntPtr size, IntPtr origin, IntPtr start_bin, IntPtr end_bin);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_time_bin_init(IntPtr temp, IntPtr duration, long torigin, IntPtr nbins);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tbox_tile_state_make(IntPtr temp, IntPtr box, IntPtr vsize, IntPtr duration, IntPtr xorigin, long torigin);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tbox_tile_state_next(IntPtr state);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tbox_tile_state_set(IntPtr value, long t, IntPtr vsize, long tunits, int basetype, int spantype, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long interval_units(IntPtr interval);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamptz_bin_start(long timestamp, long tunits, long torigin);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_bin(IntPtr value, IntPtr size, IntPtr offset, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumber_value_time_tile_init(IntPtr temp, IntPtr vsize, IntPtr duration, IntPtr vorigin, long torigin, IntPtr ntiles);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tbox_tile_state_get(IntPtr state, IntPtr box);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_transform_wcount(IntPtr temp, IntPtr interval, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tnumber_transform_wavg(IntPtr temp, IntPtr interval, IntPtr count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_wagg_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool min, [MarshalAs(UnmanagedType.U1)] bool crossings);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_wagg_transform_transfn(IntPtr state, IntPtr temp, IntPtr interval, IntPtr func, IntPtr transform);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tinstant_set(IntPtr inst, IntPtr value, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double tnumberinst_double(IntPtr inst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string tinstant_to_string(IntPtr inst, int maxdd, IntPtr value_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tinstant_restrict_values_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumberinst_restrict_span_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tnumberinst_restrict_spanset_test(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tinstant_restrict_tstzset_test(IntPtr inst, IntPtr s, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tinstant_restrict_tstzspanset_test(IntPtr inst, IntPtr ss, [MarshalAs(UnmanagedType.U1)] bool atfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tinstant_tinstant(IntPtr inst1, IntPtr inst2, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tfloat_arithop_turnpt(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, IntPtr param, long lower, long upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr arithop_tnumber_number(IntPtr temp, IntPtr value, IntPtr oper, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr arithop_tnumber_tnumber(IntPtr temp1, IntPtr temp2, IntPtr oper, IntPtr func, IntPtr tpfunc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool float_collinear(double x1, double x2, double x3, double ratio);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double floatsegm_interpolate(double value1, double value2, IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr floatsegm_locate(double value1, double value2, double value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tnumbersegm_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int basetype, long lower, long upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tsequence_norm_test(IntPtr value1, IntPtr value2, IntPtr value3, int basetype, int interp, long t1, long t2, long t3);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tsequence_join_test(IntPtr seq1, IntPtr seq2, IntPtr removelast, IntPtr removefirst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequence_join(IntPtr seq1, IntPtr seq2, [MarshalAs(UnmanagedType.U1)] bool removelast, [MarshalAs(UnmanagedType.U1)] bool removefirst);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinstarr_normalize(IntPtr instants, int interp, int count, IntPtr newcount);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tcontseq_find_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tdiscseq_find_timestamptz(IntPtr seq, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tseqarr2_to_tseqarr(IntPtr sequences, IntPtr countseqs, int count, int totalseqs);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tinstarr_common(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequence_make_exp1(IntPtr instants, int count, int maxcount, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp, [MarshalAs(UnmanagedType.U1)] bool normalize, IntPtr bbox);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool synchronize_tsequence_tsequence(IntPtr seq1, IntPtr seq2, IntPtr sync1, IntPtr sync2, [MarshalAs(UnmanagedType.U1)] bool interpoint);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tfloatsegm_intersection_value(IntPtr start, IntPtr end, IntPtr value, long lower, long upper, IntPtr t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsegment_intersection_value(IntPtr start, IntPtr end, IntPtr value, int temptype, long lower, long upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsegment_intersection(IntPtr start1, IntPtr end1, IntPtr start2, IntPtr end2, int temptype, long lower, long upper, IntPtr t1, IntPtr t2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsegment_value_at_timestamptz(IntPtr start, IntPtr end, int temptype, long lower, long upper, long t);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tdiscseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tcontseq_tdiscseq(IntPtr seq1, IntPtr seq2, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tdiscseq_tcontseq(IntPtr @is, IntPtr seq2, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tsequence_tinstant(IntPtr seq, IntPtr inst, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tinstant_tsequence(IntPtr inst, IntPtr seq, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string tsequence_to_string(IntPtr seq, int maxdd, [MarshalAs(UnmanagedType.U1)] bool component, IntPtr value_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_increasing_timestamps(IntPtr inst1, IntPtr inst2, [MarshalAs(UnmanagedType.U1)] bool strict);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void bbox_expand(IntPtr box1, IntPtr box2, int temptype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tinstarr(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool merge, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tsequence_make_valid(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool lower_inc, [MarshalAs(UnmanagedType.U1)] bool upper_inc, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tnumberseq_shift_scale_value_iter(IntPtr seq, IntPtr origin, IntPtr delta, [MarshalAs(UnmanagedType.U1)] bool hasdelta, double scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tsequence_shift_scale_time_iter(IntPtr seq, long delta, double scale);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tstepseq_to_linear_iter(IntPtr seq, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tstepseq_to_linear(IntPtr seq);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsequence_segments_iter(IntPtr seq, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tsequence_timestamps_iter(IntPtr seq, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool tsequenceset_find_timestamptz(IntPtr ss, long t, IntPtr loc);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tseqarr_normalize(IntPtr sequences, int count, IntPtr newcount);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double datum_distance(IntPtr value1, IntPtr value2, int basetype, short flags);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr ensure_valid_tinstarr_gaps(IntPtr instants, int count, [MarshalAs(UnmanagedType.U1)] bool merge, double maxdist, IntPtr maxt, IntPtr nsplits);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_valid_tseqarr(IntPtr sequences, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool synchronize_tsequenceset_tsequence(IntPtr ss, IntPtr seq, IntPtr mode, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool synchronize_tsequenceset_tsequenceset(IntPtr ss1, IntPtr ss2, IntPtr mode, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tsequenceset_tinstant(IntPtr ss, IntPtr inst, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tinstant_tsequenceset(IntPtr inst, IntPtr ss, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tsequenceset_tdiscseq(IntPtr ss, IntPtr @is, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tdiscseq_tsequenceset(IntPtr @is, IntPtr ss, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool intersection_tsequence_tsequenceset(IntPtr seq, IntPtr ss, IntPtr mode, IntPtr inter1, IntPtr inter2);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string tsequenceset_to_string(IntPtr ss, int maxdd, IntPtr value_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_textcat(IntPtr l, IntPtr r);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_lower(IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_upper(IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_initcap(IntPtr value);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr textfunc_ttext(IntPtr temp, int func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr textfunc_ttext_text(IntPtr temp, IntPtr value, IntPtr func, [MarshalAs(UnmanagedType.U1)] bool invert);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr textfunc_ttext_ttext(IntPtr temp1, IntPtr temp2, IntPtr func);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr datum_as_wkb(IntPtr value, int type, IntPtr variant, IntPtr size_out);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string datum_as_hexwkb(IntPtr value, int type, IntPtr variant, IntPtr size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int type_from_wkb(IntPtr wkb, ulong size, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int type_from_hexwkb(string hexwkb, ulong size, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_end_input(IntPtr str, string type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void p_whitespace(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_delimchar(IntPtr str, byte delim);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_obrace(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_obrace(IntPtr str, string type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_cbrace(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_cbrace(IntPtr str, string type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_obracket(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_cbracket(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_oparen(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_oparen(IntPtr str, string type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_cparen(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool ensure_cparen(IntPtr str, string type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool p_comma(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_parse(IntPtr str, int basetypid, byte delim, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool double_parse(IntPtr str, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool elem_parse(IntPtr str, int basetype, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr set_parse(IntPtr str, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool span_parse(IntPtr str, int spantype, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr span);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr spanset_parse(IntPtr str, int spantype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tbox_parse(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial long timestamp_parse(IntPtr str);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tinstant_parse(IntPtr str, int temptype, [MarshalAs(UnmanagedType.U1)] bool end);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tdiscseq_parse(IntPtr str, int temptype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tcontseq_parse(IntPtr str, int temptype, int interp, [MarshalAs(UnmanagedType.U1)] bool end);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr tsequenceset_parse(IntPtr str, int temptype, int interp);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr temporal_parse(IntPtr str, int temptype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_copy(IntPtr value, int typid);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double datum_double(IntPtr d, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int double_datum(double d, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial IntPtr bstring2bytea(IntPtr wkb, ulong size);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool basetype_in(string str, int type, [MarshalAs(UnmanagedType.U1)] bool end, IntPtr result);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string basetype_out(IntPtr value, int type, int maxdd);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void pfree_array(IntPtr array, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial string stringarr_to_string(IntPtr strings, int count, ulong outlen, string prefix, byte open, byte close, [MarshalAs(UnmanagedType.U1)] bool quotes, [MarshalAs(UnmanagedType.U1)] bool spaces);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void datumarr_sort(IntPtr values, int count, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tstzarr_sort(IntPtr times, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void spanarr_sort(IntPtr spans, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tinstarr_sort(IntPtr instants, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial void tseqarr_sort(IntPtr sequences, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datumarr_remove_duplicates(IntPtr values, int count, int basetype);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tstzarr_remove_duplicates(IntPtr values, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int tinstarr_remove_duplicates(IntPtr instants, int count);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_add(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_sub(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_mult(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_div(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum_cmp(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_eq(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_ne(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_lt(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_le(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_gt(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            [return: MarshalAs(UnmanagedType.U1)]
+            public static partial bool datum_ge(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_eq(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_ne(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_lt(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_le(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_gt(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial int datum2_ge(IntPtr l, IntPtr r, int type);
+
+            [LibraryImport(DllPath, StringMarshalling = StringMarshalling.Utf8)]
+            public static partial double hypot3d(double x, double y, double z);
 
         }
     }

--- a/README.md
+++ b/README.md
@@ -4,39 +4,29 @@ __Author__: Dudziak Thomas
 
 __My website__ : https://dudziak-thomas.be/
 
-This is a **proof of concept** for the final MEOS.NET project.
-MEOS.NET is a library that aims to wrap the functions of [MEOS](https://duckduckgo.com), the core component of [MobilityDB](https://mobilitydb.com/).
+MEOS.NET is a .NET binding for [MEOS](https://libmeos.org), the C library underlying [MobilityDB](https://github.com/MobilityDB/MobilityDB). It exposes the MEOS spatiotemporal types and functions to managed C# code, tracking MEOS 1.4.
 
-## What's in this project?
+## What's in this solution?
 
-The application features :
+- `MEOS.NET`: the binding library. Its `Internal/` layer holds the P/Invoke declarations for the MEOS C functions, generated from the [MEOS-API](https://github.com/MobilityDB/MEOS-API) catalog, and its `Types/` layer provides the hand-written, idiomatic C# wrappers over those declarations.
+- `MEOS.NET.NpgSql`: integration with [Npgsql](https://www.npgsql.org/) for reading and writing MobilityDB values over a PostgreSQL connection.
+- `MEOS.NET.Tests`: the unit test suite.
+- `ExampleApp`: a sample application built on the binding.
+- `MEOS.NET.Builder`: the original regex-based header parser. It is superseded by the IDL-driven generator under `tools/` and is kept only for historical reference.
 
-- The MEOS.NET wrapper
-- The unit tests of MEOS.NET
-- An example application based on the wrapper
-- An empty project that will host the code for database communication later
+## Prerequisites
+
+The MEOS shared library must be installed and resolvable by the OS loader through `LD_LIBRARY_PATH` (Linux), `DYLD_LIBRARY_PATH` (macOS), or `PATH` (Windows). See the [MobilityDB](https://github.com/MobilityDB/MobilityDB) build instructions for producing the MEOS library.
 
 ## Build
 
-To build this project, clone this repository and run the following command at the root of the solution. Please note that MobilityDB should be installed before trying to run this project.
+From the root of the solution:
 
 ```
 dotnet build
 ```
 
-If an error is encountered, please remove the following lines from the MEOS.NET.csproj file and retry. This could happen if there is no meos.h file under "~/Externals/MobilityDB/meos/include/meos.h".
-
-```
-  <Target Name="BeforeBuild">
-    <Exec Command="echo Building MEOS Functions..." />
-    <Exec Command="python3 $(ProjectDir)API/Builder/MEOSFunctionsBuilder.py &gt; &quot;$(ProjectDir)API/Internal/MEOSFunctions.cs&quot;" />
-    <Exec Command="echo MEOS Functions built successfully" />
-  </Target>
-```
-
 ## Run the unit tests
-
-To run the unit tests, run the following command in the MEOS.NET.Tests folder. 
 
 ```
 dotnet test
@@ -44,8 +34,11 @@ dotnet test
 
 ## Run the sample application
 
-A sample application is provided under the ExampleApp/ folder. To run the application, please run the following command under the ExampleApp/ folder :
-
 ```
+cd ExampleApp
 dotnet run
 ```
+
+## Regenerating the bindings
+
+The P/Invoke declarations under `MEOS.NET/Internal/` are generated from MEOS-API's `meos-idl.json` catalog rather than written by hand. To regenerate them against a given MEOS version, follow the instructions in [`tools/README.md`](tools/README.md).


### PR DESCRIPTION
Regenerates MEOSExternalFunctions.cs and MEOSExposedFunctions.cs against the MEOS 1.4 IDL on top of #3 (3544 functions, +1149 over 1.3 covering the new cbuffer, pose, and rgeo temporal-type families). The IDL is generated by MEOS-API against MobilityDB master with the shape metadata catalog merged in.